### PR TITLE
linux-ptl: add Lenovo 83QK SOF SoundWire audio quirk

### DIFF
--- a/pkgbuilds/linux-ptl/0030-sof-intel-exact-sdw-mask.patch
+++ b/pkgbuilds/linux-ptl/0030-sof-intel-exact-sdw-mask.patch
@@ -1,0 +1,37 @@
+diff --git a/sound/soc/sof/intel/hda.c b/sound/soc/sof/intel/hda.c
+index b3d61d973ce40b..24604e71386d6d 100644
+--- a/sound/soc/sof/intel/hda.c
++++ b/sound/soc/sof/intel/hda.c
+@@ -1337,6 +1337,8 @@ static struct snd_soc_acpi_mach *hda_sdw_machine_select(struct snd_sof_dev *sdev
+ 		return NULL;
+ 	}
+ 
++	chip = get_chip_info(sdev->pdata);
++
+ 	/*
+ 	 * Select SoundWire machine driver if needed using the
+ 	 * alternate tables. This case deals with SoundWire-only
+@@ -1352,8 +1354,13 @@ static struct snd_soc_acpi_mach *hda_sdw_machine_select(struct snd_sof_dev *sdev
+ 		 * first check whether link_mask of mach is subset of
+ 		 * link_mask supported by hw and then go on searching
+ 		 * link_adr
++		 * For those platforms that can use the created SDW mach below,
++		 * match the two masks exactly to avoid using an unexpected
++		 * mach.
+ 		 */
+-		if (~hdev->info.link_mask & mach->link_mask)
++		if (~hdev->info.link_mask & mach->link_mask ||
++		    (hdev->info.link_mask != mach->link_mask &&
++		     chip->hw_ip_version >= SOF_INTEL_ACE_2_0))
+ 			continue;
+ 
+ 		/* No need to match adr if there is no links defined */
+@@ -1393,8 +1400,6 @@ static struct snd_soc_acpi_mach *hda_sdw_machine_select(struct snd_sof_dev *sdev
+ 			 peripherals->array[i]->id.part_id,
+ 			 peripherals->array[i]->id.sdw_version);
+ 
+-	chip = get_chip_info(sdev->pdata);
+-
+ 	/* SDCA was not well supported in the BIOS before ACE2.0 */
+ 	if (chip->hw_ip_version < SOF_INTEL_ACE_2_0)
+ 		return NULL;

--- a/pkgbuilds/linux-ptl/0031-ptl-mach-lenovo-83qk-rt722-ghost.patch
+++ b/pkgbuilds/linux-ptl/0031-ptl-mach-lenovo-83qk-rt722-ghost.patch
@@ -1,0 +1,62 @@
+diff --git a/sound/soc/intel/common/soc-acpi-intel-ptl-match.c b/sound/soc/intel/common/soc-acpi-intel-ptl-match.c
+index 3b7818355ff645..8f3d7b6c0a1e2 100644
+--- a/sound/soc/intel/common/soc-acpi-intel-ptl-match.c
++++ b/sound/soc/intel/common/soc-acpi-intel-ptl-match.c
+@@ -245,6 +245,28 @@
+ 	}
+ };
+ 
++static const struct snd_soc_acpi_adr_device cs42l43_3_agg_rt722_l3_ghost_adr[] = {
++	{
++		.adr = 0x00033001FA424301ull,
++		.num_endpoints = ARRAY_SIZE(cs42l43_amp_spkagg_endpoints),
++		.endpoints = cs42l43_amp_spkagg_endpoints,
++		.name_prefix = "cs42l43"
++	},
++	/*
++	 * Lenovo Yoga Slim 7 Ultra 14IPH11 (83QK, SSID 17aa:3821) exposes
++	 * an RT722 SDCA function at link 3 in firmware. On Linux this function
++	 * remains UNATTACHED and any attempt to route speaker/jack audio through
++	 * it fails with rt722 DPN_PortCtrl errors. Treat it as a zero-endpoint
++	 * ghost so the real CS42L43 + CS35L56 sidecar speaker path can be used.
++	 */
++	{
++		.adr = 0x000330025d072201ull, /* Ghost RT722/ALC722 */
++		.num_endpoints = 0,
++		.endpoints = NULL,
++		.name_prefix = "ghost"
++	}
++};
++
+ static const struct snd_soc_acpi_adr_device cs35l56_2_lr_adr[] = {
+ 	{
+ 		.adr = 0x00023001fa355601ull,
+@@ -460,6 +482,15 @@
+ 	{}
+ };
+ 
++static const struct snd_soc_acpi_link_adr ptl_lenovo_83qk_cs42l43_l3_rt722_ghost[] = {
++	{
++		.mask = BIT(3),
++		.num_adr = ARRAY_SIZE(cs42l43_3_agg_rt722_l3_ghost_adr),
++		.adr_d = cs42l43_3_agg_rt722_l3_ghost_adr,
++	},
++	{}
++};
++
+ static const struct snd_soc_acpi_link_adr ptl_cs42l43_l2_cs35l56x6_l13[] = {
+ 	{
+ 		.mask = BIT(2),
+@@ -693,6 +724,12 @@
+ 		.sof_tplg_filename = "sof-ptl-cs42l43-agg-l3-cs35l56-l2.tplg",
+ 	},
+ 	{
++		.link_mask = BIT(3),
++		.links = ptl_lenovo_83qk_cs42l43_l3_rt722_ghost,
++		.drv_name = "sof_sdw",
++		.sof_tplg_filename = "sof-arl-cs42l43-l2-cs35l56-l3.tplg",
++	},
++	{
+ 		.link_mask = BIT(0),
+ 		.links = ptl_rvp,
+ 		.drv_name = "sof_sdw",

--- a/pkgbuilds/linux-ptl/0032-sdw-utils-lenovo-83qk-skip-cs42l43-sdca-check.patch
+++ b/pkgbuilds/linux-ptl/0032-sdw-utils-lenovo-83qk-skip-cs42l43-sdca-check.patch
@@ -1,0 +1,25 @@
+diff --git a/sound/soc/sdw_utils/soc_sdw_utils.c b/sound/soc/sdw_utils/soc_sdw_utils.c
+index 0a000000000000..0b000000000000 100644
+--- a/sound/soc/sdw_utils/soc_sdw_utils.c
++++ b/sound/soc/sdw_utils/soc_sdw_utils.c
+@@ -1542,8 +1542,18 @@
+ 				soc_end->include_sidecar = true;
+ 			}
+ 
+-			if (SDW_CLASS_ID(adr_dev->adr) && adr_dev->num_endpoints > 1)
+-				check_sdca = true;
++			if (SDW_CLASS_ID(adr_dev->adr) && adr_dev->num_endpoints > 1) {
++				/*
++				 * Lenovo 83QK exposes CS42L43 endpoints through firmware in a
++				 * way that reports only SmartAmp SDCA functions. If we enforce
++				 * SDCA endpoint probing here, SimpleJack endpoints are skipped
++				 * and CS42L43 topologies fail to connect Playback-SimpleJack.
++				 */
++				if (!(ctx->mc_quirk & SOC_SDW_SIDECAR_AMPS &&
++				      SDW_MFG_ID(adr_dev->adr) == 0x01fa &&
++				      SDW_PART_ID(adr_dev->adr) == 0x4243))
++					check_sdca = true;
++			}
+ 
+ 			for (j = 0; j < adr_dev->num_endpoints; j++) {
+ 				const struct snd_soc_acpi_endpoint *adr_end;

--- a/pkgbuilds/linux-ptl/0033-lenovo-83qk-force-2ch-pch-dmic.patch
+++ b/pkgbuilds/linux-ptl/0033-lenovo-83qk-force-2ch-pch-dmic.patch
@@ -2,20 +2,23 @@ diff --git a/sound/soc/sof/intel/hda.c b/sound/soc/sof/intel/hda.c
 index 111111111111..222222222222 100644
 --- a/sound/soc/sof/intel/hda.c
 +++ b/sound/soc/sof/intel/hda.c
-@@ -1584,6 +1584,17 @@ struct snd_soc_acpi_mach *hda_machine_select(struct snd_sof_dev *sdev)
+@@ -1584,6 +1584,20 @@ struct snd_soc_acpi_mach *hda_machine_select(struct snd_sof_dev *sdev)
  		/* report to machine driver if any DMICs are found */
  		mach->mach_params.dmic_num = check_dmic_num(sdev);
  
 +		/*
 +		 * Lenovo Yoga Slim 7 Ultra 14IPH11 (83QK, SSID 17aa:3821)
-+		 * uses the CS42L43 SoundWire DMIC path. Ignore the PCH DMICs
-+		 * from NHLT so topology filename fixup does not append "-4ch"
-+		 * and so PCH DMIC links do not shift BE IDs before iDisp.
++		 * reports 4 PCH DMICs in NHLT, but sof-firmware currently ships
++		 * the matching ARL CS42L43 + CS35L56 topology only in a 2ch DMIC
++		 * variant. Clamp the DMIC count to 2 so topology filename fixup
++		 * selects sof-arl-cs42l43-l2-cs35l56-l3-2ch.tplg instead of the
++		 * unavailable/non-working -4ch variant, while still creating the
++		 * PCH DMIC capture links for the built-in microphones.
 +		 */
 +		if (sof_pdata->subsystem_id_set &&
 +		    sof_pdata->subsystem_vendor == 0x17aa &&
 +		    sof_pdata->subsystem_device == 0x3821)
-+			mach->mach_params.dmic_num = 0;
++			mach->mach_params.dmic_num = 2;
 +
  		if (sdw_mach_found || mach->tplg_quirk_mask & SND_SOC_ACPI_TPLG_INTEL_DMIC_NUMBER)
  			dmic_fixup = true;

--- a/pkgbuilds/linux-ptl/0033-lenovo-83qk-ignore-pch-dmic.patch
+++ b/pkgbuilds/linux-ptl/0033-lenovo-83qk-ignore-pch-dmic.patch
@@ -1,0 +1,22 @@
+diff --git a/sound/soc/sof/intel/hda.c b/sound/soc/sof/intel/hda.c
+index 111111111111..222222222222 100644
+--- a/sound/soc/sof/intel/hda.c
++++ b/sound/soc/sof/intel/hda.c
+@@ -1584,6 +1584,17 @@ struct snd_soc_acpi_mach *hda_machine_select(struct snd_sof_dev *sdev)
+ 		/* report to machine driver if any DMICs are found */
+ 		mach->mach_params.dmic_num = check_dmic_num(sdev);
+ 
++		/*
++		 * Lenovo Yoga Slim 7 Ultra 14IPH11 (83QK, SSID 17aa:3821)
++		 * uses the CS42L43 SoundWire DMIC path. Ignore the PCH DMICs
++		 * from NHLT so topology filename fixup does not append "-4ch"
++		 * and so PCH DMIC links do not shift BE IDs before iDisp.
++		 */
++		if (sof_pdata->subsystem_id_set &&
++		    sof_pdata->subsystem_vendor == 0x17aa &&
++		    sof_pdata->subsystem_device == 0x3821)
++			mach->mach_params.dmic_num = 0;
++
+ 		if (sdw_mach_found || mach->tplg_quirk_mask & SND_SOC_ACPI_TPLG_INTEL_DMIC_NUMBER)
+ 			dmic_fixup = true;
+ 

--- a/pkgbuilds/linux-ptl/0034-lenovo-83qk-exclude-cs42l43-sdw-dmic.patch
+++ b/pkgbuilds/linux-ptl/0034-lenovo-83qk-exclude-cs42l43-sdw-dmic.patch
@@ -1,0 +1,21 @@
+diff --git a/sound/soc/intel/boards/sof_sdw.c b/sound/soc/intel/boards/sof_sdw.c
+index 111111111111..222222222222 100644
+--- a/sound/soc/intel/boards/sof_sdw.c
++++ b/sound/soc/intel/boards/sof_sdw.c
+@@ -858,7 +858,15 @@ static const struct snd_pci_quirk sof_sdw_ssid_quirk_table[] = {
+ 	SND_PCI_QUIRK(0x17aa, 0x2347, "Lenovo P16", SOC_SDW_CODEC_MIC),
+ 	SND_PCI_QUIRK(0x17aa, 0x2348, "Lenovo P16", SOC_SDW_CODEC_MIC),
+ 	SND_PCI_QUIRK(0x17aa, 0x2349, "Lenovo P1", SOC_SDW_CODEC_MIC),
+-	SND_PCI_QUIRK(0x17aa, 0x3821, "Lenovo 0x3821", SOC_SDW_SIDECAR_AMPS),
++	/*
++	 * Lenovo Yoga Slim 7 Ultra 14IPH11 (83QK, SSID 17aa:3821)
++	 * needs the CS35L56/CS35L57 sidecar speaker path, but the internal
++	 * microphone is the PCH DMIC path selected by the -2ch topology.
++	 * Mark SOC_SDW_CODEC_MIC as a quirk so the CS42L43 SmartMic endpoint
++	 * with quirk_exclude=true is skipped; otherwise the SDW DMIC consumes
++	 * DAI id 4 and dmic01 is not created at topology-expected id 3.
++	 */
++	SND_PCI_QUIRK(0x17aa, 0x3821, "Lenovo 0x3821", SOC_SDW_SIDECAR_AMPS | SOC_SDW_CODEC_MIC),
+ 	{}
+ };
+ 

--- a/pkgbuilds/linux-ptl/0035-lenovo-83qk-use-topology-nhlt-for-pch-dmic.patch
+++ b/pkgbuilds/linux-ptl/0035-lenovo-83qk-use-topology-nhlt-for-pch-dmic.patch
@@ -1,0 +1,26 @@
+diff --git a/sound/soc/sof/intel/hda-dai.c b/sound/soc/sof/intel/hda-dai.c
+index 111111111111..222222222222 100644
+--- a/sound/soc/sof/intel/hda-dai.c
++++ b/sound/soc/sof/intel/hda-dai.c
+@@ -758,6 +758,21 @@ void hda_set_dai_drv_ops(struct snd_sof_dev *sdev, struct snd_sof_dsp_ops *ops)
+ 	ssp_set_dai_drv_ops(sdev, ops);
+ 	dmic_set_dai_drv_ops(sdev, ops);
+ 
++	/*
++	 * Lenovo Yoga Slim 7 Ultra 14IPH11 (83QK, SSID 17aa:3821)
++	 * exposes a PCH DMIC capture path via the ARL CS42L43 + CS35L56
++	 * -2ch topology, but the BIOS NHLT blob lookup fails for that path
++	 * with "no matching blob" on DMIC Raw capture. Use the topology-provided
++	 * NHLT blobs on this machine so the PCH DMIC copier can be configured
++	 * from the topology manifest instead of the BIOS NHLT table.
++	 */
++	if (sdev->pdata->subsystem_id_set &&
++	    sdev->pdata->subsystem_vendor == 0x17aa &&
++	    sdev->pdata->subsystem_device == 0x3821) {
++		dev_info(sdev->dev, "Lenovo 83QK: using topology NHLT blobs for PCH DMIC\n");
++		hda_use_tplg_nhlt = true;
++	}
++
+ 	if (sdev->pdata->ipc_type == SOF_IPC_TYPE_4 && !hda_use_tplg_nhlt) {
+ 		struct sof_ipc4_fw_data *ipc4_data = sdev->private;
+ 

--- a/pkgbuilds/linux-ptl/PKGBUILD
+++ b/pkgbuilds/linux-ptl/PKGBUILD
@@ -3,7 +3,7 @@
 
 pkgbase=linux-ptl
 pkgver=7.0.3.arch1
-pkgrel=2
+pkgrel=6
 pkgdesc='Linux with Panther Lake hardware backports (SDCA audio, PSR2, Panel Replay SU)'
 url='https://github.com/archlinux/linux'
 arch=(
@@ -37,6 +37,10 @@ source=(
   0027-drm-i915-trans-push-frame-change-for-panel-replay.patch
   0028-drm-i915-psr-exit-Panel-Replay-for-ALPM-lag.patch
   0029-drm-edid-populate-monitor-range-from-displayid-adaptive-sync.patch
+  0030-sof-intel-exact-sdw-mask.patch
+  0031-ptl-mach-lenovo-83qk-rt722-ghost.patch
+  0032-sdw-utils-lenovo-83qk-skip-cs42l43-sdca-check.patch
+  0033-lenovo-83qk-ignore-pch-dmic.patch
 )
 source_x86_64=(config.x86_64)
 validpgpkeys=(
@@ -48,7 +52,7 @@ b2sums=('SKIP'
         'SKIP'
         'SKIP'
         'SKIP'
-        'SKIP' 'SKIP' 'SKIP' 'SKIP' 'SKIP' 'SKIP' 'SKIP')
+        'SKIP' 'SKIP' 'SKIP' 'SKIP' 'SKIP' 'SKIP' 'SKIP' 'SKIP' 'SKIP' 'SKIP' 'SKIP')
 b2sums_x86_64=('9742088ab0381d8196046e42e8acb4ce01ea77461fada77dc90d197e859631e73b06ead4d512f15ab619b33ebad7bca58a10d4506d66916a99c40f9f52708a53')
 
 # https://www.kernel.org/pub/linux/kernel/v7.x/sha256sums.asc
@@ -56,7 +60,7 @@ sha256sums=('0bedadbf5788693ddebbcc913c893f1a97349af79ddde7144c2a80b401959f1c'
             'SKIP'
             'SKIP'
             'SKIP'
-            'SKIP' 'SKIP' 'SKIP' 'SKIP' 'SKIP' 'SKIP' 'SKIP')
+            'SKIP' 'SKIP' 'SKIP' 'SKIP' 'SKIP' 'SKIP' 'SKIP' 'SKIP' 'SKIP' 'SKIP' 'SKIP')
 
 export KBUILD_BUILD_HOST=archlinux
 export KBUILD_BUILD_USER=$pkgbase

--- a/pkgbuilds/linux-ptl/PKGBUILD
+++ b/pkgbuilds/linux-ptl/PKGBUILD
@@ -3,7 +3,7 @@
 
 pkgbase=linux-ptl
 pkgver=7.0.3.arch1
-pkgrel=7
+pkgrel=9
 pkgdesc='Linux with Panther Lake hardware backports (SDCA audio, PSR2, Panel Replay SU)'
 url='https://github.com/archlinux/linux'
 arch=(
@@ -41,6 +41,8 @@ source=(
   0031-ptl-mach-lenovo-83qk-rt722-ghost.patch
   0032-sdw-utils-lenovo-83qk-skip-cs42l43-sdca-check.patch
   0033-lenovo-83qk-force-2ch-pch-dmic.patch
+  0034-lenovo-83qk-exclude-cs42l43-sdw-dmic.patch
+  0035-lenovo-83qk-use-topology-nhlt-for-pch-dmic.patch
 )
 source_x86_64=(config.x86_64)
 validpgpkeys=(
@@ -52,7 +54,7 @@ b2sums=('SKIP'
         'SKIP'
         'SKIP'
         'SKIP'
-        'SKIP' 'SKIP' 'SKIP' 'SKIP' 'SKIP' 'SKIP' 'SKIP' 'SKIP' 'SKIP' 'SKIP' 'SKIP')
+        'SKIP' 'SKIP' 'SKIP' 'SKIP' 'SKIP' 'SKIP' 'SKIP' 'SKIP' 'SKIP' 'SKIP' 'SKIP' 'SKIP' 'SKIP')
 b2sums_x86_64=('9742088ab0381d8196046e42e8acb4ce01ea77461fada77dc90d197e859631e73b06ead4d512f15ab619b33ebad7bca58a10d4506d66916a99c40f9f52708a53')
 
 # https://www.kernel.org/pub/linux/kernel/v7.x/sha256sums.asc
@@ -60,7 +62,7 @@ sha256sums=('0bedadbf5788693ddebbcc913c893f1a97349af79ddde7144c2a80b401959f1c'
             'SKIP'
             'SKIP'
             'SKIP'
-            'SKIP' 'SKIP' 'SKIP' 'SKIP' 'SKIP' 'SKIP' 'SKIP' 'SKIP' 'SKIP' 'SKIP' 'SKIP')
+            'SKIP' 'SKIP' 'SKIP' 'SKIP' 'SKIP' 'SKIP' 'SKIP' 'SKIP' 'SKIP' 'SKIP' 'SKIP' 'SKIP' 'SKIP')
 
 export KBUILD_BUILD_HOST=archlinux
 export KBUILD_BUILD_USER=$pkgbase

--- a/pkgbuilds/linux-ptl/PKGBUILD
+++ b/pkgbuilds/linux-ptl/PKGBUILD
@@ -3,7 +3,7 @@
 
 pkgbase=linux-ptl
 pkgver=7.0.3.arch1
-pkgrel=6
+pkgrel=7
 pkgdesc='Linux with Panther Lake hardware backports (SDCA audio, PSR2, Panel Replay SU)'
 url='https://github.com/archlinux/linux'
 arch=(
@@ -40,7 +40,7 @@ source=(
   0030-sof-intel-exact-sdw-mask.patch
   0031-ptl-mach-lenovo-83qk-rt722-ghost.patch
   0032-sdw-utils-lenovo-83qk-skip-cs42l43-sdca-check.patch
-  0033-lenovo-83qk-ignore-pch-dmic.patch
+  0033-lenovo-83qk-force-2ch-pch-dmic.patch
 )
 source_x86_64=(config.x86_64)
 validpgpkeys=(


### PR DESCRIPTION
## Summary

Fixes built-in speakers and internal microphone on Lenovo Yoga Slim 7 Ultra 14IPH11 (`83QK`, PCI audio subsystem `17aa:3821`) for `linux-ptl`.

This machine has:

- CS42L43 on SoundWire link 3
- RT722/ALC722 also described on link 3, but it stays `UNATTACHED`
- CS35L57/CS35L56 speaker amps on SPI sidecar
- internal microphone working through the PCH DMIC path in the `-2ch` topology

The fix keeps the ghost RT722 only for matching, routes speakers through the CS42L43 + CS35L56 sidecar path, selects the shipped `-2ch` topology, skips the silent CS42L43 SoundWire mic endpoint, and uses topology-provided NHLT blobs for the PCH DMIC.

## What was broken

Before these patches, speaker playback could be routed through the unattached RT722 path and failed with errors like:

```text
rt722-sdca ... DPN_PortCtrl register write failed
soundwire ... Program transport params failed: -61
SDW3-Playback-SmartAmp: ASoC error (-61)
```

The first speaker fix worked, but the internal microphone was still wrong. The usable mic path is the PCH DMIC from:

```text
sof-arl-cs42l43-l2-cs35l56-l3-2ch.tplg
```

The BIOS NHLT lookup did not provide a matching blob for that PCH DMIC path; using topology-provided NHLT blobs fixed capture.

## Patch contents

- `0030-sof-intel-exact-sdw-mask.patch`
  - Requires exact SoundWire link-mask matching on ACE2+ platforms.

- `0031-ptl-mach-lenovo-83qk-rt722-ghost.patch`
  - Adds the Lenovo 83QK machine entry.
  - Keeps RT722/ALC722 as a zero-endpoint ghost so matching succeeds but audio is not routed through it.

- `0032-sdw-utils-lenovo-83qk-skip-cs42l43-sdca-check.patch`
  - Avoids skipping needed CS42L43 endpoints on this sidecar-amp layout.

- `0033-lenovo-83qk-force-2ch-pch-dmic.patch`
  - Clamps `17aa:3821` from 4 reported DMICs to 2 so the shipped `-2ch` topology is selected.

- `0034-lenovo-83qk-exclude-cs42l43-sdw-dmic.patch`
  - Marks `17aa:3821` with `SOC_SDW_CODEC_MIC` so the CS42L43 SoundWire mic endpoint is skipped.
  - This lets the PCH `dmic01` link line up with the topology.

- `0035-lenovo-83qk-use-topology-nhlt-for-pch-dmic.patch`
  - For `17aa:3821`, uses topology-provided NHLT blobs instead of BIOS NHLT for the PCH DMIC.
  - This fixes the previous `no matching blob ... DMIC Raw` capture failure.

## Tested result

Validated locally with:

```text
linux-ptl 7.0.3.arch1-9
uname -r: 7.0.3-arch1-9-ptl
```

Kernel/card:

```text
0 [sofsoundwire]: sof-soundwire - sof-soundwire
                 LENOVO-83QK-YogaSlim7Ultra14IPH11-LNVNB161216
```

Loaded topology:

```text
Topology file: intel/sof-ipc4-tplg/sof-arl-cs42l43-l2-cs35l56-l3-2ch.tplg
Lenovo 83QK: using topology NHLT blobs for PCH DMIC
```

PipeWire/UCM exposes the expected routes:

```text
sof-soundwire Speaker
sof-soundwire Digital Microphone
```

Confirmed locally:

- built-in speakers work
- internal microphone records voice
- RT722 remains unattached but no longer blocks speaker routing
- no Dummy Output / missing-card failure on the final `pkgrel=9` build

## Test plan

- [x] Build `linux-ptl` with `makepkg`
- [x] Install `linux-ptl` and matching headers
- [x] Boot patched kernel on Lenovo `83QK` / `17aa:3821`
- [x] Confirm `sof-soundwire` card appears
- [x] Confirm `sof-arl-cs42l43-l2-cs35l56-l3-2ch.tplg` is loaded
- [x] Confirm CS35L57/CS35L56 speaker amp firmware/calibration loads
- [x] Confirm built-in speakers are audible
- [x] Confirm internal microphone records voice

## Notes

This is validated on one Lenovo 83QK unit. The SoundWire/DMIC changes are subsystem-ID scoped to `17aa:3821` where possible.
