### PR TITLE
Add omarchy-webapp-theme

### DIFF
--- a/pkgbuilds/omarchy-webapp-theme/.omarchy/package.json
+++ b/pkgbuilds/omarchy-webapp-theme/.omarchy/package.json
@@ -1,0 +1,4 @@
+{
+  "source": "aur",
+  "upstream_commit": "3481e3528bf66e279b3e512b39aedbf83b0b7c13"
+}

--- a/pkgbuilds/omarchy-webapp-theme/.omarchy/package.json
+++ b/pkgbuilds/omarchy-webapp-theme/.omarchy/package.json
@@ -1,4 +1,4 @@
 {
   "source": "aur",
-  "upstream_commit": "3481e3528bf66e279b3e512b39aedbf83b0b7c13"
+  "upstream_commit": "b72558712c8a7d938977449abede32c0622caa31"
 }

--- a/pkgbuilds/omarchy-webapp-theme/PKGBUILD
+++ b/pkgbuilds/omarchy-webapp-theme/PKGBUILD
@@ -1,0 +1,73 @@
+# Maintainer: Scott Jones <scottajones@gmail.com>
+
+pkgname=omarchy-webapp-theme
+pkgver=0.3.4
+pkgrel=1
+pkgdesc="Make Slack, Discord, GitHub, Linear, Outlook and WhatsApp follow your Omarchy theme"
+arch=('any')
+url="https://github.com/scottjones/omarchy-webapp-theme"
+license=('MIT')
+# The host is pure bash + coreutils; coreutils is part of base, so bash is the
+# only thing worth declaring. Omarchy 4+ is a hard runtime requirement, but it
+# isn't a pacman package — omarchy-webapp-theme-setup enforces it at runtime.
+depends=('bash')
+optdepends=(
+  'omarchy: Omarchy 4+ required -- provides the theme it reads and the theme-set hook'
+  'chromium: supported browser'
+  'brave-bin: supported browser'
+  'google-chrome: supported browser'
+)
+# This package was omarchy-slack-theme through 0.2.x, before it grew packs for
+# more sites than Slack.
+replaces=('omarchy-slack-theme')
+conflicts=('omarchy-slack-theme')
+provides=('omarchy-slack-theme')
+install="$pkgname.install"
+source=("$pkgname-$pkgver.tar.gz::$url/archive/refs/tags/v$pkgver.tar.gz")
+# Pinned to the published v0.3.4 tag tarball. Regenerate with `updpkgsums` on
+# every version bump — a stale sum fails the build for everyone.
+sha256sums=('e81c511bcf12ce309b0ffe5db07157ee0525dddd1023acd4f68844604861898d')
+
+package() {
+  cd "$srcdir/$pkgname-$pkgver"
+
+  # The native-messaging host, at a stable path the system manifests point to.
+  install -Dm755 native-host/omarchy-webapp-theme-host \
+    "$pkgdir/usr/bin/omarchy-webapp-theme-host"
+
+  # install.sh does double duty: ./install.sh in a checkout, and the per-user
+  # setup command here. It detects which by looking for the repo layout beside
+  # itself, so installed at this path it only does the per-user wiring.
+  install -Dm755 install.sh "$pkgdir/usr/bin/omarchy-webapp-theme-setup"
+
+  # The unpacked extension. Users get it via --load-extension, pointed here by
+  # omarchy-webapp-theme-setup.
+  install -dm755 "$pkgdir/usr/share/$pkgname/extension"
+  install -Dm644 -t "$pkgdir/usr/share/$pkgname/extension" extension/*
+
+  # The omarchy theme-set hook. Can't be installed into ~ from a package, so
+  # omarchy-webapp-theme-setup links it into the user's hooks dir.
+  install -Dm755 hooks/omarchy-webapp-theme \
+    "$pkgdir/usr/share/$pkgname/hooks/omarchy-webapp-theme"
+
+  # System-wide native-messaging manifests, so no per-user registration is
+  # needed. Verified against the shipped binaries' compiled-in search paths:
+  #   /etc/chromium/native-messaging-hosts   -> chromium AND brave
+  #   /etc/opt/chrome/native-messaging-hosts -> google-chrome (brave reads it too)
+  # Edge is best-effort: its path follows the same convention but is untested,
+  # and an unused manifest is inert.
+  local manifest
+  manifest="$(sed 's|__HOST_PATH__|/usr/bin/omarchy-webapp-theme-host|' \
+    native-host/com.omarchy.webapp_theme.json.template)"
+
+  local d
+  for d in /etc/chromium /etc/opt/chrome /etc/opt/edge; do
+    install -dm755 "$pkgdir$d/native-messaging-hosts"
+    printf '%s\n' "$manifest" \
+      >"$pkgdir$d/native-messaging-hosts/com.omarchy.webapp_theme.json"
+    chmod 644 "$pkgdir$d/native-messaging-hosts/com.omarchy.webapp_theme.json"
+  done
+
+  install -Dm644 LICENSE "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+  install -Dm644 README.md "$pkgdir/usr/share/doc/$pkgname/README.md"
+}

--- a/pkgbuilds/omarchy-webapp-theme/PKGBUILD
+++ b/pkgbuilds/omarchy-webapp-theme/PKGBUILD
@@ -1,9 +1,9 @@
 # Maintainer: Scott Jones <scottajones@gmail.com>
 
 pkgname=omarchy-webapp-theme
-pkgver=0.3.4
+pkgver=0.3.5
 pkgrel=1
-pkgdesc="Make Slack, Discord, GitHub, Linear, Outlook and WhatsApp follow your Omarchy theme"
+pkgdesc="Make Slack, Discord, GitHub, Linear, Outlook, WhatsApp, Notion and HEY follow your Omarchy theme"
 arch=('any')
 url="https://github.com/scottjones/omarchy-webapp-theme"
 license=('MIT')
@@ -24,9 +24,9 @@ conflicts=('omarchy-slack-theme')
 provides=('omarchy-slack-theme')
 install="$pkgname.install"
 source=("$pkgname-$pkgver.tar.gz::$url/archive/refs/tags/v$pkgver.tar.gz")
-# Pinned to the published v0.3.4 tag tarball. Regenerate with `updpkgsums` on
+# Pinned to the published v0.3.5 tag tarball. Regenerate with `updpkgsums` on
 # every version bump — a stale sum fails the build for everyone.
-sha256sums=('e81c511bcf12ce309b0ffe5db07157ee0525dddd1023acd4f68844604861898d')
+sha256sums=('d3b90e299926162953d009d53951f80c415a25d30142f36b9393a966c11456b9')
 
 package() {
   cd "$srcdir/$pkgname-$pkgver"

--- a/pkgbuilds/omarchy-webapp-theme/omarchy-webapp-theme.install
+++ b/pkgbuilds/omarchy-webapp-theme/omarchy-webapp-theme.install
@@ -12,8 +12,9 @@ post_install() {
 
       pkill brave    # or chromium / google-chrome-stable
 
-  Open app.slack.com, web.whatsapp.com, github.com, linear.app, discord.com
-  or outlook.office.com and switch omarchy themes; they should follow.
+  Open app.slack.com, web.whatsapp.com, github.com, linear.app, discord.com,
+  outlook.office.com, app.notion.com or app.hey.com and switch omarchy themes;
+  they should follow.
 
 EOF
 }

--- a/pkgbuilds/omarchy-webapp-theme/omarchy-webapp-theme.install
+++ b/pkgbuilds/omarchy-webapp-theme/omarchy-webapp-theme.install
@@ -1,0 +1,49 @@
+post_install() {
+  cat <<'EOF'
+
+  The native-messaging host is registered system-wide, but the per-user bits
+  (the omarchy theme-set hook and the browser --load-extension flag) can't be
+  installed from a package. Finish setup as your normal user:
+
+      omarchy-webapp-theme-setup
+
+  (Upgrading from omarchy-slack-theme? The setup also cleans up that old
+  wiring.) Then fully quit your browser -- closing the window isn't enough:
+
+      pkill brave    # or chromium / google-chrome-stable
+
+  Open app.slack.com, web.whatsapp.com, github.com, linear.app, discord.com
+  or outlook.office.com and switch omarchy themes; they should follow.
+
+EOF
+}
+
+post_upgrade() {
+  cat <<'EOF'
+
+  Re-run 'omarchy-webapp-theme-setup' so the per-user wiring points at the new
+  files, then restart your browser.
+
+  Migrating from a git-checkout install? Retire the clone FIRST, then set up
+  the package -- in that order:
+
+      ./install.sh --uninstall            # in your clone
+      omarchy-webapp-theme-setup
+
+  Both use the same theme-set.d hook name, so doing it the other way round
+  used to leave you with no hook at all -- and with no hook there is no
+  SIGUSR1, which is the only thing that pushes theme changes.
+
+EOF
+}
+
+pre_remove() {
+  cat <<'EOF'
+
+  Removing the package leaves the per-user wiring behind. To clean it up, run
+  this BEFORE the package disappears:
+
+      omarchy-webapp-theme-setup --uninstall
+
+EOF
+}


### PR DESCRIPTION
## Summary

Add `omarchy-webapp-theme` 0.3.7 as an opt-in package for making Slack, Discord, GitHub, Linear, Outlook, WhatsApp, Notion and HEY follow the active Omarchy theme. It packages the Chromium extension, Bash native-messaging host, theme hook, and per-user setup command. The current release includes Brave Origin setup support.

The package is `arch=any` and uses the default edge release policy. Omarchy owns the recipe and tracks the project's `v{pkgver}` Git tags directly, downloading and hashing the tagged source archive when a newer version appears. This covers versions that have tags without GitHub Release entries. The metadata preserves the original AUR import provenance.

System files and native-messaging manifests are package-owned. Users opt in with `omarchy-webapp-theme-setup`, which checks for Omarchy 4+ and configures their hook and browser flags. Site-specific theme overrides may need maintenance when the web applications change.

## Validation

- Built `omarchy-webapp-theme-0.3.7-1-any.pkg.tar.zst` through upstream's native aarch64 builder; source checksum verification passed.
- Verified the built package's version, all 20 extension files against the release archive, manifest-referenced assets, extension ID/native-host registration, executable permissions, and MIT license. Packaged JavaScript and shell syntax checks passed.
- Installed the artifact in a disposable, network-disabled ARM container. As an unprivileged user with a temporary home and mock Brave Origin command, verified setup preserves existing flags, repeated setup is idempotent, and removal restores prior flags while retaining package-owned system manifests.
- Exercised the packaged native host and verified a correctly framed JSON message containing the test theme's colors.
- Verified the live tag provider discovers 0.3.7 and its correct checksum from a 0.3.5 fixture; an up-to-date recipe reports no update.
- Passed all seven commands from the repository's self-tests CI job locally.

Live browser rendering and per-site behavior were not retested during this packaging refresh.
