### PR TITLE
linux-ptl: add SOF backports for Zenbook S14 UX5406AA audio

### DIFF
--- a/pkgbuilds/edge/linux-ptl/0030-sof-intel-exact-sdw-mask.patch
+++ b/pkgbuilds/edge/linux-ptl/0030-sof-intel-exact-sdw-mask.patch
@@ -1,0 +1,37 @@
+diff --git a/sound/soc/sof/intel/hda.c b/sound/soc/sof/intel/hda.c
+index b3d61d973ce40b..24604e71386d6d 100644
+--- a/sound/soc/sof/intel/hda.c
++++ b/sound/soc/sof/intel/hda.c
+@@ -1337,6 +1337,8 @@ static struct snd_soc_acpi_mach *hda_sdw_machine_select(struct snd_sof_dev *sdev
+ 		return NULL;
+ 	}
+ 
++	chip = get_chip_info(sdev->pdata);
++
+ 	/*
+ 	 * Select SoundWire machine driver if needed using the
+ 	 * alternate tables. This case deals with SoundWire-only
+@@ -1352,8 +1354,13 @@ static struct snd_soc_acpi_mach *hda_sdw_machine_select(struct snd_sof_dev *sdev
+ 		 * first check whether link_mask of mach is subset of
+ 		 * link_mask supported by hw and then go on searching
+ 		 * link_adr
++		 * For those platforms that can use the created SDW mach below,
++		 * match the two masks exactly to avoid using an unexpected
++		 * mach.
+ 		 */
+-		if (~hdev->info.link_mask & mach->link_mask)
++		if (~hdev->info.link_mask & mach->link_mask ||
++		    (hdev->info.link_mask != mach->link_mask &&
++		     chip->hw_ip_version >= SOF_INTEL_ACE_2_0))
+ 			continue;
+ 
+ 		/* No need to match adr if there is no links defined */
+@@ -1393,8 +1400,6 @@ static struct snd_soc_acpi_mach *hda_sdw_machine_select(struct snd_sof_dev *sdev
+ 			 peripherals->array[i]->id.part_id,
+ 			 peripherals->array[i]->id.sdw_version);
+ 
+-	chip = get_chip_info(sdev->pdata);
+-
+ 	/* SDCA was not well supported in the BIOS before ACE2.0 */
+ 	if (chip->hw_ip_version < SOF_INTEL_ACE_2_0)
+ 		return NULL;

--- a/pkgbuilds/edge/linux-ptl/0031-ptl-mach-rt722-ghost.patch
+++ b/pkgbuilds/edge/linux-ptl/0031-ptl-mach-rt722-ghost.patch
@@ -1,0 +1,106 @@
+diff --git a/sound/soc/intel/common/soc-acpi-intel-ptl-match.c b/sound/soc/intel/common/soc-acpi-intel-ptl-match.c
+index 3b7818355ff645..b4458c33c4a89d 100644
+--- a/sound/soc/intel/common/soc-acpi-intel-ptl-match.c
++++ b/sound/soc/intel/common/soc-acpi-intel-ptl-match.c
+@@ -211,6 +211,25 @@ static const struct snd_soc_acpi_adr_device cs42l43_2_adr[] = {
+ 	}
+ };
+ 
++static const struct snd_soc_acpi_adr_device cs42l43_3_agg_rt722_ghost_adr[] = {
++	{
++		.adr = 0x00033001FA424301ull,
++		.num_endpoints = ARRAY_SIZE(cs42l43_amp_spkagg_endpoints),
++		.endpoints = cs42l43_amp_spkagg_endpoints,
++		.name_prefix = "cs42l43"
++	},
++	/*
++	 * To handle cases where the ALC722 codec is listed in the BIOS while the
++	 * hardware is not physically present.
++	 */
++	{
++		.adr = 0x000330025d072201ull, /* Ghost ALC722 */
++		.num_endpoints = 0,
++		.endpoints = NULL,
++		.name_prefix = "ghost"
++	}
++};
++
+ static const struct snd_soc_acpi_adr_device cs42l43_3_agg_adr[] = {
+ 	{
+ 		.adr = 0x00033001FA424301ull,
+@@ -235,6 +254,36 @@ static const struct snd_soc_acpi_adr_device cs35l56_2_lr_adr[] = {
+ 	}
+ };
+ 
++static const struct snd_soc_acpi_adr_device cs35l56_2_2amp_adr[] = {
++	{
++		.adr = 0x00023001fa355601ull,
++		.num_endpoints = 1,
++		.endpoints = &spk_1_endpoint,
++		.name_prefix = "AMP1"
++	},
++	{
++		.adr = 0x00023101fa355601ull,
++		.num_endpoints = 1,
++		.endpoints = &spk_2_endpoint,
++		.name_prefix = "AMP2"
++	}
++};
++
++static const struct snd_soc_acpi_adr_device cs35l56_1_2amp_adr[] = {
++	{
++		.adr = 0x00013201fa355601ull,
++		.num_endpoints = 1,
++		.endpoints = &spk_3_endpoint,
++		.name_prefix = "AMP3"
++	},
++	{
++		.adr = 0x00013301fa355601ull,
++		.num_endpoints = 1,
++		.endpoints = &spk_4_endpoint,
++		.name_prefix = "AMP4"
++	}
++};
++
+ static const struct snd_soc_acpi_adr_device cs35l56_1_3amp_adr[] = {
+ 	{
+ 		.adr = 0x00013001fa355601ull,
+@@ -394,6 +443,25 @@ static const struct snd_soc_acpi_adr_device rt1320_3_group2_adr[] = {
+ 	}
+ };
+ 
++static const struct snd_soc_acpi_link_adr ptl_cs42l43_agg_l3_cs35l56_l12_ghost_rt722[] = {
++	{
++		.mask = BIT(3),
++		.num_adr = ARRAY_SIZE(cs42l43_3_agg_rt722_ghost_adr),
++		.adr_d = cs42l43_3_agg_rt722_ghost_adr,
++	},
++	{
++		.mask = BIT(2),
++		.num_adr = ARRAY_SIZE(cs35l56_2_2amp_adr),
++		.adr_d = cs35l56_2_2amp_adr,
++	},
++	{
++		.mask = BIT(1),
++		.num_adr = ARRAY_SIZE(cs35l56_1_2amp_adr),
++		.adr_d = cs35l56_1_2amp_adr,
++	},
++	{}
++};
++
+ static const struct snd_soc_acpi_link_adr ptl_cs42l43_agg_l3_cs35l56_l2[] = {
+ 	{
+ 		.mask = BIT(3),
+@@ -584,6 +652,12 @@ struct snd_soc_acpi_mach snd_soc_acpi_intel_ptl_sdw_machines[] = {
+ 		.drv_name = "sof_sdw",
+ 		.sof_tplg_filename = "sof-ptl-cs42l43-l2-cs35l56x6-l13.tplg",
+ 	},
++	{
++		.link_mask = BIT(1) | BIT(2) | BIT(3),
++		.links = ptl_cs42l43_agg_l3_cs35l56_l12_ghost_rt722,
++		.drv_name = "sof_sdw",
++		.sof_tplg_filename = "sof-ptl-cs42l43-agg-l3-cs35l56-l2.tplg",
++	},
+ 	{
+ 		.link_mask = BIT(0) | BIT(2) | BIT(3),
+ 		.links = ptl_rt722_l0_rt1320_l23,

--- a/pkgbuilds/edge/linux-ptl/PKGBUILD
+++ b/pkgbuilds/edge/linux-ptl/PKGBUILD
@@ -3,7 +3,7 @@
 
 pkgbase=linux-ptl
 pkgver=7.0.3.arch1
-pkgrel=1
+pkgrel=2
 pkgdesc='Linux with Panther Lake hardware backports (SDCA audio, PSR2, Panel Replay SU)'
 url='https://github.com/archlinux/linux'
 arch=(
@@ -37,6 +37,8 @@ source=(
   0027-drm-i915-trans-push-frame-change-for-panel-replay.patch
   0028-drm-i915-psr-exit-Panel-Replay-for-ALPM-lag.patch
   0029-drm-edid-populate-monitor-range-from-displayid-adaptive-sync.patch
+  0030-sof-intel-exact-sdw-mask.patch
+  0031-ptl-mach-rt722-ghost.patch
 )
 source_x86_64=(config.x86_64)
 validpgpkeys=(
@@ -48,7 +50,7 @@ b2sums=('SKIP'
         'SKIP'
         'SKIP'
         'SKIP'
-        'SKIP' 'SKIP' 'SKIP' 'SKIP' 'SKIP' 'SKIP' 'SKIP')
+        'SKIP' 'SKIP' 'SKIP' 'SKIP' 'SKIP' 'SKIP' 'SKIP' 'SKIP' 'SKIP')
 b2sums_x86_64=('9742088ab0381d8196046e42e8acb4ce01ea77461fada77dc90d197e859631e73b06ead4d512f15ab619b33ebad7bca58a10d4506d66916a99c40f9f52708a53')
 
 # https://www.kernel.org/pub/linux/kernel/v7.x/sha256sums.asc
@@ -56,7 +58,7 @@ sha256sums=('0bedadbf5788693ddebbcc913c893f1a97349af79ddde7144c2a80b401959f1c'
             'SKIP'
             'SKIP'
             'SKIP'
-            'SKIP' 'SKIP' 'SKIP' 'SKIP' 'SKIP' 'SKIP' 'SKIP')
+            'SKIP' 'SKIP' 'SKIP' 'SKIP' 'SKIP' 'SKIP' 'SKIP' 'SKIP' 'SKIP')
 
 export KBUILD_BUILD_HOST=archlinux
 export KBUILD_BUILD_USER=$pkgbase


### PR DESCRIPTION
## Summary

Adds two SOF SoundWire patches to `linux-ptl` to fix audio on the ASUS Zenbook S14 UX5406AA (Panther Lake / Core Ultra 9 386H, SSID 10431464). Following up on @dhh's comment in basecamp/omarchy#5557 — happy for you to take this as-is, rework, or use as a reference.

- **0030** = `thesofproject/linux#5728` (still open upstream): tightens SoundWire mask matching so ACE 2.0+ platforms can't fall back to a partial machine table entry.
- **0031** = `thesofproject/linux#5754` (still open upstream): adds the UX5406AA-specific entry. The board's BIOS declares an `rt722` SDCA device on link 0 that doesn't physically exist; the new entry declares it as a zero-endpoint ghost so the SDCA enumeration matches reality (cs42l43 on link 3 + 4× cs35l56 on links 1/2).

Both apply cleanly against the current `linux-7.0.3.arch1` base — only line-offset shifts, no rejected hunks.

## Test results (UX5406AA / BIOS UX5406AA.303)

I built locally against `v7.1-rc2` with the same two patches and audio came up: `sof-soundwire` card registered, all 4 cs35l56 amps loaded their tuning blobs from `linux-firmware-cirrus 20260410-1`, headphone jack and internal mic functional, HDMI works. Full report at thesofproject/linux#5721 (comment 4379439293).

## Caveat — upstream churn

PR #5754 is still under review. @bardliao mentioned in the upstream thread that the next revision (commit `e411f65`) retargets a different topology file (`…-agg-l3-cs35l56-l12.tplg`) which isn't yet in `firmware-sof 2025.12.2-1`. If the merged version of #5754 differs materially from the diff included here, this PR will need a refresh. The version included now is the one I've personally booted and verified end-to-end.

## Refs

- thesofproject/linux#5728
- thesofproject/linux#5754
- thesofproject/linux#5721
- basecamp/omarchy#5557

## Test plan

- [ ] `makepkg -s` against this branch builds successfully on `x86_64`
- [ ] Resulting `linux-ptl` package boots on Zenbook S14 UX5406AA
- [ ] `aplay -l` lists `sof-soundwire` card; speakers/jack/mic produce audio