### PR TITLE
Add snd-hda-macbookpro-dkms for 2016-2017 MacBook speakers

### DIFF
--- a/pkgbuilds/snd-hda-macbookpro-dkms/.omarchy/package.json
+++ b/pkgbuilds/snd-hda-macbookpro-dkms/.omarchy/package.json
@@ -1,0 +1,3 @@
+{
+  "source": "local"
+}

--- a/pkgbuilds/snd-hda-macbookpro-dkms/PKGBUILD
+++ b/pkgbuilds/snd-hda-macbookpro-dkms/PKGBUILD
@@ -1,0 +1,38 @@
+# Maintainer: Omarchy <https://omarchy.org>
+# Upstream: https://github.com/davidjo/snd_hda_macbookpro
+#
+# The AUR package (snd-hda-macbookpro-dkms-git) copies only a subset of
+# the tree and does not depend on wget, which PRE_BUILD needs to fetch
+# matching kernel sources. This package installs the whole driver and
+# pins the commit verified on MacBookPro14,3 / linux 7.1.8.
+
+_pkgbase=snd-hda-macbookpro
+pkgname=${_pkgbase}-dkms
+pkgver=0.1
+pkgrel=1
+pkgdesc="DKMS driver for Cirrus CS8409 HDA on 2016–2017 MacBook Pros"
+arch=('x86_64')
+url="https://github.com/davidjo/snd_hda_macbookpro"
+license=('GPL-2.0-only')
+depends=('dkms' 'wget' 'patch')
+makedepends=('git')
+optdepends=('linux-headers: build against the Arch kernel')
+provides=('snd-hda-macbookpro-dkms-git')
+conflicts=('snd-hda-macbookpro-dkms-git')
+# 6c324f6: dkms.conf for current kernels; 6.17+ install path.
+_commit=6c324f6c9262faa853fdd74d798c5686937a9d0f
+source=("git+https://github.com/davidjo/snd_hda_macbookpro.git#commit=${_commit}")
+sha256sums=('SKIP')
+
+package() {
+    local dest="${pkgdir}/usr/src/${_pkgbase}-${pkgver}"
+
+    install -dm755 "$dest"
+    cp -a snd_hda_macbookpro/. "$dest/"
+    rm -rf "$dest/.git" "$dest/build"
+
+    # PRE_BUILD runs install.cirrus.driver.sh; the AUR package left these 0644.
+    chmod 755 "$dest"/install.cirrus.driver.sh \
+              "$dest"/install.cirrus.driver.pre617.sh \
+              "$dest"/dkms.sh
+}

--- a/pkgbuilds/snd-hda-macbookpro-dkms/PKGBUILD
+++ b/pkgbuilds/snd-hda-macbookpro-dkms/PKGBUILD
@@ -7,9 +7,14 @@
 # pins the commit verified on MacBookPro14,3 / linux 7.1.8.
 
 _pkgbase=snd-hda-macbookpro
+# Must match PACKAGE_NAME in upstream dkms.conf. The AUR dest uses hyphens
+# (snd-hda-macbookpro-0.1); Arch's alpm hook then runs
+# `dkms install snd-hda-macbookpro/0.1`, which exits 7 because PACKAGE_NAME
+# is snd_hda_macbookpro. omarchy-pkg-add relies on that hook.
+_srcname=snd_hda_macbookpro
 pkgname=${_pkgbase}-dkms
 pkgver=0.1
-pkgrel=1
+pkgrel=2
 pkgdesc="DKMS driver for Cirrus CS8409 HDA on 2016–2017 MacBook Pros"
 arch=('x86_64')
 url="https://github.com/davidjo/snd_hda_macbookpro"
@@ -25,7 +30,7 @@ source=("git+https://github.com/davidjo/snd_hda_macbookpro.git#commit=${_commit}
 sha256sums=('SKIP')
 
 package() {
-    local dest="${pkgdir}/usr/src/${_pkgbase}-${pkgver}"
+    local dest="${pkgdir}/usr/src/${_srcname}-${pkgver}"
 
     install -dm755 "$dest"
     cp -a snd_hda_macbookpro/. "$dest/"


### PR DESCRIPTION
Pairs with https://github.com/basecamp/omarchy/pull/7140. That PR detects CS8409 MacBook Pros and installs this package.

In-tree `snd_hda_codec_cs8409` enumerates the CS8409 but never programs the MAX98706 / SSM3515 / TAS5764L speaker amps, so those machines show an unmuted Analog Stereo sink and play nothing. [davidjo/snd_hda_macbookpro](https://github.com/davidjo/snd_hda_macbookpro) is the Apple path.

The AUR package (`snd-hda-macbookpro-dkms-git`) copies only a subset of the tree and does not depend on `wget`, which `PRE_BUILD` needs to fetch matching kernel sources. This package:

- pins commit `6c324f6` (verified on MacBookPro14,3 / linux 7.1.8)
- installs the full tree with executable install scripts
- depends on `dkms`, `wget`, and `patch`

`source: local` so an AUR sync does not replace it.

Verified on this machine: after DKMS install + reboot, `srcversion` is the patched module, dmesg takes the APPLE path, and speakers play.