### PR TITLE
Fix SoundWire audio on ASUS ExpertBook B9406

### DIFF
--- a/pkgbuilds/linux-ptl/0030-soundwire-ignore-ghost-rt722-on-asus-b9406.patch
+++ b/pkgbuilds/linux-ptl/0030-soundwire-ignore-ghost-rt722-on-asus-b9406.patch
@@ -1,0 +1,52 @@
+From: argrig666 <66850845+argrig666@users.noreply.github.com>
+Subject: [PATCH] soundwire: ignore ghost rt722 on ASUS ExpertBook B9406CAA
+
+The ASUS ExpertBook B9406CAA firmware advertises a phantom Realtek
+rt722 on SoundWire link 3 alongside the real CS42L43 codec. Linux 7.1's
+function-topology builder creates the same SDW3-Playback-SimpleJack link
+for both devices, then fails the sof_sdw probe with -EEXIST. No ALSA card
+is registered as a result.
+
+Remap the phantom rt722 address to zero so the SoundWire core ignores it.
+The CS42L43 and both CS35L56 amplifiers then enumerate normally.
+
+Tested on an ASUS ExpertBook B9406CAA with PCI subsystem 1043:15e4.
+
+---
+ drivers/soundwire/dmi-quirks.c | 21 +++++++++++++++++++++
+ 1 file changed, 21 insertions(+)
+
+diff --git a/drivers/soundwire/dmi-quirks.c b/drivers/soundwire/dmi-quirks.c
+--- a/drivers/soundwire/dmi-quirks.c
++++ b/drivers/soundwire/dmi-quirks.c
+@@ -90,7 +90,28 @@ static const struct adr_remap intel_rooks_county[] = {
+ 	{}
+ };
+ 
++/*
++ * The ASUS ExpertBook B9406CAA firmware advertises a phantom RT722 on
++ * SoundWire link 3 next to the real CS42L43 codec. Mapping the ghost address
++ * to zero makes the SoundWire core ignore it and prevents the duplicate
++ * SimpleJack link from being added to the function topology.
++ */
++static const struct adr_remap asus_b9406caa[] = {
++	{
++		0x000330025d072201ull,
++		0,
++	},
++	{}
++};
++
+ static const struct dmi_system_id adr_remap_quirk_table[] = {
++	{
++		.matches = {
++			DMI_MATCH(DMI_SYS_VENDOR, "ASUS"),
++			DMI_MATCH(DMI_BOARD_NAME, "B9406CAA"),
++		},
++		.driver_data = (void *)asus_b9406caa,
++	},
+ 	/* TGL devices */
+ 	{
+ 		.matches = {
+-- 
+2.51.0

--- a/pkgbuilds/linux-ptl/PKGBUILD
+++ b/pkgbuilds/linux-ptl/PKGBUILD
@@ -3,7 +3,7 @@
 
 pkgbase=linux-ptl
 pkgver=7.1.8.arch1
-pkgrel=2
+pkgrel=3
 pkgdesc='Linux for Panther Lake with Panel Replay power and OLED VRR fixes'
 url='https://github.com/archlinux/linux'
 arch=(
@@ -43,6 +43,7 @@ source=(
   0020-drm-i915-alpm-limit-pr-alpm-to-panel-replay.patch
   0028-drm-i915-psr-exit-Panel-Replay-for-ALPM-lag.patch
   0029-drm-edid-populate-monitor-range-from-displayid-adaptive-sync.patch
+  0030-soundwire-ignore-ghost-rt722-on-asus-b9406.patch
 )
 source_x86_64=(config.x86_64)
 validpgpkeys=(
@@ -56,7 +57,8 @@ b2sums=('84b59e5572d91f5ea1bb603aa7691851bd9549e1bf18a6bec8e27eb8a6e2de2e33da2ad
         'SKIP'
         'e672cd8d1f48756cf1062f84b83b4f676504cc6b44496511816a670435e00ccc22720fcbc36d013fd9b393389b955de5ec90715429ddbdcea860e1be80ab13fd'
         '82b976261ed6f9c9ab4e30466eb91c74e94d38b489628d2de5b9974a0406a38bdec493112b84ed9f4b917662c871e70b1ea1c626d467eda245eaf7bfd973848b'
-        'ed167ad347e83f072316b0d980ad192d97d0c4a69f6d1841a96089aa17caa0e57cb785214ed9297290f034420b5d0838dc75f84c7e9a9459eb49fd9dc22f3a3e')
+        'ed167ad347e83f072316b0d980ad192d97d0c4a69f6d1841a96089aa17caa0e57cb785214ed9297290f034420b5d0838dc75f84c7e9a9459eb49fd9dc22f3a3e'
+        '5d1ef0e7b6a44c163a2460e1bf4915913f6376d21ba27007fda9da212b31a98581ee2e37a48dab37e6c9dc121b48b0c7ca0a1bc0daf1240aa81d680ec14a37f1')
 b2sums_x86_64=('b10d80423aa3eb65e2046bf5b1998f9a7bdbc97494c6881881f50ffcdb5fe2e242782f59dbb6402cd77ce64b988dbf295fd9fa54f20180c76fbe88b82e1dbc9d')
 
 # https://www.kernel.org/pub/linux/kernel/v7.x/sha256sums.asc
@@ -66,7 +68,8 @@ sha256sums=('ff01dcb449279d5b4cfccdb01fee639cf5ff1803f1749a77844dd33915422c49'
             'SKIP'
             '150f059eaf36580f9ca8eff4f917d8c3ee4eb5493507cbc29ce8e91b3ec56a93'
             '4a1f12817a985361c7497965b7474efb5dd8dcc36d47d04d1bb98fd1941b5901'
-            '1a0bebfba76248bbda67f8812278835de71754412369454ce60f4dde0bd81916')
+            '1a0bebfba76248bbda67f8812278835de71754412369454ce60f4dde0bd81916'
+            'f068b73de2c3cc5881fe0d14d7286de8fb23abeb818be31e9d6c292cea9bd932')
 
 export KBUILD_BUILD_HOST=archlinux
 export KBUILD_BUILD_USER=$pkgbase


### PR DESCRIPTION
## What

Add a hardware-scoped `linux-ptl` patch for the ASUS ExpertBook B9406CAA and bump the package release.

The laptop firmware advertises an unattached RT722 at SoundWire address `0x000330025d072201` beside the real CS42L43. Linux 7.1's function-topology builder creates two `SDW3-Playback-SimpleJack` links, hits `-EEXIST`, and aborts `sof_sdw` registration, leaving no ALSA card.

The patch remaps only that phantom address to zero for ASUS board name `B9406CAA`, so SoundWire ignores it and the real CS42L43 plus both CS35L56 amplifiers enumerate normally.

## Live hardware validation

Tested on ASUS ExpertBook B9406CAA, PCI audio subsystem `1043:15e4`, kernel `7.1.8-arch1-3`:

- Before the quirk: duplicate `SDW3-Playback-SimpleJack`, `sof_sdw` probe failed with `-12`, no ALSA card.
- With the equivalent DKMS quirk: `sof-soundwire` registers, both CS35L56 DSPs load OEM firmware and calibration, and PipeWire exposes the HiFi Speaker sink.
- The current Arch `alsa-ucm-conf 1.2.16.1` and `linux-firmware-cirrus` already contain the needed UCM and firmware, so no userspace files are bundled here.

## Validation

- `makepkg --nobuild --nodeps --skippgpcheck` completes and applies all four kernel patches.
- SHA-256 and BLAKE2 checksums pass through `makepkg --verifysource`.
- `drivers/soundwire`, including `dmi-quirks.o` and `soundwire-intel.ko`, compiles and links against the prepared package source.
- `bin/omarchy-pkgs self-test` passes.

A coordinated `basecamp/omarchy` PR will select this kernel only on the already-supported PTL XPS models and the B9406.
