### PR TITLE
Add MacBook12 CS4208 DKMS package

### DIFF
--- a/pkgbuilds/macbook12-audio-driver-dkms/.omarchy/package.json
+++ b/pkgbuilds/macbook12-audio-driver-dkms/.omarchy/package.json
@@ -1,0 +1,3 @@
+{
+  "source": "local"
+}

--- a/pkgbuilds/macbook12-audio-driver-dkms/PKGBUILD
+++ b/pkgbuilds/macbook12-audio-driver-dkms/PKGBUILD
@@ -1,0 +1,32 @@
+_pkgbase=macbook12-audio-driver
+pkgname=${_pkgbase}-dkms
+pkgver=0.1
+pkgrel=1
+pkgdesc="CS4208 audio driver for the 12-inch MacBook (DKMS)"
+arch=('x86_64')
+url="https://github.com/leifliddy/macbook12-audio-driver"
+license=('GPL-2.0-or-later')
+depends=('curl' 'dkms' 'linux-headers')
+makedepends=('git')
+conflicts=('snd-hda-macbookpro-dkms-git')
+options=('!debug' '!strip')
+_commit=04500a120ea685694b651c1b1d46fafcae8cff46
+source=("${_pkgbase}::git+${url}.git#commit=${_commit}"
+        'dkms.conf'
+        'prepare.cirrus.driver.sh')
+sha256sums=('SKIP'
+            '248f564d6f4e9cab636b833fd9a90d9159fa852da1b4e319085f4d9a53aa4268'
+            'a6aa408a3b25a85fa24953996201d911d3f94f582e95511806de984eca7b1bb1')
+
+package() {
+  local target="$pkgdir/usr/src/${_pkgbase}-${pkgver}"
+
+  install -dm755 "$target"
+  install -m644 \
+    "$srcdir/$_pkgbase/Makefile_cirrus" \
+    "$srcdir/$_pkgbase/Makefile_cs420x" \
+    "$target"
+  install -m644 "$srcdir/dkms.conf" "$target"
+  install -m755 "$srcdir/prepare.cirrus.driver.sh" "$target"
+  cp -r "$srcdir/$_pkgbase/patch_cirrus" "$target"
+}

--- a/pkgbuilds/macbook12-audio-driver-dkms/dkms.conf
+++ b/pkgbuilds/macbook12-audio-driver-dkms/dkms.conf
@@ -1,0 +1,22 @@
+PACKAGE_NAME="macbook12-audio-driver"
+PACKAGE_VERSION="0.1"
+
+kernel_release="${kernelver:-$(uname -r)}"
+kernel_version="${kernel_release%%-*}"
+major_version="${kernel_version%%.*}"
+version_tail="${kernel_version#*.}"
+minor_version="${version_tail%%.*}"
+
+PRE_BUILD="./prepare.cirrus.driver.sh $kernelver"
+MAKE[0]="make"
+
+if (( major_version > 6 || (major_version == 6 && minor_version >= 17) )); then
+  BUILT_MODULE_NAME[0]="snd-hda-codec-cs420x"
+  BUILT_MODULE_LOCATION[0]="build/hda/codecs/cirrus"
+else
+  BUILT_MODULE_NAME[0]="snd-hda-codec-cirrus"
+  BUILT_MODULE_LOCATION[0]="build/hda"
+fi
+
+DEST_MODULE_LOCATION[0]="/kernel/extra"
+AUTOINSTALL="yes"

--- a/pkgbuilds/macbook12-audio-driver-dkms/prepare.cirrus.driver.sh
+++ b/pkgbuilds/macbook12-audio-driver-dkms/prepare.cirrus.driver.sh
@@ -1,0 +1,157 @@
+#!/bin/bash
+
+set -euo pipefail
+
+kernel_release="${1:-$(uname -r)}"
+kernel_version="${kernel_release%%-*}"
+kernel_version="${kernel_version%%_*}"
+
+if [[ ! $kernel_version =~ ^[0-9]+\.[0-9]+(\.[0-9]+)?([.-]rc[0-9]+)?$ ]]; then
+  echo "Unsupported kernel release: $kernel_release" >&2
+  exit 2
+fi
+
+major_version="${kernel_version%%.*}"
+version_tail="${kernel_version#*.}"
+minor_version="${version_tail%%.*}"
+kernel_short_version="$major_version.$minor_version"
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+cd "$script_dir"
+
+build_dir="$script_dir/build"
+patch_dir="$script_dir/patch_cirrus"
+hda_dir="$build_dir/hda"
+base_url="https://cdn.kernel.org/pub/linux/kernel/v${major_version}.x"
+
+if [[ -n ${MACBOOK12_AUDIO_KERNEL_CACHE:-} ]]; then
+  cache_dir="$MACBOOK12_AUDIO_KERNEL_CACHE"
+elif (( EUID == 0 )); then
+  cache_dir="/var/cache/macbook12-audio-driver"
+else
+  cache_dir="$build_dir"
+fi
+
+download() {
+  local url="$1"
+  local destination="$2"
+
+  if command -v curl >/dev/null; then
+    curl --fail --location --retry 3 --silent --show-error \
+      --output "$destination" "$url"
+  elif command -v wget >/dev/null; then
+    wget --quiet --tries=3 --output-document="$destination" "$url"
+  else
+    echo "Install curl or wget to download the matching kernel source." >&2
+    return 127
+  fi
+}
+
+refresh_checksums() {
+  local partial="$checksums.part"
+  rm -f "$partial"
+  download "$base_url/sha256sums.asc" "$partial"
+  mv "$partial" "$checksums"
+}
+
+checksum_for() {
+  local archive_name="$1"
+  awk -v filename="$archive_name" '$2 == filename { print $1; exit }' "$checksums"
+}
+
+mkdir -p "$build_dir" "$cache_dir"
+rm -rf "$hda_dir"
+
+checksums="$cache_dir/sha256sums-v${major_version}.asc"
+[[ -f $checksums ]] || refresh_checksums
+
+archive=""
+for candidate_version in "$kernel_version" "$kernel_short_version"; do
+  archive_name="linux-${candidate_version}.tar.xz"
+  expected_sha256="$(checksum_for "$archive_name")"
+
+  if [[ -z $expected_sha256 ]]; then
+    refresh_checksums
+    expected_sha256="$(checksum_for "$archive_name")"
+  fi
+  [[ -n $expected_sha256 ]] || continue
+
+  candidate_archive="$cache_dir/$archive_name"
+  if [[ -f $candidate_archive ]]; then
+    actual_sha256="$(sha256sum "$candidate_archive" | awk '{ print $1 }')"
+  else
+    actual_sha256=""
+  fi
+
+  if [[ $actual_sha256 != "$expected_sha256" ]]; then
+    partial_archive="$candidate_archive.part"
+    rm -f "$partial_archive"
+    echo "Downloading $archive_name"
+    if ! download "$base_url/$archive_name" "$partial_archive"; then
+      rm -f "$partial_archive"
+      continue
+    fi
+
+    actual_sha256="$(sha256sum "$partial_archive" | awk '{ print $1 }')"
+    if [[ $actual_sha256 != "$expected_sha256" ]]; then
+      rm -f "$partial_archive"
+      echo "SHA-256 verification failed for $archive_name" >&2
+      exit 3
+    fi
+    mv "$partial_archive" "$candidate_archive"
+  fi
+
+  archive="$candidate_archive"
+  kernel_version="$candidate_version"
+  break
+done
+
+if [[ -z $archive ]]; then
+  echo "No verified kernel.org source archive found for $kernel_release" >&2
+  exit 4
+fi
+
+if (( major_version > 6 || (major_version == 6 && minor_version >= 17) )); then
+  makefile_name="Makefile_cs420x"
+  tar --strip-components=2 -xf "$archive" --directory="$build_dir" \
+    "linux-${kernel_version}/sound/hda"
+  mv "$hda_dir/codecs/cirrus/Makefile" "$hda_dir/codecs/cirrus/Makefile.orig"
+  mv "$hda_dir/codecs/cirrus/cs420x.c" "$hda_dir/codecs/cirrus/cs420x.c.orig"
+  cp "$patch_dir/cs420x.c" \
+    "$patch_dir/patch_cirrus_a1534_setup.h" \
+    "$patch_dir/patch_cirrus_a1534_pcm.h" \
+    "$hda_dir/codecs/cirrus"
+  cp "$patch_dir/$makefile_name" "$hda_dir/codecs/cirrus/Makefile"
+else
+  makefile_name="Makefile_cirrus"
+  tar --strip-components=3 -xf "$archive" --directory="$build_dir" \
+    "linux-${kernel_version}/sound/pci/hda"
+  mv "$hda_dir/Makefile" "$hda_dir/Makefile.orig"
+  mv "$hda_dir/patch_cirrus.c" "$hda_dir/patch_cirrus.c.orig"
+  cp "$patch_dir/patch_cirrus.c" \
+    "$patch_dir/patch_cirrus_a1534_setup.h" \
+    "$patch_dir/patch_cirrus_a1534_pcm.h" \
+    "$hda_dir"
+  cp "$patch_dir/$makefile_name" "$hda_dir/Makefile"
+fi
+
+if (( major_version > 6 || (major_version == 6 && minor_version >= 17) )); then
+  sed -i 's/\.free/.remove/' "$hda_dir/codecs/cirrus/patch_cirrus_a1534_pcm.h"
+fi
+
+if (( major_version == 6 && minor_version >= 12 && minor_version < 17 )); then
+  sed -i 's/snd_pci_quirk/hda_quirk/' "$hda_dir/patch_cirrus.c"
+  sed -i 's/SND_PCI_QUIRK\b/HDA_CODEC_QUIRK/' "$hda_dir/patch_cirrus.c"
+fi
+
+if (( major_version == 6 && minor_version <= 11 )); then
+  sed -i 's/hda_quirk/snd_pci_quirk/' "$hda_dir/patch_cirrus.c"
+fi
+
+if (( major_version < 5 || (major_version == 5 && minor_version < 6) )); then
+  sed -i 's/timespec64/timespec/' "$hda_dir/patch_cirrus.c"
+  sed -i 's/timespec64/timespec/' "$hda_dir/patch_cirrus_a1534_pcm.h"
+  sed -i 's/ktime_get_real_ts64/getnstimeofday/' "$hda_dir/patch_cirrus_a1534_pcm.h"
+fi
+
+cp "$script_dir/$makefile_name" "$script_dir/Makefile"


### PR DESCRIPTION
## Summary

- add `macbook12-audio-driver-dkms`, the package expected by basecamp/omarchy#6921
- pin the known-good upstream driver revision and verify every source checksum
- package the DKMS source under `/usr/src/macbook12-audio-driver-0.1`
- declare the required DKMS/kernel-header dependencies and the conflicting legacy CS4208 package

The two small local lifecycle overrides match [upstream driver PR #60](https://github.com/leifliddy/macbook12-audio-driver/pull/60) and can be dropped once that change is released.

## Validation

- `makepkg --verifysource`
- clean `makepkg` build
- inspected package metadata and installed file layout
- extracted the package into an isolated root and completed `dkms add`, `dkms build`, and `dkms install` for `7.1.8-arch1-3`
- confirmed the installed module path, CS4208 alias, module name, and vermagic
- `bin/repo build --dry-run --package macbook12-audio-driver-dkms`

Hardware validation was performed on a MacBook10,1 running Omarchy; its internal speakers work with the expected stereo profile.
