### PR TITLE
Package yt-dlp ahead of Arch's extra

### DIFF
--- a/pkgbuilds/yt-dlp/.omarchy/package.json
+++ b/pkgbuilds/yt-dlp/.omarchy/package.json
@@ -1,0 +1,4 @@
+{
+  "source": "local",
+  "release_ring": "fast"
+}

--- a/pkgbuilds/yt-dlp/.omarchy/upstream.sh
+++ b/pkgbuilds/yt-dlp/.omarchy/upstream.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# yt-dlp ships a signed SHA2-256SUMS beside every release, so an update costs two
+# small requests instead of a 5.7 MB download. The version comes from the
+# /releases/latest redirect rather than the API, which is rate limited per IP and
+# would fail the sync on a busy build host.
+set -euo pipefail
+
+REPO_URL="https://github.com/yt-dlp/yt-dlp"
+TARBALL="yt-dlp.tar.gz"
+
+# The redirect target ends in /releases/tag/<version>; anything else means GitHub
+# answered with something other than a release and the version cannot be trusted.
+location=$(curl -fsS -o /dev/null -w '%{url_effective}' -L "$REPO_URL/releases/latest")
+pkgver="${location##*/releases/tag/}"
+
+if [[ "$pkgver" == "$location" || -z "$pkgver" ]]; then
+  echo "Could not read a release tag from $location" >&2
+  exit 1
+fi
+
+sha256=$(curl -fsSL "$REPO_URL/releases/download/$pkgver/SHA2-256SUMS" |
+  awk -v file="$TARBALL" '$2 == file { print $1; exit }')
+
+if [[ -z "$sha256" ]]; then
+  echo "Release $pkgver publishes no checksum for $TARBALL" >&2
+  exit 1
+fi
+
+jq -n --arg pkgver "$pkgver" --arg sha256 "$sha256" \
+  '{pkgver: $pkgver, sha256sums: {any: [$sha256]}}'

--- a/pkgbuilds/yt-dlp/PKGBUILD
+++ b/pkgbuilds/yt-dlp/PKGBUILD
@@ -1,0 +1,51 @@
+# Maintainer: Antonio Rojas <arojas@archlinux.org>
+# Contributor: Stefan Tatschner <stefan@rumpelsepp.org>
+# Contributor: katt <magunasu.b97@gmail.com>
+
+pkgname=yt-dlp
+pkgver=2026.08.19
+pkgrel=1
+pkgdesc='A youtube-dl fork with additional features and fixes'
+arch=(any)
+url='https://github.com/yt-dlp/yt-dlp'
+license=(Unlicense)
+depends=(python
+         python-certifi
+         python-requests
+         python-urllib3
+         yt-dlp-ejs)
+makedepends=(python-build
+             python-hatchling
+             python-installer)
+checkdepends=(python-pytest)
+optdepends=('ffmpeg: for video post-processing'
+            'rtmpdump: for rtmp streams support'
+            'atomicparsley: for embedding thumbnails into m4a files'
+            'aria2: for using aria2 as external downloader'
+            'python-curl_cffi: support for impersonating browser requests'
+            'python-mutagen: for embedding thumbnail in certain formats'
+            'python-pycryptodome: for decrypting AES-128 HLS streams and various other data'
+            'python-pycryptodomex: for decrypting AES-128 HLS streams and various other data'
+            'python-websockets: for downloading over websocket'
+            'python-brotli: brotli content encoding support'
+            'python-brotlicffi: brotli content encoding support'
+            'python-xattr: for writing xattr metadata'
+            'python-pyxattr: for writing xattr metadata (alternative option)'
+            'python-secretstorage: For -cookies-from-browser to access the GNOME keyring while decrypting cookies of Chromium-based browsers')
+source=($pkgname-$pkgver.tar.gz::https://github.com/yt-dlp/yt-dlp/releases/download/$pkgver/yt-dlp.tar.gz)
+sha256sums=('072aad4f2a7604e92155f61a275a4752dc64046c8f6d90df3710525d94cd37c1')
+
+build() {
+  cd $pkgname
+  python -m build --wheel --no-isolation
+}
+
+check() {
+  cd $pkgname
+  pytest -v -m "not download"
+}
+
+package() {
+  cd $pkgname
+  python -m installer --destdir="$pkgdir" dist/*.whl
+}


### PR DESCRIPTION
yt-dlp breaks the moment a site changes its player, and upstream ships a fix within days. Arch's `extra` is on **2026.07.04** as of this PR while upstream is on **2026.08.19** — six weeks of extractor fixes that Omarchy users do not have.

The PKGBUILD is Arch's, with only `pkgver` and `sha256sums` changed. Keeping it a two-line delta means it stays cheap to diff against theirs, and cheap to drop entirely if Arch ever keeps pace. Upstream still pins `yt-dlp-ejs==0.8.0`, so `depends` needed no change.

`.omarchy/upstream.sh` keeps it current without anyone watching:

- the version comes from the `/releases/latest` redirect rather than the GitHub API, which is rate limited per IP and would fail the sync on a busy build host
- the checksum is read out of the `SHA2-256SUMS` that yt-dlp signs and publishes beside every release, so an update is two small requests instead of a 5.7 MB download

It builds in the **fast ring** deliberately. A package that shadows `extra` has to reach stable on its own; waiting for a promote would leave stable users on an older yt-dlp than `extra` would have handed them.

One thing to know before merging: this only becomes reachable once `[omarchy]` is ordered above `[extra]`. pacman stops at the first repository carrying a name and never compares versions across the rest, so under today's ordering this package is built and published but never installed. The ordering change is a separate PR against `omarchy`, and it should not land before the deadweight cleanup in #177.