### PR TITLE
linux-ptl: fix Xe reclaim stalls under fragmentation

### DIFF
--- a/pkgbuilds/linux-ptl/1001-mm-opportunistic-compaction.patch
+++ b/pkgbuilds/linux-ptl/1001-mm-opportunistic-compaction.patch
@@ -1,0 +1,461 @@
+Subject: [PATCH v6 1/2] mm: Introduce opportunistic_compaction concept to
+ vmscan and shrinkers
+From: Matthew Brost <matthew.brost@intel.com>
+Date: Tue, 16 Jun 2026 20:22:17 -0700
+Message-Id: <20260617032218.1165929-2-matthew.brost@intel.com>
+MIME-Version: 1.0
+Content-Type: text/plain; charset="utf-8"
+Content-Transfer-Encoding: 8bit
+
+High-order allocations using __GFP_NORETRY or __GFP_RETRY_MAYFAIL
+are often opportunistic attempts to satisfy fragmentation-sensitive
+allocations rather than indications of severe memory pressure. In these
+cases, reclaim may invoke shrinkers that aggressively destroy working
+sets even though reclaim is unlikely to materially improve the
+allocation outcome.
+
+Some shrinkers manage expensive backing or migration operations where
+reclaim can result in substantial working set disruption despite the
+system having sufficient free memory overall. This is particularly
+visible in fragmentation-heavy workloads where reclaim repeatedly tears
+down active state while kswapd attempts to satisfy higher-order
+allocations.
+
+Introduce an opportunistic_compaction hint in shrink_control that allows
+kswapd to communicate when reclaim originates from a high-order
+allocation context that may be fragmentation driven rather than true
+memory pressure. Shrinkers may use this hint to avoid destructive
+working set reclaim while still participating normally during order-0
+or stronger reclaim conditions.
+
+The hint is propagated through shrink_slab() and derived from
+high-order kswapd wakeups associated or direct reclaim gfp with
+non-failing allocation contexts.
+
+No functional changes are introduced for existing shrinkers.
+
+Cc: Andrew Morton <akpm@linux-foundation.org>
+Cc: Dave Chinner <david@fromorbit.com>
+Cc: Qi Zheng <zhengqi.arch@bytedance.com>
+Cc: Roman Gushchin <roman.gushchin@linux.dev>
+Cc: Muchun Song <muchun.song@linux.dev>
+Cc: David Hildenbrand <david@kernel.org>
+Cc: Lorenzo Stoakes <ljs@kernel.org>
+Cc: "Liam R. Howlett" <Liam.Howlett@oracle.com>
+Cc: Vlastimil Babka <vbabka@kernel.org>
+Cc: Mike Rapoport <rppt@kernel.org>
+Cc: Suren Baghdasaryan <surenb@google.com>
+Cc: Michal Hocko <mhocko@suse.com>
+Cc: Johannes Weiner <hannes@cmpxchg.org>
+Cc: Shakeel Butt <shakeel.butt@linux.dev>
+Cc: Kairui Song <kasong@tencent.com>
+Cc: Barry Song <baohua@kernel.org>
+Cc: Axel Rasmussen <axelrasmussen@google.com>
+Cc: Yuanchu Xie <yuanchu@google.com>
+Cc: Wei Xu <weixugc@google.com>
+Cc: linux-mm@kvack.org
+Cc: linux-kernel@vger.kernel.org
+Assisted-by: Claude:claude-opus-4.6
+Signed-off-by: Matthew Brost <matthew.brost@intel.com>
+---
+Dave Chinner — I’d appreciate feedback on this approach, as you NACKed
+an earlier revision where a similar heuristic was implemented in the
+drivers. It is now baked into the shrinker, as you suggested.
+
+---
+ include/linux/mmzone.h   | 40 +++++++++++++++++
+ include/linux/shrinker.h | 20 +++++++++
+ mm/internal.h            |  2 +-
+ mm/shrinker.c            | 13 ++++--
+ mm/vmscan.c              | 95 ++++++++++++++++++++++++++++++++++++----
+ 5 files changed, 157 insertions(+), 13 deletions(-)
+
+diff --git a/include/linux/mmzone.h b/include/linux/mmzone.h
+index 9adb2ad21da5..1afc51018355 100644
+--- a/include/linux/mmzone.h
++++ b/include/linux/mmzone.h
+@@ -1461,6 +1461,39 @@ struct memory_failure_stats {
+ };
+ #endif
+ 
++/*
++ * Per-pgdat state machine for the kswapd "opportunistic compaction" hint.
++ *
++ * wakeup_kswapd() collapses the gfp flags of all wakers that arrive between
++ * two kswapd runs into a single tri-state, which kswapd then forwards to the
++ * shrinkers via shrink_control::opportunistic_compaction:
++ *
++ *   KSWAPD_UNSET_OPPORTUNISTIC_COMPACTION
++ *	Initial state after kswapd consumes the previous value. No waker has
++ *	been observed yet for the upcoming run.
++ *
++ *   KSWAPD_NO_OPPORTUNISTIC_COMPACTION
++ *	At least one waker is an order-0 allocation, or a high-order
++ *	allocation that cannot tolerate failure (i.e., not eligible for
++ *	opportunistic behaviour). Shrinkers must do their normal best-effort
++ *	work; the hint is cleared.
++ *
++ *   KSWAPD_OPPORTUNISTIC_COMPACTION
++ *	All wakers seen so far are high-order allocations that may fail
++ *	(__GFP_NORETRY or __GFP_RETRY_MAYFAIL, without __GFP_NOFAIL). Shrinkers
++ *	may skip work that is unlikely to produce a contiguous high-order
++ *	block (e.g., evicting working-set pages).
++ *
++ * The state is sticky in the "NO" direction within a single kswapd run: once
++ * any non-eligible waker is observed, subsequent eligible wakers cannot
++ * upgrade it back to KSWAPD_OPPORTUNISTIC_COMPACTION.
++ */
++enum kswapd_opportunistic_compaction_type {
++	KSWAPD_UNSET_OPPORTUNISTIC_COMPACTION = 0,
++	KSWAPD_NO_OPPORTUNISTIC_COMPACTION,
++	KSWAPD_OPPORTUNISTIC_COMPACTION,
++};
++
+ /*
+  * On NUMA machines, each NUMA node would have a pg_data_t to describe
+  * it's memory layout. On UMA machines there is a single pglist_data which
+@@ -1525,6 +1558,13 @@ typedef struct pglist_data {
+ #endif
+ 	struct task_struct *kswapd;	/* Protected by kswapd_lock */
+ 	int kswapd_order;
++	/*
++	 * Aggregated opportunistic-compaction hint for the next kswapd run.
++	 * Updated by wakeup_kswapd() based on the gfp flags / order of each
++	 * waker, and consumed (and reset) by kswapd before balance_pgdat().
++	 * See enum kswapd_opportunistic_compaction_type for the state machine.
++	 */
++	atomic_t kswapd_opportunistic_compaction;
+ 	enum zone_type kswapd_highest_zoneidx;
+ 
+ 	atomic_t kswapd_failures;	/* Number of 'reclaimed == 0' runs */
+diff --git a/include/linux/shrinker.h b/include/linux/shrinker.h
+index 1a00be90d93a..5f3e8dc98129 100644
+--- a/include/linux/shrinker.h
++++ b/include/linux/shrinker.h
+@@ -37,6 +37,26 @@ struct shrink_control {
+ 	/* current node being shrunk (for NUMA aware shrinkers) */
+ 	int nid;
+ 
++	/*
++	 * Opportunistic compaction hint.
++	 *
++	 * Set by the reclaim path to tell shrinkers that this pass is
++	 * driven by an order > 0 allocation that the caller is willing to
++	 * have fail (e.g., __GFP_NORETRY / __GFP_RETRY_MAYFAIL without
++	 * __GFP_NOFAIL). Such allocations only really benefit from
++	 * shrinking when doing so frees up a contiguous, high-order block;
++	 * thrashing working sets in the hope of producing one is typically
++	 * counter-productive.
++	 *
++	 * Shrinkers that can produce naturally-aligned high-order folios
++	 * (see shrink_control::order) should treat this as a hint to skip
++	 * costly work that is unlikely to help compaction (for example,
++	 * evicting hot/working-set pages just to free single pages).
++	 *
++	 * Only meaningful when @order > 0; ignored otherwise.
++	 */
++	bool opportunistic_compaction;
++
+ 	/*
+ 	 * How many objects scan_objects should scan and try to reclaim.
+ 	 * This is reset before every call, so it is safe for callees
+diff --git a/mm/internal.h b/mm/internal.h
+index 5a2ddcf68e0b..cc915f04cf1e 100644
+--- a/mm/internal.h
++++ b/mm/internal.h
+@@ -1760,7 +1760,7 @@ void __meminit __init_page_from_nid(unsigned long pfn, int nid);
+ 
+ /* shrinker related functions */
+ unsigned long shrink_slab(gfp_t gfp_mask, int nid, struct mem_cgroup *memcg,
+-			  int priority);
++			  int priority, bool opportunistic_compaction);
+ 
+ int shmem_add_to_page_cache(struct folio *folio,
+ 			    struct address_space *mapping,
+diff --git a/mm/shrinker.c b/mm/shrinker.c
+index 76b3f750cf65..2cf8f3a157f9 100644
+--- a/mm/shrinker.c
++++ b/mm/shrinker.c
+@@ -467,7 +467,7 @@ static unsigned long do_shrink_slab(struct shrink_control *shrinkctl,
+ 
+ #ifdef CONFIG_MEMCG
+ static unsigned long shrink_slab_memcg(gfp_t gfp_mask, int nid,
+-			struct mem_cgroup *memcg, int priority)
++			struct mem_cgroup *memcg, int priority, bool opportunistic_compaction)
+ {
+ 	struct shrinker_info *info;
+ 	unsigned long ret, freed = 0;
+@@ -529,6 +529,7 @@ static unsigned long shrink_slab_memcg(gfp_t gfp_mask, int nid,
+ 				.gfp_mask = gfp_mask,
+ 				.nid = nid,
+ 				.memcg = memcg,
++				.opportunistic_compaction = opportunistic_compaction,
+ 			};
+ 			struct shrinker *shrinker;
+ 			int shrinker_id = calc_shrinker_id(index, offset);
+@@ -588,7 +589,8 @@ static unsigned long shrink_slab_memcg(gfp_t gfp_mask, int nid,
+ }
+ #else /* !CONFIG_MEMCG */
+ static unsigned long shrink_slab_memcg(gfp_t gfp_mask, int nid,
+-			struct mem_cgroup *memcg, int priority)
++			struct mem_cgroup *memcg, int priority,
++			bool opportunistic_compaction)
+ {
+ 	return 0;
+ }
+@@ -600,6 +602,7 @@ static unsigned long shrink_slab_memcg(gfp_t gfp_mask, int nid,
+  * @nid: node whose slab caches to target
+  * @memcg: memory cgroup whose slab caches to target
+  * @priority: the reclaim priority
++ * @opportunistic_compaction: do compaction opportunistically (e.g., do not swap working sets)
+  *
+  * Call the shrink functions to age shrinkable caches.
+  *
+@@ -615,7 +618,7 @@ static unsigned long shrink_slab_memcg(gfp_t gfp_mask, int nid,
+  * Returns the number of reclaimed slab objects.
+  */
+ unsigned long shrink_slab(gfp_t gfp_mask, int nid, struct mem_cgroup *memcg,
+-			  int priority)
++			  int priority, bool opportunistic_compaction)
+ {
+ 	unsigned long ret, freed = 0;
+ 	struct shrinker *shrinker;
+@@ -628,7 +631,8 @@ unsigned long shrink_slab(gfp_t gfp_mask, int nid, struct mem_cgroup *memcg,
+ 	 * oom.
+ 	 */
+ 	if (!mem_cgroup_disabled() && !mem_cgroup_is_root(memcg))
+-		return shrink_slab_memcg(gfp_mask, nid, memcg, priority);
++		return shrink_slab_memcg(gfp_mask, nid, memcg, priority,
++					 opportunistic_compaction);
+ 
+ 	/*
+ 	 * lockless algorithm of global shrink.
+@@ -657,6 +661,7 @@ unsigned long shrink_slab(gfp_t gfp_mask, int nid, struct mem_cgroup *memcg,
+ 			.gfp_mask = gfp_mask,
+ 			.nid = nid,
+ 			.memcg = memcg,
++			.opportunistic_compaction = opportunistic_compaction,
+ 		};
+ 
+ 		if (!shrinker_try_get(shrinker))
+diff --git a/mm/vmscan.c b/mm/vmscan.c
+index bd1b1aa12581..c40bc3f9ddd4 100644
+--- a/mm/vmscan.c
++++ b/mm/vmscan.c
+@@ -96,6 +96,14 @@ struct scan_control {
+ 	/* Swappiness value for proactive reclaim. Always use sc_swappiness()! */
+ 	int *proactive_swappiness;
+ 
++	/*
++	 * Opportunistic compaction hint snapshotted from the pgdat at the
++	 * start of this reclaim pass. Forwarded to shrinkers through
++	 * shrink_control::opportunistic_compaction so they can skip
++	 * non-productive work for failable high-order allocations.
++	 */
++	enum kswapd_opportunistic_compaction_type kswapd_opportunistic_compaction;
++
+ 	/* Can active folios be deactivated as part of reclaim? */
+ #define DEACTIVATE_ANON 1
+ #define DEACTIVATE_FILE 2
+@@ -200,6 +208,29 @@ struct scan_control {
+  */
+ int vm_swappiness = 60;
+ 
++/*
++ * Is @gfp_flags a high-order allocation that is eligible for the
++ * "opportunistic compaction" treatment in kswapd / shrinkers?
++ *
++ * The caller must be willing to tolerate failure (__GFP_NORETRY or
++ * __GFP_RETRY_MAYFAIL) and must not have set __GFP_NOFAIL. For such
++ * allocations there is little value in burning working-set pages just to
++ * scrape together a single high-order block: if compaction can't easily
++ * succeed, the caller would rather see the allocation fail.
++ */
++static bool gfp_opportunistic_compaction(gfp_t gfp_flags)
++{
++	return (gfp_flags & (__GFP_NORETRY | __GFP_RETRY_MAYFAIL)) &&
++		!(gfp_flags & __GFP_NOFAIL);
++}
++
++static bool sc_opportunistic_compaction(struct scan_control *sc)
++{
++	return sc->order && (sc->kswapd_opportunistic_compaction ==
++		KSWAPD_OPPORTUNISTIC_COMPACTION || (!current_is_kswapd() &&
++		 gfp_opportunistic_compaction(sc->gfp_mask)));
++}
++
+ #ifdef CONFIG_MEMCG
+ 
+ /* Returns true for reclaim through cgroup limits or cgroup interfaces. */
+@@ -412,7 +443,7 @@ static unsigned long drop_slab_node(int nid)
+ 
+ 	memcg = mem_cgroup_iter(NULL, NULL, NULL);
+ 	do {
+-		freed += shrink_slab(GFP_KERNEL, nid, memcg, 0);
++		freed += shrink_slab(GFP_KERNEL, nid, memcg, 0, false);
+ 	} while ((memcg = mem_cgroup_iter(NULL, memcg, NULL)) != NULL);
+ 
+ 	return freed;
+@@ -5053,6 +5084,7 @@ static int shrink_one(struct lruvec *lruvec, struct scan_control *sc)
+ 	unsigned long reclaimed = sc->nr_reclaimed;
+ 	struct mem_cgroup *memcg = lruvec_memcg(lruvec);
+ 	struct pglist_data *pgdat = lruvec_pgdat(lruvec);
++	bool opportunistic_compaction = sc_opportunistic_compaction(sc);
+ 
+ 	/* lru_gen_age_node() called mem_cgroup_calculate_protection() */
+ 	if (mem_cgroup_below_min(NULL, memcg))
+@@ -5068,7 +5100,8 @@ static int shrink_one(struct lruvec *lruvec, struct scan_control *sc)
+ 
+ 	success = try_to_shrink_lruvec(lruvec, sc);
+ 
+-	shrink_slab(sc->gfp_mask, pgdat->node_id, memcg, sc->priority);
++	shrink_slab(sc->gfp_mask, pgdat->node_id, memcg, sc->priority,
++		    opportunistic_compaction);
+ 
+ 	if (!sc->proactive)
+ 		vmpressure(sc->gfp_mask, memcg, false, sc->nr_scanned - scanned,
+@@ -6134,6 +6167,7 @@ static void shrink_node_memcgs(pg_data_t *pgdat, struct scan_control *sc)
+ 		struct lruvec *lruvec = mem_cgroup_lruvec(memcg, pgdat);
+ 		unsigned long reclaimed;
+ 		unsigned long scanned;
++		bool opportunistic_compaction = sc_opportunistic_compaction(sc);
+ 
+ 		/*
+ 		 * This loop can become CPU-bound when target memcgs
+@@ -6171,7 +6205,7 @@ static void shrink_node_memcgs(pg_data_t *pgdat, struct scan_control *sc)
+ 		shrink_lruvec(lruvec, sc);
+ 
+ 		shrink_slab(sc->gfp_mask, pgdat->node_id, memcg,
+-			    sc->priority);
++			    sc->priority, opportunistic_compaction);
+ 
+ 		/* Record the group's reclaim efficiency */
+ 		if (!sc->proactive)
+@@ -7104,8 +7138,14 @@ clear_reclaim_active(pg_data_t *pgdat, int highest_zoneidx)
+  * found to have free_pages <= high_wmark_pages(zone), any page in that zone
+  * or lower is eligible for reclaim until at least one usable zone is
+  * balanced.
++ *
++ * @kswapd_opportunistic_compaction is the aggregated hint produced by
++ * wakeup_kswapd() for this run; it is propagated into scan_control so that
++ * shrinkers can skip costly work that is unlikely to help compaction when
++ * all wakers are failable high-order allocations.
+  */
+-static int balance_pgdat(pg_data_t *pgdat, int order, int highest_zoneidx)
++static int balance_pgdat(pg_data_t *pgdat, int order, int highest_zoneidx,
++			 enum kswapd_opportunistic_compaction_type kswapd_opportunistic_compaction)
+ {
+ 	int i;
+ 	unsigned long nr_soft_reclaimed;
+@@ -7119,6 +7159,7 @@ static int balance_pgdat(pg_data_t *pgdat, int order, int highest_zoneidx)
+ 		.gfp_mask = GFP_KERNEL,
+ 		.order = order,
+ 		.may_unmap = 1,
++		.kswapd_opportunistic_compaction = kswapd_opportunistic_compaction,
+ 	};
+ 
+ 	set_task_reclaim_state(current, &sc.reclaim_state);
+@@ -7338,8 +7379,10 @@ static enum zone_type kswapd_highest_zoneidx(pg_data_t *pgdat,
+ 	return curr_idx == MAX_NR_ZONES ? prev_highest_zoneidx : curr_idx;
+ }
+ 
+-static void kswapd_try_to_sleep(pg_data_t *pgdat, int alloc_order, int reclaim_order,
+-				unsigned int highest_zoneidx)
++static void
++kswapd_try_to_sleep(pg_data_t *pgdat, int alloc_order, int reclaim_order,
++		    unsigned int highest_zoneidx,
++		    enum kswapd_opportunistic_compaction_type kswapd_opportunistic_compaction)
+ {
+ 	long remaining = 0;
+ 	DEFINE_WAIT(wait);
+@@ -7385,6 +7428,11 @@ static void kswapd_try_to_sleep(pg_data_t *pgdat, int alloc_order, int reclaim_o
+ 
+ 			if (READ_ONCE(pgdat->kswapd_order) < reclaim_order)
+ 				WRITE_ONCE(pgdat->kswapd_order, reclaim_order);
++
++			if (kswapd_opportunistic_compaction ==
++			    KSWAPD_NO_OPPORTUNISTIC_COMPACTION)
++				atomic_set(&pgdat->kswapd_opportunistic_compaction,
++					   KSWAPD_NO_OPPORTUNISTIC_COMPACTION);
+ 		}
+ 
+ 		finish_wait(&pgdat->kswapd_wait, &wait);
+@@ -7441,6 +7489,7 @@ static int kswapd(void *p)
+ 	unsigned int highest_zoneidx = MAX_NR_ZONES - 1;
+ 	pg_data_t *pgdat = (pg_data_t *)p;
+ 	struct task_struct *tsk = current;
++	enum kswapd_opportunistic_compaction_type kswapd_opportunistic_compaction;
+ 
+ 	/*
+ 	 * Tell the memory management that we're a "memory allocator",
+@@ -7458,6 +7507,8 @@ static int kswapd(void *p)
+ 	set_freezable();
+ 
+ 	WRITE_ONCE(pgdat->kswapd_order, 0);
++	atomic_set(&pgdat->kswapd_opportunistic_compaction,
++		   KSWAPD_UNSET_OPPORTUNISTIC_COMPACTION);
+ 	WRITE_ONCE(pgdat->kswapd_highest_zoneidx, MAX_NR_ZONES);
+ 	atomic_set(&pgdat->nr_writeback_throttled, 0);
+ 	for ( ; ; ) {
+@@ -7466,13 +7517,18 @@ static int kswapd(void *p)
+ 		alloc_order = reclaim_order = READ_ONCE(pgdat->kswapd_order);
+ 		highest_zoneidx = kswapd_highest_zoneidx(pgdat,
+ 							highest_zoneidx);
++		kswapd_opportunistic_compaction =
++			atomic_read(&pgdat->kswapd_opportunistic_compaction);
+ 
+ kswapd_try_sleep:
+ 		kswapd_try_to_sleep(pgdat, alloc_order, reclaim_order,
+-					highest_zoneidx);
++				    highest_zoneidx, kswapd_opportunistic_compaction);
+ 
+ 		/* Read the new order and highest_zoneidx */
+ 		alloc_order = READ_ONCE(pgdat->kswapd_order);
++		kswapd_opportunistic_compaction =
++			atomic_xchg(&pgdat->kswapd_opportunistic_compaction,
++				    KSWAPD_UNSET_OPPORTUNISTIC_COMPACTION);
+ 		highest_zoneidx = kswapd_highest_zoneidx(pgdat,
+ 							highest_zoneidx);
+ 		WRITE_ONCE(pgdat->kswapd_order, 0);
+@@ -7499,7 +7555,8 @@ static int kswapd(void *p)
+ 		trace_mm_vmscan_kswapd_wake(pgdat->node_id, highest_zoneidx,
+ 						alloc_order);
+ 		reclaim_order = balance_pgdat(pgdat, alloc_order,
+-						highest_zoneidx);
++						highest_zoneidx,
++						kswapd_opportunistic_compaction);
+ 		if (reclaim_order < alloc_order)
+ 			goto kswapd_try_sleep;
+ 	}
+@@ -7537,6 +7594,28 @@ void wakeup_kswapd(struct zone *zone, gfp_t gfp_flags, int order,
+ 	if (READ_ONCE(pgdat->kswapd_order) < order)
+ 		WRITE_ONCE(pgdat->kswapd_order, order);
+ 
++	/*
++	 * Fold this waker into the per-pgdat opportunistic-compaction hint
++	 * that kswapd will pick up at the start of its next run.
++	 *
++	 * The state is sticky in the "NO" direction: once any waker in this
++	 * batch is order-0 or a non-failable high-order allocation, the hint
++	 * stays cleared until kswapd consumes it. Only when every waker so
++	 * far is a failable high-order allocation do we set
++	 * KSWAPD_OPPORTUNISTIC_COMPACTION, asking shrinkers to skip work
++	 * that won't realistically help compaction.
++	 */
++	if (atomic_read(&pgdat->kswapd_opportunistic_compaction) !=
++	    KSWAPD_NO_OPPORTUNISTIC_COMPACTION) {
++		if (!order || !gfp_opportunistic_compaction(gfp_flags))
++			atomic_set(&pgdat->kswapd_opportunistic_compaction,
++				   KSWAPD_NO_OPPORTUNISTIC_COMPACTION);
++		else if (order && gfp_opportunistic_compaction(gfp_flags))
++			atomic_cmpxchg(&pgdat->kswapd_opportunistic_compaction,
++				       KSWAPD_UNSET_OPPORTUNISTIC_COMPACTION,
++				       KSWAPD_OPPORTUNISTIC_COMPACTION);
++	}
++
+ 	if (!waitqueue_active(&pgdat->kswapd_wait))
+ 		return;
+ 
+-- 
+2.34.1
+

--- a/pkgbuilds/linux-ptl/1002-xe-opportunistic-compaction.patch
+++ b/pkgbuilds/linux-ptl/1002-xe-opportunistic-compaction.patch
@@ -1,0 +1,98 @@
+Subject: [PATCH v6 2/2] drm/xe: Make use of
+ shrink_control::opportunistic_compaction hint
+From: Matthew Brost <matthew.brost@intel.com>
+Date: Tue, 16 Jun 2026 20:22:18 -0700
+Message-Id: <20260617032218.1165929-3-matthew.brost@intel.com>
+MIME-Version: 1.0
+Content-Type: text/plain; charset="utf-8"
+Content-Transfer-Encoding: 8bit
+
+Xe/TTM backup reclaim can be extremely expensive under fragmentation
+pressure as reclaim may migrate or destroy actively used GPU working
+sets despite the system still having substantial free memory available.
+
+Under high-order opportunistic reclaim, repeatedly backing up GPU
+memory can lead to reclaim/rebind ping-pong behavior where active GPU
+working sets are continuously torn down and reconstructed without
+materially improving allocation success.
+
+Use the new shrink_control::opportunistic_compaction hint to avoid Xe
+backup reclaim during fragmentation-driven high-order reclaim attempts.
+In this mode the shrinker skips advertising backup-backed reclaimable
+memory and avoids initiating backup operations entirely.
+
+Order-0 and non-opportunistic reclaim behavior remain unchanged, so
+Xe backup reclaim still participates normally during genuine memory
+pressure.
+
+Cc: Andrew Morton <akpm@linux-foundation.org>
+Cc: Dave Chinner <david@fromorbit.com>
+Cc: Qi Zheng <zhengqi.arch@bytedance.com>
+Cc: Roman Gushchin <roman.gushchin@linux.dev>
+Cc: Muchun Song <muchun.song@linux.dev>
+Cc: David Hildenbrand <david@kernel.org>
+Cc: Lorenzo Stoakes <ljs@kernel.org>
+Cc: "Liam R. Howlett" <Liam.Howlett@oracle.com>
+Cc: Vlastimil Babka <vbabka@kernel.org>
+Cc: Mike Rapoport <rppt@kernel.org>
+Cc: Suren Baghdasaryan <surenb@google.com>
+Cc: Michal Hocko <mhocko@suse.com>
+Cc: Johannes Weiner <hannes@cmpxchg.org>
+Cc: Shakeel Butt <shakeel.butt@linux.dev>
+Cc: Kairui Song <kasong@tencent.com>
+Cc: Barry Song <baohua@kernel.org>
+Cc: Axel Rasmussen <axelrasmussen@google.com>
+Cc: Yuanchu Xie <yuanchu@google.com>
+Cc: Wei Xu <weixugc@google.com>
+Cc: linux-mm@kvack.org
+Cc: linux-kernel@vger.kernel.org
+Assisted-by: Claude:claude-opus-4.6
+Signed-off-by: Matthew Brost <matthew.brost@intel.com>
+Reviewed-by: Thomas Hellström <thomas.hellstrom@linux.intel.com>
+---
+ drivers/gpu/drm/xe/xe_shrinker.c | 20 +++++++++++++++++---
+ 1 file changed, 17 insertions(+), 3 deletions(-)
+
+diff --git a/drivers/gpu/drm/xe/xe_shrinker.c b/drivers/gpu/drm/xe/xe_shrinker.c
+index 83374cd57660..198149f266c6 100644
+--- a/drivers/gpu/drm/xe/xe_shrinker.c
++++ b/drivers/gpu/drm/xe/xe_shrinker.c
+@@ -139,10 +139,17 @@ static unsigned long
+ xe_shrinker_count(struct shrinker *shrink, struct shrink_control *sc)
+ {
+ 	struct xe_shrinker *shrinker = to_xe_shrinker(shrink);
+-	unsigned long num_pages;
++	unsigned long num_pages = 0;
+ 	bool can_backup = !!(sc->gfp_mask & __GFP_FS);
+ 
+-	num_pages = ttm_backup_bytes_avail() >> PAGE_SHIFT;
++	/*
++	 * Skip accounting backup-able pages when this is an opportunistic
++	 * high-order pass: TTM backup work shrinks at native page granularity
++	 * and is unlikely to produce the contiguous block the caller wants,
++	 * so don't advertise it as reclaimable for this hint.
++	 */
++	if (!sc->opportunistic_compaction)
++		num_pages = ttm_backup_bytes_avail() >> PAGE_SHIFT;
+ 	read_lock(&shrinker->lock);
+ 
+ 	if (can_backup)
+@@ -233,7 +240,14 @@ static unsigned long xe_shrinker_scan(struct shrinker *shrink, struct shrink_con
+ 	}
+ 
+ 	sc->nr_scanned = nr_scanned;
+-	if (nr_scanned >= nr_to_scan || !can_backup)
++	/*
++	 * Stop after the purge pass for opportunistic high-order reclaim:
++	 * the subsequent backup/writeback pass works at native page order
++	 * and is unlikely to free a contiguous high-order block, so doing
++	 * it here would just churn working sets for no compaction benefit.
++	 */
++	if (nr_scanned >= nr_to_scan || !can_backup ||
++	    sc->opportunistic_compaction)
+ 		goto out;
+ 
+ 	/* If we didn't wake before, try to do it now if needed. */
+-- 
+2.34.1
+

--- a/pkgbuilds/linux-ptl/PKGBUILD
+++ b/pkgbuilds/linux-ptl/PKGBUILD
@@ -3,9 +3,10 @@
 
 pkgbase=linux-ptl
 pkgver=7.1.8.arch1
-pkgrel=2
-pkgdesc='Linux for Panther Lake with Panel Replay power and OLED VRR fixes'
+pkgrel=3
+pkgdesc='Linux for Panther Lake with Panel Replay power and OLED VRR fixes and Xe opportunistic compaction'
 url='https://github.com/archlinux/linux'
+
 arch=(
   x86_64
 )
@@ -43,6 +44,8 @@ source=(
   0020-drm-i915-alpm-limit-pr-alpm-to-panel-replay.patch
   0028-drm-i915-psr-exit-Panel-Replay-for-ALPM-lag.patch
   0029-drm-edid-populate-monitor-range-from-displayid-adaptive-sync.patch
+  1001-mm-opportunistic-compaction.patch
+  1002-xe-opportunistic-compaction.patch
 )
 source_x86_64=(config.x86_64)
 validpgpkeys=(
@@ -56,7 +59,10 @@ b2sums=('84b59e5572d91f5ea1bb603aa7691851bd9549e1bf18a6bec8e27eb8a6e2de2e33da2ad
         'SKIP'
         'e672cd8d1f48756cf1062f84b83b4f676504cc6b44496511816a670435e00ccc22720fcbc36d013fd9b393389b955de5ec90715429ddbdcea860e1be80ab13fd'
         '82b976261ed6f9c9ab4e30466eb91c74e94d38b489628d2de5b9974a0406a38bdec493112b84ed9f4b917662c871e70b1ea1c626d467eda245eaf7bfd973848b'
-        'ed167ad347e83f072316b0d980ad192d97d0c4a69f6d1841a96089aa17caa0e57cb785214ed9297290f034420b5d0838dc75f84c7e9a9459eb49fd9dc22f3a3e')
+        'ed167ad347e83f072316b0d980ad192d97d0c4a69f6d1841a96089aa17caa0e57cb785214ed9297290f034420b5d0838dc75f84c7e9a9459eb49fd9dc22f3a3e'
+        '21e6ec76cd59a181bcf8a03a0f5034b5a19f13bb289bc82883bce9de33ff197da2f08c88c5f4d1688a0744c1e5b8027065852740c08494e3b1d9b9264c510e9b'
+        '36e319bd83a7209c6f5f4d7fa1334411353450cede62a857782f1155f22677d57c6779666e79f75fb5ae7b9caad4653fa878014de283755d5a068d0e9f1169b9')
+
 b2sums_x86_64=('b10d80423aa3eb65e2046bf5b1998f9a7bdbc97494c6881881f50ffcdb5fe2e242782f59dbb6402cd77ce64b988dbf295fd9fa54f20180c76fbe88b82e1dbc9d')
 
 # https://www.kernel.org/pub/linux/kernel/v7.x/sha256sums.asc
@@ -66,7 +72,9 @@ sha256sums=('ff01dcb449279d5b4cfccdb01fee639cf5ff1803f1749a77844dd33915422c49'
             'SKIP'
             '150f059eaf36580f9ca8eff4f917d8c3ee4eb5493507cbc29ce8e91b3ec56a93'
             '4a1f12817a985361c7497965b7474efb5dd8dcc36d47d04d1bb98fd1941b5901'
-            '1a0bebfba76248bbda67f8812278835de71754412369454ce60f4dde0bd81916')
+            '1a0bebfba76248bbda67f8812278835de71754412369454ce60f4dde0bd81916'
+            '6c92eab359153cc9f8544b52ff484d4da38235c1e60068cb7e6cf4b41ff29cbf'
+            '3d2e2a8e46fa62e49c7a778b6d5d3a5ba14b300d67b7ee32dcc3bcd3b4930744')
 
 export KBUILD_BUILD_HOST=archlinux
 export KBUILD_BUILD_USER=$pkgbase


### PR DESCRIPTION
## Summary

Carry Matthew Brost's v6 `mm, drm/xe: Avoid reclaim/eviction loops under fragmentation` series in `linux-ptl`.

The series prevents fragmentation-driven high-order reclaim from repeatedly evicting and rebuilding active Xe/TTM working sets when reclaim cannot produce the contiguous allocation requested.

## Current base

Rebased onto `omacom-io/omarchy-pkgs:master` at `e4e7b9a` (includes `b53c9cc` XPS 16 Panel Replay workaround). Recipe is current `linux-ptl 7.1.8.arch1` **pkgrel 3**.

The 7.1.8 base already includes:

- Linux 7.1.6 `drm/ttm/pool: back up at native page order`: https://github.com/gregkh/linux/commit/921d6acd57613c0a9585fc7e6283601f4e8c7df5
- Linux 7.1.8 `drm/xe: Set TTM device beneficial_order to 9`: https://github.com/gregkh/linux/commit/3e891bfe08b4c6f420a63a63e6997203c12c9fac

This PR adds only the two opportunistic-compaction patches on top of that master recipe.

## Changes

- `1001-mm-opportunistic-compaction.patch`
  - complete b4-retrieved v6/1 patch: author, subject, Message-Id, sign-off, and commit message preserved
  - adds `shrink_control::opportunistic_compaction`
  - identifies failable, fragmentation-driven high-order reclaim
  - propagates the hint through kswapd and shrinker plumbing
- `1002-xe-opportunistic-compaction.patch`
  - complete b4-retrieved v6/2 patch, including `Reviewed-by: Thomas Hellström`
  - consumes that hint in `drivers/gpu/drm/xe/xe_shrinker.c`
  - skips TTM backup reclaim that destroys active GPU working sets without helping form a contiguous high-order block
- `PKGBUILD` `pkgrel` **2 → 3** so this upgrades shipping `7.1.8.arch1-2`

## Known limits that this revision cannot fix

- v6 is still the latest posted series. Matthew Brost said on 31 Jul that the GFP heuristic misses THP fallback allocations and that a later revision should include deferred-split handling. No v7 is on lore / Patchwork / Linus / mm / drm-xe-next. Inventing that revision here would be worse than carrying v6.
- The MM half is generic plumbing. Existing shrinkers and order-0 reclaim stay unchanged; Xe is the only consumer. That still makes this a core-MM delta on every `linux-ptl` Xe system, which is the architectural risk Dave Chinner is arguing about.

## Scope

- Normal/order-0 and non-opportunistic reclaim retain existing behavior.
- Existing shrinkers retain existing behavior unless they explicitly consume the new hint.
- Xe is the only consumer in this series.
- `linux-ptl` remains an x86_64, explicitly built package with `skip_build: true`.

## Patch provenance

- Cover letter: https://lore.kernel.org/all/20260617032218.1165929-1-matthew.brost@intel.com/
- MM patch: https://lore.kernel.org/all/20260617032218.1165929-2-matthew.brost@intel.com/
- Xe patch: https://lore.kernel.org/all/20260617032218.1165929-3-matthew.brost@intel.com/
- Author note on remaining v6 gaps: https://lore.kernel.org/all/amxTfjc4I16J3q9P@gsse-cloud1.jf.intel.com/

Retrieved with `b4`; Intel DKIM validation passed on the original retrieval. Packaged files now keep the full headers and trailers.

## Verification

- `makepkg --nobuild --cleanbuild` on current master + these patches: hashes, signatures, Arch patch, the three current Panther Lake/Panel Replay patches, and both complete Xe patches all applied. Prepared version string: `7.1.8-arch1-2-ptl-xe` for the side-by-side local package (same sources, `pkgbase=linux-ptl-xe`, `pkgrel=2` so stock `linux-ptl 7.1.8.arch1-2` stays installed).
- Full package build of that side-by-side `linux-ptl-xe` is in progress on the XPS; hashes will be posted when it finishes.
- Recommended A/B remains: stock `7.1.8.arch1-2` (never yet booted on this machine) vs this series, same 30–60 minute 5K workload.