### PR TITLE
Add MacBookPro13,1 camera and audio packages

### DIFF
--- a/pkgbuilds/facetimehd-dkms/.nvchecker.toml
+++ b/pkgbuilds/facetimehd-dkms/.nvchecker.toml
@@ -1,0 +1,3 @@
+[facetimehd-dkms]
+source = "git"
+git = "https://github.com/patjak/facetimehd.git"

--- a/pkgbuilds/facetimehd-dkms/.omarchy/package.json
+++ b/pkgbuilds/facetimehd-dkms/.omarchy/package.json
@@ -1,0 +1,4 @@
+{
+  "source": "aur",
+  "upstream_commit": "e1da85aded92a98f3739265c6157fa92fd674ce4"
+}

--- a/pkgbuilds/facetimehd-dkms/.omarchy/patches/0001-pin-release-archive.patch
+++ b/pkgbuilds/facetimehd-dkms/.omarchy/patches/0001-pin-release-archive.patch
@@ -1,0 +1,22 @@
+diff --git a/PKGBUILD b/PKGBUILD
+index d560ca4..f149827 100644
+--- a/PKGBUILD
++++ b/PKGBUILD
+@@ -13,14 +13,13 @@ license=('GPL-2.0-only')
+ arch=('any')
+ 
+-makedepends=('git')
+ optdepends=('facetimehd-data: Sensor calibration data')
+ 
+ provides=('bcwc-pcie' 'bcwc-pcie-dkms')
+ conflicts=('bcwc-pcie' 'bcwc-pcie-dkms')
+ 
+-_pkgsrc="$_pkgname"
+-source=("$_pkgsrc"::"git+https://github.com/patjak/facetimehd.git#tag=$pkgver")
+-sha256sums=('e25dbbf89f2145c8a61ee53a594271ef5bb3a6b8b006e70c637996240fffc219')
++_pkgsrc="facetimehd-$pkgver"
++source=("$_pkgsrc.tar.gz::https://github.com/patjak/facetimehd/archive/refs/tags/$pkgver.tar.gz")
++sha256sums=('3bf7cdfa62c57258a1f6188caf10e767d9315574deefaf246d4725a17547191a')
+ 
+ prepare() {
+   # deprecated

--- a/pkgbuilds/facetimehd-dkms/.omarchy/patches/0002-expose-build-dependencies.patch
+++ b/pkgbuilds/facetimehd-dkms/.omarchy/patches/0002-expose-build-dependencies.patch
@@ -1,0 +1,27 @@
+diff --git a/PKGBUILD b/PKGBUILD
+index f149827..1ca9c20 100644
+--- a/PKGBUILD
++++ b/PKGBUILD
+@@ -13,6 +13,10 @@
+ license=('GPL-2.0-only')
+ arch=('any')
+ 
++depends=(
++  'facetimehd-firmware'
++  'dkms'
++)
+ optdepends=('facetimehd-data: Sensor calibration data')
+ 
+ provides=('bcwc-pcie' 'bcwc-pcie-dkms')
+@@ -28,11 +32,6 @@
+ }
+ 
+ package() {
+-  depends=(
+-    'facetimehd-firmware'
+-    'dkms'
+-  )
+-
+   cd "$_pkgsrc"
+   for FILE in dkms.conf Makefile *.[ch]; do
+     install -Dm644 "$FILE" "$pkgdir/usr/src/facetimehd-$pkgver/$FILE"

--- a/pkgbuilds/facetimehd-dkms/.omarchy/patches/0003-verify-module-after-kernel-transactions.patch
+++ b/pkgbuilds/facetimehd-dkms/.omarchy/patches/0003-verify-module-after-kernel-transactions.patch
@@ -1,0 +1,118 @@
+diff --git a/PKGBUILD b/PKGBUILD
+index 1ca9c20..eb54f36 100644
+--- a/PKGBUILD
++++ b/PKGBUILD
+@@ -23,8 +23,16 @@ provides=('bcwc-pcie' 'bcwc-pcie-dkms')
+ conflicts=('bcwc-pcie' 'bcwc-pcie-dkms')
+ 
+ _pkgsrc="facetimehd-$pkgver"
+-source=("$_pkgsrc.tar.gz::https://github.com/patjak/facetimehd/archive/refs/tags/$pkgver.tar.gz")
+-sha256sums=('3bf7cdfa62c57258a1f6188caf10e767d9315574deefaf246d4725a17547191a')
++source=(
++  "$_pkgsrc.tar.gz::https://github.com/patjak/facetimehd/archive/refs/tags/$pkgver.tar.gz"
++  'verify-kernel-modules'
++  '75-facetimehd-verify.hook'
++)
++sha256sums=(
++  '3bf7cdfa62c57258a1f6188caf10e767d9315574deefaf246d4725a17547191a'
++  '072a14aea0ccf57346a82cd380db268186970853877a3add8538fe7ab8faff1b'
++  'ed9e3154fe7381086f4f5b6e8469b22aa94603161ff48215b335a84eb07f2d2f'
++)
+ 
+ prepare() {
+   # deprecated
+@@ -36,4 +44,8 @@ package() {
+   for FILE in dkms.conf Makefile *.[ch]; do
+     install -Dm644 "$FILE" "$pkgdir/usr/src/facetimehd-$pkgver/$FILE"
+   done
++  install -Dm755 "$srcdir/verify-kernel-modules" \
++    "$pkgdir/usr/lib/omarchy/verify-facetimehd"
++  install -Dm644 "$srcdir/75-facetimehd-verify.hook" \
++    "$pkgdir/usr/share/libalpm/hooks/75-facetimehd-verify.hook"
+ }
+diff --git a/75-facetimehd-verify.hook b/75-facetimehd-verify.hook
+new file mode 100644
+index 0000000..ef1636a
+--- /dev/null
++++ b/75-facetimehd-verify.hook
+@@ -0,0 +1,12 @@
++[Trigger]
++Operation = Install
++Operation = Upgrade
++Type = Path
++Target = usr/lib/modules/*/modules.order
++Target = usr/src/facetimehd-*/dkms.conf
++
++[Action]
++Description = Verify FaceTime HD module for stock kernels
++When = PostTransaction
++Exec = /usr/lib/omarchy/verify-facetimehd
++NeedsTargets
+diff --git a/verify-kernel-modules b/verify-kernel-modules
+new file mode 100755
+index 0000000..30e81c7
+--- /dev/null
++++ b/verify-kernel-modules
+@@ -0,0 +1,62 @@
++#!/bin/bash
++set -euo pipefail
++
++modules_root=/usr/lib/modules
++
++usage() {
++  echo "Usage: ${0##*/} [--modules-root DIR]" >&2
++}
++
++while (( $# > 0 )); do
++  case "$1" in
++    --modules-root)
++      modules_root=${2:-}
++      shift 2
++      ;;
++    -h|--help)
++      usage
++      exit 0
++      ;;
++    *)
++      usage
++      exit 2
++      ;;
++  esac
++done
++
++declare -A kernels=()
++verify_all=false
++
++while read -r target; do
++  if [[ "$target" =~ ^usr/lib/modules/([^/]+)/ ]]; then
++    kernels["${BASH_REMATCH[1]}"]=1
++  elif [[ "$target" =~ ^usr/src/facetimehd-[^/]+/dkms\.conf$ ]]; then
++    verify_all=true
++  fi
++done
++
++if [[ "$verify_all" == true && -d "$modules_root" ]]; then
++  for pkgbase_file in "$modules_root"/*/pkgbase; do
++    [[ -f "$pkgbase_file" ]] || continue
++    kernelver=${pkgbase_file%/pkgbase}
++    kernels["${kernelver##*/}"]=1
++  done
++fi
++
++failures=0
++while read -r kernelver; do
++  [[ -n "$kernelver" ]] || continue
++  kernel_root="$modules_root/$kernelver"
++  [[ -f "$kernel_root/pkgbase" ]] || continue
++  read -r pkgbase < "$kernel_root/pkgbase"
++  [[ "$pkgbase" == linux ]] || continue
++
++  module_base="$kernel_root/updates/dkms/facetimehd.ko"
++  if [[ ! -f "$module_base" && ! -f "$module_base.gz" && \
++        ! -f "$module_base.xz" && ! -f "$module_base.zst" ]]; then
++    echo "ERROR: Missing facetimehd for stock kernel $kernelver" >&2
++    failures=$((failures + 1))
++  fi
++done < <(printf '%s\n' "${!kernels[@]}" | sort -V)
++
++(( failures == 0 ))

--- a/pkgbuilds/facetimehd-dkms/75-facetimehd-verify.hook
+++ b/pkgbuilds/facetimehd-dkms/75-facetimehd-verify.hook
@@ -1,0 +1,12 @@
+[Trigger]
+Operation = Install
+Operation = Upgrade
+Type = Path
+Target = usr/lib/modules/*/modules.order
+Target = usr/src/facetimehd-*/dkms.conf
+
+[Action]
+Description = Verify FaceTime HD module for stock kernels
+When = PostTransaction
+Exec = /usr/lib/omarchy/verify-facetimehd
+NeedsTargets

--- a/pkgbuilds/facetimehd-dkms/PKGBUILD
+++ b/pkgbuilds/facetimehd-dkms/PKGBUILD
@@ -1,0 +1,51 @@
+# Maintainer: Harrison <contact@htv04.com>
+# Contributor: Vladislav Ivanishin <vladislav.ivanishin@gmail.com>
+# Contributor: Aetf <aetf@unlimitedcodeworks.xyz>
+# Contributor: Hugo Osvaldo Barrera <hugo@barrera.io>
+# Contributor: Christoph Gysin <christoph.gysin@gmail.com>
+
+_pkgname="facetimehd-dkms"
+pkgname="$_pkgname"
+pkgver=0.7.0.2
+pkgrel=1.1
+pkgdesc='Reverse engineered Linux driver for the FacetimeHD (Broadcom 1570) PCIe webcam'
+url='https://github.com/patjak/facetimehd'
+license=('GPL-2.0-only')
+arch=('any')
+
+depends=(
+  'facetimehd-firmware'
+  'dkms'
+)
+optdepends=('facetimehd-data: Sensor calibration data')
+
+provides=('bcwc-pcie' 'bcwc-pcie-dkms')
+conflicts=('bcwc-pcie' 'bcwc-pcie-dkms')
+
+_pkgsrc="facetimehd-$pkgver"
+source=(
+  "$_pkgsrc.tar.gz::https://github.com/patjak/facetimehd/archive/refs/tags/$pkgver.tar.gz"
+  'verify-kernel-modules'
+  '75-facetimehd-verify.hook'
+)
+sha256sums=(
+  '3bf7cdfa62c57258a1f6188caf10e767d9315574deefaf246d4725a17547191a'
+  '072a14aea0ccf57346a82cd380db268186970853877a3add8538fe7ab8faff1b'
+  'ed9e3154fe7381086f4f5b6e8469b22aa94603161ff48215b335a84eb07f2d2f'
+)
+
+prepare() {
+  # deprecated
+  sed -E -e '/^(CLEAN|MODULES_CONF)/d' -i "$_pkgsrc/dkms.conf"
+}
+
+package() {
+  cd "$_pkgsrc"
+  for FILE in dkms.conf Makefile *.[ch]; do
+    install -Dm644 "$FILE" "$pkgdir/usr/src/facetimehd-$pkgver/$FILE"
+  done
+  install -Dm755 "$srcdir/verify-kernel-modules" \
+    "$pkgdir/usr/lib/omarchy/verify-facetimehd"
+  install -Dm644 "$srcdir/75-facetimehd-verify.hook" \
+    "$pkgdir/usr/share/libalpm/hooks/75-facetimehd-verify.hook"
+}

--- a/pkgbuilds/facetimehd-dkms/verify-kernel-modules
+++ b/pkgbuilds/facetimehd-dkms/verify-kernel-modules
@@ -1,0 +1,62 @@
+#!/bin/bash
+set -euo pipefail
+
+modules_root=/usr/lib/modules
+
+usage() {
+  echo "Usage: ${0##*/} [--modules-root DIR]" >&2
+}
+
+while (( $# > 0 )); do
+  case "$1" in
+    --modules-root)
+      modules_root=${2:-}
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      usage
+      exit 2
+      ;;
+  esac
+done
+
+declare -A kernels=()
+verify_all=false
+
+while read -r target; do
+  if [[ "$target" =~ ^usr/lib/modules/([^/]+)/ ]]; then
+    kernels["${BASH_REMATCH[1]}"]=1
+  elif [[ "$target" =~ ^usr/src/facetimehd-[^/]+/dkms\.conf$ ]]; then
+    verify_all=true
+  fi
+done
+
+if [[ "$verify_all" == true && -d "$modules_root" ]]; then
+  for pkgbase_file in "$modules_root"/*/pkgbase; do
+    [[ -f "$pkgbase_file" ]] || continue
+    kernelver=${pkgbase_file%/pkgbase}
+    kernels["${kernelver##*/}"]=1
+  done
+fi
+
+failures=0
+while read -r kernelver; do
+  [[ -n "$kernelver" ]] || continue
+  kernel_root="$modules_root/$kernelver"
+  [[ -f "$kernel_root/pkgbase" ]] || continue
+  read -r pkgbase < "$kernel_root/pkgbase"
+  [[ "$pkgbase" == linux ]] || continue
+
+  module_base="$kernel_root/updates/dkms/facetimehd.ko"
+  if [[ ! -f "$module_base" && ! -f "$module_base.gz" && \
+        ! -f "$module_base.xz" && ! -f "$module_base.zst" ]]; then
+    echo "ERROR: Missing facetimehd for stock kernel $kernelver" >&2
+    failures=$((failures + 1))
+  fi
+done < <(printf '%s\n' "${!kernels[@]}" | sort -V)
+
+(( failures == 0 ))

--- a/pkgbuilds/facetimehd-firmware/.omarchy/package.json
+++ b/pkgbuilds/facetimehd-firmware/.omarchy/package.json
@@ -1,0 +1,4 @@
+{
+  "source": "aur",
+  "upstream_commit": "3cf07f097e9666511118d61d13f04071f95e927a"
+}

--- a/pkgbuilds/facetimehd-firmware/.omarchy/patches/0001-verify-packaged-license.patch
+++ b/pkgbuilds/facetimehd-firmware/.omarchy/patches/0001-verify-packaged-license.patch
@@ -1,0 +1,13 @@
+diff --git a/PKGBUILD b/PKGBUILD
+index f98e9de..80b019d 100644
+--- a/PKGBUILD
++++ b/PKGBUILD
+@@ -20,7 +20,7 @@ conflicts=('bcwc-pcie-firmware')
+ 
+ _pkgsrc="$_pkgname"
+ source=('LicenseRef-Apple.tar.xz')
+-sha256sums=('SKIP')
++sha256sums=('f4e84968cf4105c1545638c99116735c349d32695c5bf9ac74d7a99eab3fcebe')
+ 
+ prepare() (
+   # partial download because dmg is 723 MiB

--- a/pkgbuilds/facetimehd-firmware/PKGBUILD
+++ b/pkgbuilds/facetimehd-firmware/PKGBUILD
@@ -1,0 +1,63 @@
+# Maintainer: Harrison <contact@htv04.com>
+# Contributor: Hugo Osvaldo Barrera <hugo@barrera.io>
+
+## extraction reference
+# https://github.com/patjak/facetimehd-firmware
+
+_pkgname="facetimehd-firmware"
+pkgname="$_pkgname"
+pkgver=1.43_5
+pkgrel=2.1
+epoch=1
+pkgdesc='Firmware for the FacetimeHD (Broadcom 1570) PCIe webcam'
+license=('LicenseRef-Apple')
+arch=('any')
+
+makedepends=(
+  'cpio'
+  'xz'
+)
+
+conflicts=('bcwc-pcie-firmware')
+provides=('bcwc-pcie-firmware')
+
+_pkgsrc="$_pkgname"
+source=('LicenseRef-Apple.tar.xz')
+sha256sums=('f4e84968cf4105c1545638c99116735c349d32695c5bf9ac74d7a99eab3fcebe')
+
+prepare() (
+  # partial download because dmg is 723 MiB
+  URL="https://updates.cdn-apple.com/2019/cert/041-88431-20191011-e7ee7d98-2878-4cd9-bc0a-d98b3a1e24b1/OSXUpd10.11.5.dmg"
+  RANGE=204909802-207733123
+  OSX_DRV=AppleCameraInterface
+  OSX_DRV_DIR=System/Library/Extensions/AppleCameraInterface.kext/Contents/MacOS
+  FILE="$OSX_DRV_DIR/$OSX_DRV"
+
+  DRV_HASH=f56e68a880b65767335071531a1c75f3cfd4958adc6d871adf8dbf3b788e8ee1
+  FW_HASH=e3e6034a67dfdaa27672dd547698bbc5b33f47f1fc7f5572a2fb68ea09d32d3d
+
+  OFFSET=81920
+  SIZE=603715
+
+  echo "Downloading driver..."
+  curl -k -L -r "$RANGE" "$URL" | xzcat -qq -Q | cpio --format odc -i -d "./$FILE" &> /dev/null || true
+  mv "$FILE" .
+
+  echo "Extracting firmware..."
+  dd bs=1 skip=$OFFSET count=$SIZE if=./$OSX_DRV of=./firmware.bin.gz &> /dev/null
+  gunzip ./firmware.bin.gz
+
+  cat > firmware.sha256 << END
+$DRV_HASH  $OSX_DRV
+$FW_HASH  firmware.bin
+END
+)
+
+check() {
+  sha256sum -c firmware.sha256
+}
+
+package() {
+  install -Dm644 firmware.bin -t "$pkgdir/usr/lib/firmware/facetimehd/"
+  install -Dm644 LicenseRef-Apple/*.rtf -t "$pkgdir/usr/share/licenses/$pkgname/"
+}

--- a/pkgbuilds/snd-hda-macbookpro-dkms/.omarchy/package.json
+++ b/pkgbuilds/snd-hda-macbookpro-dkms/.omarchy/package.json
@@ -1,0 +1,3 @@
+{
+  "source": "local"
+}

--- a/pkgbuilds/snd-hda-macbookpro-dkms/75-snd-hda-macbookpro-verify.hook
+++ b/pkgbuilds/snd-hda-macbookpro-dkms/75-snd-hda-macbookpro-verify.hook
@@ -1,0 +1,12 @@
+[Trigger]
+Operation = Install
+Operation = Upgrade
+Type = Path
+Target = usr/lib/modules/*/modules.order
+Target = usr/src/snd_hda_macbookpro-*/dkms.conf
+
+[Action]
+Description = Verify MacBook Pro audio module for stock kernels
+When = PostTransaction
+Exec = /usr/lib/omarchy/verify-snd-hda-macbookpro
+NeedsTargets

--- a/pkgbuilds/snd-hda-macbookpro-dkms/Makefile
+++ b/pkgbuilds/snd-hda-macbookpro-dkms/Makefile
@@ -1,0 +1,18 @@
+KBUILD_EXTRA_CFLAGS := -DAPPLE_PINSENSE_FIXUP -DAPPLE_CODECS \
+	-DCONFIG_SND_HDA_RECONFIG=1 -Wno-unused-variable -Wno-unused-function
+
+ifndef KERNELRELEASE
+$(error KERNELRELEASE must name the target kernel)
+endif
+
+KERNELBUILD := /usr/lib/modules/$(KERNELRELEASE)/build
+MODULE_ROOT := $(CURDIR)/build/hda
+
+.PHONY: all clean
+
+all:
+	$(MAKE) -C $(KERNELBUILD) CFLAGS_MODULE="$(KBUILD_EXTRA_CFLAGS)" \
+		M=$(MODULE_ROOT) modules
+
+clean:
+	$(MAKE) -C $(KERNELBUILD) M=$(MODULE_ROOT) clean

--- a/pkgbuilds/snd-hda-macbookpro-dkms/PKGBUILD
+++ b/pkgbuilds/snd-hda-macbookpro-dkms/PKGBUILD
@@ -1,0 +1,61 @@
+# Maintainer: Omarchy <packages@omarchy.org>
+
+pkgname=snd-hda-macbookpro-dkms
+pkgver=0.1
+pkgrel=1
+pkgdesc='Offline DKMS source for MacBook Pro Cirrus CS8409 audio'
+arch=('any')
+url='https://github.com/davidjo/snd_hda_macbookpro'
+license=('GPL-2.0-only')
+depends=('dkms')
+
+_driver_commit=cb27cc483f4fe98be03a4f4bef466c00aa7d244b
+_driver_archive="snd_hda_macbookpro-${_driver_commit}.tar.gz"
+_driver_dir="snd_hda_macbookpro-${_driver_commit}"
+
+source=(
+  "${_driver_archive}::https://github.com/davidjo/snd_hda_macbookpro/archive/${_driver_commit}.tar.gz"
+  'linux-7.1.8.tar.xz::https://cdn.kernel.org/pub/linux/kernel/v7.x/linux-7.1.8.tar.xz'
+  'prepare-source'
+  'prepare-dkms-build'
+  'Makefile'
+  'dkms.conf'
+  'verify-kernel-modules'
+  '75-snd-hda-macbookpro-verify.hook'
+)
+sha256sums=(
+  '74320a51c1675d94533f75f97ace9a27c08ae8d7e0d67dd352a5f6b07293de81'
+  'ff01dcb449279d5b4cfccdb01fee639cf5ff1803f1749a77844dd33915422c49'
+  '3a199f4897fd8071be2df74060404cbfebeab81200dc08c99299c9820327d3c8'
+  'ca66a6f43341911a7713ad5ad1fa5e96e56a968323d68b2d71b13fcb5a867eaa'
+  'eec9ea7249cad7bf99dc67d711adcc11c5a32428cc4cdc8894a5629a5173e2c8'
+  '5d0302489d2e9229172d5f9d62f9c53805da1474c9102e398bb974165b1a4bbc'
+  '62a9cd3dc0a55f782258a194ca9e3fa92e77da99bbe5b84cdcd7ef85ea707678'
+  '4fe7ad5d2b23bb51167df94772c5ce43a7cb6e60a214726273483fbbbddc9b08'
+)
+noextract=('linux-7.1.8.tar.xz')
+
+prepare() {
+  "$srcdir/prepare-source" \
+    --driver-root "$srcdir/$_driver_dir" \
+    --linux-archive "$srcdir/linux-7.1.8.tar.xz" \
+    --output "$srcdir/prepared/7.1"
+}
+
+package() {
+  local dkms_root="$pkgdir/usr/src/snd_hda_macbookpro-$pkgver"
+
+  install -dm755 "$dkms_root/series/7.1"
+  cp -a --no-preserve=ownership \
+    "$srcdir/prepared/7.1/hda" "$dkms_root/series/7.1/"
+  install -Dm755 "$srcdir/prepare-dkms-build" "$dkms_root/prepare-dkms-build"
+  install -Dm644 "$srcdir/Makefile" "$dkms_root/Makefile"
+  install -Dm644 "$srcdir/dkms.conf" "$dkms_root/dkms.conf"
+  sed -i "s/@PKGVER@/$pkgver/" "$dkms_root/dkms.conf"
+  install -Dm755 "$srcdir/verify-kernel-modules" \
+    "$pkgdir/usr/lib/omarchy/verify-snd-hda-macbookpro"
+  install -Dm644 "$srcdir/75-snd-hda-macbookpro-verify.hook" \
+    "$pkgdir/usr/share/libalpm/hooks/75-snd-hda-macbookpro-verify.hook"
+  install -Dm644 "$srcdir/$_driver_dir/LICENSE" \
+    "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+}

--- a/pkgbuilds/snd-hda-macbookpro-dkms/dkms.conf
+++ b/pkgbuilds/snd-hda-macbookpro-dkms/dkms.conf
@@ -1,0 +1,8 @@
+PACKAGE_NAME="snd_hda_macbookpro"
+PACKAGE_VERSION="@PKGVER@"
+PRE_BUILD="./prepare-dkms-build $kernelver"
+MAKE[0]="make KERNELBUILD=$kernel_source_dir"
+BUILT_MODULE_NAME[0]="snd-hda-codec-cs8409"
+BUILT_MODULE_LOCATION[0]="build/hda/codecs/cirrus"
+DEST_MODULE_LOCATION[0]="/updates/dkms"
+AUTOINSTALL="yes"

--- a/pkgbuilds/snd-hda-macbookpro-dkms/prepare-dkms-build
+++ b/pkgbuilds/snd-hda-macbookpro-dkms/prepare-dkms-build
@@ -1,0 +1,29 @@
+#!/bin/bash
+set -euo pipefail
+
+kernelver=${1:-}
+if [[ -z "$kernelver" ]]; then
+  echo "Usage: ${0##*/} KERNEL_VERSION" >&2
+  exit 2
+fi
+
+kernel_release=${kernelver%%-*}
+IFS=. read -r kernel_major kernel_minor _ <<< "$kernel_release"
+if [[ -z "${kernel_major:-}" || -z "${kernel_minor:-}" ]]; then
+  echo "Invalid kernel version: $kernelver" >&2
+  exit 2
+fi
+
+series="$kernel_major.$kernel_minor"
+source_root=$(cd -- "${BASH_SOURCE[0]%/*}" && pwd)
+prepared="$source_root/series/$series/hda"
+build="$source_root/build"
+
+if [[ ! -d "$prepared" ]]; then
+  echo "No prepared audio source for kernel series $series ($kernelver)" >&2
+  exit 1
+fi
+
+rm -rf -- "$build"
+mkdir -p "$build"
+cp -a "$prepared" "$build/hda"

--- a/pkgbuilds/snd-hda-macbookpro-dkms/prepare-source
+++ b/pkgbuilds/snd-hda-macbookpro-dkms/prepare-source
@@ -1,0 +1,77 @@
+#!/bin/bash
+set -euo pipefail
+
+driver_root=""
+linux_archive=""
+output=""
+
+usage() {
+  echo "Usage: ${0##*/} --driver-root DIR --linux-archive FILE --output DIR" >&2
+}
+
+while (( $# > 0 )); do
+  case "$1" in
+    --driver-root)
+      driver_root=${2:-}
+      shift 2
+      ;;
+    --linux-archive)
+      linux_archive=${2:-}
+      shift 2
+      ;;
+    --output)
+      output=${2:-}
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      usage
+      exit 2
+      ;;
+  esac
+done
+
+[[ -d "$driver_root" ]] || { echo "Driver source not found: $driver_root" >&2; exit 1; }
+[[ -f "$linux_archive" ]] || { echo "Linux source archive not found: $linux_archive" >&2; exit 1; }
+[[ -n "$output" ]] || { usage; exit 2; }
+[[ ! -e "$output" ]] || { echo "Output already exists: $output" >&2; exit 1; }
+
+work=$(mktemp -d)
+trap 'rm -rf "$work"' EXIT
+stage="$work/prepared"
+mkdir -p "$stage"
+
+tar -xJf "$linux_archive" --wildcards --strip-components=2 \
+  -C "$stage" '*/sound/hda'
+
+[[ -d "$stage/hda/codecs/cirrus" ]] || {
+  echo "Linux archive does not contain sound/hda/codecs/cirrus" >&2
+  exit 1
+}
+
+mv "$stage/hda/Makefile" "$stage/hda/Makefile.orig"
+mv "$stage/hda/common/Makefile" "$stage/hda/common/Makefile.orig"
+mv "$stage/hda/codecs/Makefile" "$stage/hda/codecs/Makefile.orig"
+mv "$stage/hda/codecs/cirrus/Makefile" "$stage/hda/codecs/cirrus/Makefile.orig"
+
+install -m644 "$driver_root/makefiles/Makefile" "$stage/hda/Makefile"
+install -m644 "$driver_root/makefiles/Makefile_common" "$stage/hda/common/Makefile"
+install -m644 "$driver_root/makefiles/Makefile_codecs" "$stage/hda/codecs/Makefile"
+install -m644 "$driver_root/makefiles/Makefile_cirrus" "$stage/hda/codecs/cirrus/Makefile"
+
+for header in cirrus_apple.h patch_cirrus_boot84.h patch_cirrus_new84.h \
+  patch_cirrus_real84.h patch_cirrus_hda_generic_copy.h patch_cirrus_real84_i2c.h; do
+  install -m644 "$driver_root/patch_cirrus/$header" "$stage/hda/codecs/cirrus/$header"
+done
+
+(
+  cd "$stage/hda"
+  patch -p1 --forward --batch < "$driver_root/patch_cs8409.c.diff"
+  patch -p1 --forward --batch < "$driver_root/patch_cs8409.h.diff"
+)
+
+mkdir -p "${output%/*}"
+mv "$stage" "$output"

--- a/pkgbuilds/snd-hda-macbookpro-dkms/verify-kernel-modules
+++ b/pkgbuilds/snd-hda-macbookpro-dkms/verify-kernel-modules
@@ -1,0 +1,62 @@
+#!/bin/bash
+set -euo pipefail
+
+modules_root=/usr/lib/modules
+
+usage() {
+  echo "Usage: ${0##*/} [--modules-root DIR]" >&2
+}
+
+while (( $# > 0 )); do
+  case "$1" in
+    --modules-root)
+      modules_root=${2:-}
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      usage
+      exit 2
+      ;;
+  esac
+done
+
+declare -A kernels=()
+verify_all=false
+
+while read -r target; do
+  if [[ "$target" =~ ^usr/lib/modules/([^/]+)/ ]]; then
+    kernels["${BASH_REMATCH[1]}"]=1
+  elif [[ "$target" =~ ^usr/src/snd_hda_macbookpro-[^/]+/dkms\.conf$ ]]; then
+    verify_all=true
+  fi
+done
+
+if [[ "$verify_all" == true && -d "$modules_root" ]]; then
+  for pkgbase_file in "$modules_root"/*/pkgbase; do
+    [[ -f "$pkgbase_file" ]] || continue
+    kernelver=${pkgbase_file%/pkgbase}
+    kernels["${kernelver##*/}"]=1
+  done
+fi
+
+failures=0
+while read -r kernelver; do
+  [[ -n "$kernelver" ]] || continue
+  kernel_root="$modules_root/$kernelver"
+  [[ -f "$kernel_root/pkgbase" ]] || continue
+  read -r pkgbase < "$kernel_root/pkgbase"
+  [[ "$pkgbase" == linux ]] || continue
+
+  module_base="$kernel_root/updates/dkms/snd-hda-codec-cs8409.ko"
+  if [[ ! -f "$module_base" && ! -f "$module_base.gz" && \
+        ! -f "$module_base.xz" && ! -f "$module_base.zst" ]]; then
+    echo "ERROR: Missing snd-hda-codec-cs8409 for stock kernel $kernelver" >&2
+    failures=$((failures + 1))
+  fi
+done < <(printf '%s\n' "${!kernels[@]}" | sort -V)
+
+(( failures == 0 ))

--- a/tests/build-macbookpro13-1-dkms
+++ b/tests/build-macbookpro13-1-dkms
@@ -1,0 +1,121 @@
+#!/bin/bash
+set -euo pipefail
+
+if (( $# < 3 )); then
+  echo "Usage: ${0##*/} AUDIO_PACKAGE CAMERA_PACKAGE LINUX_HEADERS_PACKAGE..." >&2
+  exit 2
+fi
+
+audio_package=$1
+camera_package=$2
+shift 2
+
+for package in "$audio_package" "$camera_package"; do
+  [[ -f "$package" ]] || { echo "Package not found: $package" >&2; exit 1; }
+done
+
+work=$(mktemp -d)
+trap 'rm -rf "$work"' EXIT
+mkdir -p "$work/package" "$work/source" "$work/tree" "$work/install" \
+  "$work/home" "$work/fakebin"
+
+for command in curl wget git; do
+  printf '#!/bin/sh\necho "Unexpected network command: %s" >&2\nexit 99\n' \
+    "$command" > "$work/fakebin/$command"
+  chmod +x "$work/fakebin/$command"
+done
+
+bsdtar -xf "$audio_package" -C "$work/package"
+bsdtar -xf "$camera_package" -C "$work/package"
+
+shopt -s nullglob
+audio_sources=("$work/package/usr/src/snd_hda_macbookpro-"*)
+camera_sources=("$work/package/usr/src/facetimehd-"*)
+(( ${#audio_sources[@]} == 1 )) || {
+  echo "Expected one snd_hda_macbookpro source directory in $audio_package" >&2
+  exit 1
+}
+(( ${#camera_sources[@]} == 1 )) || {
+  echo "Expected one facetimehd source directory in $camera_package" >&2
+  exit 1
+}
+
+audio_version=${audio_sources[0]##*/snd_hda_macbookpro-}
+camera_version=${camera_sources[0]##*/facetimehd-}
+cp -a "${audio_sources[0]}" "$work/source/"
+cp -a "${camera_sources[0]}" "$work/source/"
+
+dkms_args=(
+  --dkmstree "$work/tree"
+  --sourcetree "$work/source"
+  --installtree "$work/install"
+)
+build_env=(env "HOME=$work/home" "PATH=$work/fakebin:$PATH")
+
+module_exists() {
+  local module_base=$1 suffix
+
+  for suffix in '' .gz .xz .zst; do
+    [[ -s "$module_base$suffix" ]] && return 0
+  done
+  return 1
+}
+
+"${build_env[@]}" dkms add -m snd_hda_macbookpro -v "$audio_version" "${dkms_args[@]}"
+"${build_env[@]}" dkms add -m facetimehd -v "$camera_version" "${dkms_args[@]}"
+
+for headers_package in "$@"; do
+  [[ -f "$headers_package" ]] || {
+    echo "Headers package not found: $headers_package" >&2
+    exit 1
+  }
+
+  kernelver=$(bsdtar -tf "$headers_package" | sed -n \
+    's|^usr/lib/modules/\([^/]*\)/build/Makefile$|\1|p')
+  [[ -n "$kernelver" && "$kernelver" != *$'\n'* ]] || {
+    echo "Could not identify one kernel version in $headers_package" >&2
+    exit 1
+  }
+
+  header_root="$work/headers-$kernelver"
+  mkdir -p "$header_root" "$work/install/$kernelver"
+  bsdtar -xf "$headers_package" -C "$header_root"
+  kernel_source="$header_root/usr/lib/modules/$kernelver/build"
+
+  "${build_env[@]}" dkms build \
+    -m snd_hda_macbookpro -v "$audio_version" -k "$kernelver" --arch x86_64 \
+    --kernelsourcedir "$kernel_source" "${dkms_args[@]}"
+  "${build_env[@]}" dkms build \
+    -m facetimehd -v "$camera_version" -k "$kernelver" --arch x86_64 \
+    --kernelsourcedir "$kernel_source" "${dkms_args[@]}"
+
+  fakeroot "${build_env[@]}" dkms install --no-depmod \
+    -m snd_hda_macbookpro -v "$audio_version" -k "$kernelver" --arch x86_64 \
+    "${dkms_args[@]}"
+  fakeroot "${build_env[@]}" dkms install --no-depmod \
+    -m facetimehd -v "$camera_version" -k "$kernelver" --arch x86_64 \
+    "${dkms_args[@]}"
+
+  audio_module="$work/tree/snd_hda_macbookpro/$audio_version/$kernelver/x86_64/module/snd-hda-codec-cs8409.ko"
+  camera_module="$work/tree/facetimehd/$camera_version/$kernelver/x86_64/module/facetimehd.ko"
+  [[ -s "$audio_module" ]] || {
+    echo "DKMS did not produce snd-hda-codec-cs8409 for $kernelver" >&2
+    exit 1
+  }
+  [[ -s "$camera_module" ]] || {
+    echo "DKMS did not produce facetimehd for $kernelver" >&2
+    exit 1
+  }
+  module_exists "$work/install/$kernelver/updates/dkms/snd-hda-codec-cs8409.ko" || {
+    echo "DKMS did not install snd-hda-codec-cs8409 for $kernelver" >&2
+    exit 1
+  }
+  module_exists "$work/install/$kernelver/updates/dkms/facetimehd.ko" || {
+    echo "DKMS did not install facetimehd for $kernelver" >&2
+    exit 1
+  }
+
+  echo "PASS $kernelver"
+  echo "  audio  srcversion=$(modinfo -F srcversion "$audio_module") vermagic=$(modinfo -F vermagic "$audio_module")"
+  echo "  camera srcversion=$(modinfo -F srcversion "$camera_module") vermagic=$(modinfo -F vermagic "$camera_module")"
+done

--- a/tests/macbookpro13-1-packages
+++ b/tests/macbookpro13-1-packages
@@ -1,0 +1,354 @@
+#!/bin/bash
+set -euo pipefail
+
+repo_root=$(realpath "${BASH_SOURCE[0]%/*}/..")
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+srcinfo_for() {
+  local package=$1
+  local package_dir="$repo_root/pkgbuilds/$package"
+
+  [[ -f "$package_dir/PKGBUILD" ]] || fail "$package is missing its PKGBUILD"
+  (cd "$package_dir" && makepkg --printsrcinfo)
+}
+
+assert_field() {
+  local srcinfo=$1 field=$2 expected=$3
+  grep -Eq "^[[:space:]]+$field = $expected$" <<< "$srcinfo" ||
+    fail "expected $field = $expected"
+}
+
+assert_pinned_sources() {
+  local srcinfo=$1 package=$2
+  local sources sums
+
+  sources=$(awk -F' = ' '$1 ~ /^[[:space:]]*source($|_)/ { print $2 }' <<< "$srcinfo")
+  sums=$(awk -F' = ' '$1 ~ /^[[:space:]]*sha256sums($|_)/ { print $2 }' <<< "$srcinfo")
+
+  [[ -n "$sources" ]] || fail "$package declares no sources"
+  [[ -n "$sums" ]] || fail "$package declares no sha256sums"
+  ! grep -Eq '(^|[+:])(git|hg|svn|bzr)\+' <<< "$sources" ||
+    fail "$package uses a moving VCS source"
+  ! grep -Fxq 'SKIP' <<< "$sums" || fail "$package skips source verification"
+  awk 'length != 64 || /[^0-9a-f]/ { exit 1 }' <<< "$sums" ||
+    fail "$package has a non-SHA-256 source checksum"
+}
+
+prepare_verifier_fixture() {
+  local modules=$1 installed_module=$2
+
+  mkdir -p "$modules/7.1.8-arch1-3/updates/dkms" \
+    "$modules/7.1.8-arch1-4" \
+    "$modules/7.1.8-zen1-1-zen"
+  printf 'linux\n' > "$modules/7.1.8-arch1-3/pkgbase"
+  printf 'linux\n' > "$modules/7.1.8-arch1-4/pkgbase"
+  printf 'linux-zen\n' > "$modules/7.1.8-zen1-1-zen/pkgbase"
+  printf 'module fixture\n' > \
+    "$modules/7.1.8-arch1-3/updates/dkms/$installed_module"
+}
+
+assert_stock_kernel_verifier() {
+  local verifier=$1 modules=$2 module_name=$3 capability=$4
+  local output
+
+  printf 'usr/lib/modules/7.1.8-arch1-3/modules.order\n' | \
+    "$verifier" --modules-root "$modules" ||
+    fail "$capability verifier rejected a present stock-kernel DKMS module"
+
+  if output=$(printf 'usr/lib/modules/7.1.8-arch1-4/modules.order\n' | \
+    "$verifier" --modules-root "$modules" 2>&1); then
+    fail "$capability verifier accepted a missing stock-kernel DKMS module"
+  fi
+  grep -Fq "Missing $module_name for stock kernel 7.1.8-arch1-4" <<< "$output" ||
+    fail "$capability verifier did not identify the missing stock-kernel module"
+
+  printf 'usr/lib/modules/7.1.8-zen1-1-zen/modules.order\n' | \
+    "$verifier" --modules-root "$modules" ||
+    fail "$capability verifier treated an alternative kernel as stock"
+}
+
+test_camera_packages_are_versioned_and_pinned() {
+  local driver firmware
+
+  driver=$(srcinfo_for facetimehd-dkms)
+  assert_field "$driver" pkgver 0.7.0.2
+  assert_field "$driver" pkgrel 1.1
+  assert_field "$driver" depends dkms
+  assert_field "$driver" depends facetimehd-firmware
+  assert_pinned_sources "$driver" facetimehd-dkms
+
+  firmware=$(srcinfo_for facetimehd-firmware)
+  assert_field "$firmware" epoch 1
+  assert_field "$firmware" pkgver 1.43_5
+  assert_field "$firmware" pkgrel 2.1
+  assert_pinned_sources "$firmware" facetimehd-firmware
+}
+
+test_camera_firmware_builds_before_driver() {
+  local plan order
+
+  plan=$("$repo_root/bin/repo" build --dry-run --package \
+    facetimehd-dkms facetimehd-firmware snd-hda-macbookpro-dkms)
+  order=$(sed -n 's/^==> Build order: //p' <<< "$plan")
+  [[ "$order" == *facetimehd-firmware*facetimehd-dkms* ]] ||
+    fail "package builder does not order FaceTime HD firmware before its driver"
+}
+
+test_camera_package_installs_post_dkms_verifier() {
+  local package_dir="$repo_root/pkgbuilds/facetimehd-dkms"
+  local work
+
+  work=$(mktemp -d)
+  trap 'rm -rf "$work"' RETURN
+  mkdir -p "$work/src/facetimehd-0.7.0.2"
+  printf 'GPL fixture\n' > "$work/src/facetimehd-0.7.0.2/LICENSE"
+  printf 'PACKAGE_NAME="facetimehd"\nPACKAGE_VERSION="0.7.0.2"\n' > \
+    "$work/src/facetimehd-0.7.0.2/dkms.conf"
+  printf 'fixture\n' > "$work/src/facetimehd-0.7.0.2/Makefile"
+  printf 'fixture\n' > "$work/src/facetimehd-0.7.0.2/fthd_fixture.c"
+  for package_file in verify-kernel-modules 75-facetimehd-verify.hook; do
+    [[ -f "$package_dir/$package_file" ]] && cp "$package_dir/$package_file" "$work/src/"
+  done
+
+  fakeroot bash -c '
+    set -euo pipefail
+    source "$1"
+    srcdir=$2
+    pkgdir=$3
+    cd "$srcdir"
+    package
+  ' _ "$package_dir/PKGBUILD" "$work/src" "$work/pkg"
+
+  [[ -x "$work/pkg/usr/lib/omarchy/verify-facetimehd" ]] ||
+    fail "camera package omitted its post-DKMS verifier"
+  [[ -f "$work/pkg/usr/share/libalpm/hooks/75-facetimehd-verify.hook" ]] ||
+    fail "camera package omitted its post-DKMS pacman hook"
+  grep -Fxq 'NeedsTargets' \
+    "$work/pkg/usr/share/libalpm/hooks/75-facetimehd-verify.hook" ||
+    fail "camera post-DKMS hook does not pass transaction targets to the verifier"
+}
+
+test_camera_verifier_fails_when_stock_kernel_module_is_missing() {
+  local verifier="$repo_root/pkgbuilds/facetimehd-dkms/verify-kernel-modules"
+  local work modules output
+
+  [[ -x "$verifier" ]] || fail "camera post-DKMS verifier is missing"
+
+  work=$(mktemp -d)
+  trap 'rm -rf "$work"' RETURN
+  modules="$work/modules"
+  prepare_verifier_fixture "$modules" facetimehd.ko.xz
+  assert_stock_kernel_verifier "$verifier" "$modules" facetimehd camera
+
+  if output=$(printf 'usr/src/facetimehd-0.7.0.2/dkms.conf\n' | \
+    "$verifier" --modules-root "$modules" 2>&1); then
+    fail "camera package upgrade ignored a stock kernel without its module"
+  fi
+  grep -Fq 'Missing facetimehd for stock kernel 7.1.8-arch1-4' <<< "$output" ||
+    fail "camera package upgrade did not identify an unbuilt stock kernel"
+}
+
+test_audio_source_preparation_is_reproducible() {
+  local prepare="$repo_root/pkgbuilds/snd-hda-macbookpro-dkms/prepare-source"
+  local work driver kernel archive first second header
+
+  [[ -x "$prepare" ]] || fail "audio source preparation command is missing"
+
+  work=$(mktemp -d)
+  trap 'rm -rf "$work"' RETURN
+  driver="$work/driver"
+  kernel="$work/kernel/linux-7.1.8/sound/hda"
+  archive="$work/linux-7.1.8.tar.xz"
+  first="$work/first"
+  second="$work/second"
+
+  mkdir -p "$driver/makefiles" "$driver/patch_cirrus" \
+    "$kernel/common" "$kernel/codecs/cirrus"
+  printf 'upstream hda makefile\n' > "$kernel/Makefile"
+  printf 'upstream common makefile\n' > "$kernel/common/Makefile"
+  printf 'upstream codecs makefile\n' > "$kernel/codecs/Makefile"
+  printf 'upstream cirrus makefile\n' > "$kernel/codecs/cirrus/Makefile"
+  printf 'upstream source\n' > "$kernel/codecs/cirrus/patch_cs8409.c"
+  printf 'upstream header\n' > "$kernel/codecs/cirrus/patch_cs8409.h"
+
+  printf 'fixture hda makefile\n' > "$driver/makefiles/Makefile"
+  printf 'fixture common makefile\n' > "$driver/makefiles/Makefile_common"
+  printf 'fixture codecs makefile\n' > "$driver/makefiles/Makefile_codecs"
+  printf 'fixture cirrus makefile\n' > "$driver/makefiles/Makefile_cirrus"
+  for header in cirrus_apple.h patch_cirrus_boot84.h patch_cirrus_new84.h \
+    patch_cirrus_real84.h patch_cirrus_hda_generic_copy.h patch_cirrus_real84_i2c.h; do
+    printf 'fixture %s\n' "$header" > "$driver/patch_cirrus/$header"
+  done
+  printf '%s\n' \
+    '--- a/codecs/cirrus/patch_cs8409.c' \
+    '+++ b/codecs/cirrus/patch_cs8409.c' \
+    '@@ -1 +1 @@' \
+    '-upstream source' \
+    '+patched fixture source' > "$driver/patch_cs8409.c.diff"
+  printf '%s\n' \
+    '--- a/codecs/cirrus/patch_cs8409.h' \
+    '+++ b/codecs/cirrus/patch_cs8409.h' \
+    '@@ -1 +1 @@' \
+    '-upstream header' \
+    '+patched fixture header' > "$driver/patch_cs8409.h.diff"
+
+  tar -cJf "$archive" -C "$work/kernel" linux-7.1.8
+  env -u HOME "$prepare" --driver-root "$driver" --linux-archive "$archive" --output "$first"
+  env HOME=/nonexistent "$prepare" --driver-root "$driver" --linux-archive "$archive" --output "$second"
+
+  diff -ruN "$first" "$second" >/dev/null || fail "prepared audio source is not reproducible"
+  grep -Fxq 'upstream hda makefile' "$first/hda/Makefile.orig" ||
+    fail "prepared audio source did not preserve the upstream makefile"
+  grep -Fxq 'fixture hda makefile' "$first/hda/Makefile" ||
+    fail "prepared audio source did not install the driver makefile"
+  grep -Fxq 'patched fixture source' "$first/hda/codecs/cirrus/patch_cs8409.c" ||
+    fail "prepared audio source did not apply the driver patch"
+}
+
+test_audio_package_pins_active_kernel_series() {
+  local srcinfo
+
+  srcinfo=$(srcinfo_for snd-hda-macbookpro-dkms)
+  assert_field "$srcinfo" pkgver 0.1
+  assert_field "$srcinfo" pkgrel 1
+  assert_field "$srcinfo" arch any
+  assert_field "$srcinfo" depends dkms
+  assert_field "$srcinfo" \
+    source \
+    'snd_hda_macbookpro-cb27cc483f4fe98be03a4f4bef466c00aa7d244b.tar.gz::https://github.com/davidjo/snd_hda_macbookpro/archive/cb27cc483f4fe98be03a4f4bef466c00aa7d244b.tar.gz'
+  assert_field "$srcinfo" \
+    source \
+    'linux-7.1.8.tar.xz::https://cdn.kernel.org/pub/linux/kernel/v7.x/linux-7.1.8.tar.xz'
+  assert_field "$srcinfo" noextract linux-7.1.8.tar.xz
+  assert_field "$srcinfo" sha256sums 74320a51c1675d94533f75f97ace9a27c08ae8d7e0d67dd352a5f6b07293de81
+  assert_field "$srcinfo" sha256sums ff01dcb449279d5b4cfccdb01fee639cf5ff1803f1749a77844dd33915422c49
+  assert_pinned_sources "$srcinfo" snd-hda-macbookpro-dkms
+}
+
+test_audio_dkms_contract_is_offline_and_series_aware() {
+  local package_dir="$repo_root/pkgbuilds/snd-hda-macbookpro-dkms"
+  local selector="$package_dir/prepare-dkms-build"
+  local work fakebin output
+
+  [[ -x "$selector" ]] || fail "DKMS kernel-series selector is missing"
+  [[ -f "$package_dir/dkms.conf" ]] || fail "audio dkms.conf is missing"
+
+  work=$(mktemp -d)
+  trap 'rm -rf "$work"' RETURN
+  fakebin="$work/fakebin"
+  mkdir -p "$work/source/series/7.1/hda" "$fakebin"
+  printf 'prepared 7.1 source\n' > "$work/source/series/7.1/hda/series-marker"
+  cp "$selector" "$work/source/prepare-dkms-build"
+
+  for command in uname curl wget git; do
+    printf '#!/bin/sh\nexit 99\n' > "$fakebin/$command"
+    chmod +x "$fakebin/$command"
+  done
+
+  (
+    cd "$work/source"
+    env -u HOME PATH="$fakebin:/usr/bin" ./prepare-dkms-build 7.1.8-arch1-3
+  )
+  grep -Fxq 'prepared 7.1 source' "$work/source/build/hda/series-marker" ||
+    fail "DKMS did not select the prepared 7.1 source"
+
+  if output=$(cd "$work/source" && HOME=/nonexistent PATH="$fakebin:/usr/bin" \
+    ./prepare-dkms-build 7.2.0-arch1-1 2>&1); then
+    fail "DKMS accepted an unprepared kernel series"
+  fi
+  grep -Fq 'No prepared audio source for kernel series 7.2' <<< "$output" ||
+    fail "DKMS did not explain the unsupported kernel series"
+
+  (
+    kernelver=7.1.8-arch1-3
+    kernel_source_dir=/fixtures/7.1.8/build
+    source "$package_dir/dkms.conf"
+    [[ ${PRE_BUILD:-} == './prepare-dkms-build 7.1.8-arch1-3' ]] || exit 1
+    [[ ${MAKE[0]:-} == 'make KERNELBUILD=/fixtures/7.1.8/build' ]] || exit 1
+    [[ ${BUILT_MODULE_NAME[0]:-} == 'snd-hda-codec-cs8409' ]] || exit 1
+    [[ ${BUILT_MODULE_LOCATION[0]:-} == 'build/hda/codecs/cirrus' ]] || exit 1
+  ) || fail "dkms.conf does not target the explicit kernel and modern module location"
+}
+
+test_audio_package_installs_self_contained_dkms_source() {
+  local package_dir="$repo_root/pkgbuilds/snd-hda-macbookpro-dkms"
+  local work dkms_root
+
+  work=$(mktemp -d)
+  trap 'rm -rf "$work"' RETURN
+  mkdir -p "$work/src/prepared/7.1/hda" \
+    "$work/src/snd_hda_macbookpro-cb27cc483f4fe98be03a4f4bef466c00aa7d244b"
+  printf 'prepared source\n' > "$work/src/prepared/7.1/hda/series-marker"
+  printf 'GPL fixture\n' > \
+    "$work/src/snd_hda_macbookpro-cb27cc483f4fe98be03a4f4bef466c00aa7d244b/LICENSE"
+  cp "$package_dir/Makefile" "$package_dir/dkms.conf" \
+    "$package_dir/prepare-dkms-build" "$work/src/"
+  for package_file in verify-kernel-modules 75-snd-hda-macbookpro-verify.hook; do
+    [[ -f "$package_dir/$package_file" ]] && cp "$package_dir/$package_file" "$work/src/"
+  done
+
+  fakeroot bash -c '
+    set -euo pipefail
+    source "$1"
+    srcdir=$2
+    pkgdir=$3
+    package
+  ' _ "$package_dir/PKGBUILD" "$work/src" "$work/pkg"
+
+  dkms_root="$work/pkg/usr/src/snd_hda_macbookpro-0.1"
+  [[ -f "$dkms_root/series/7.1/hda/series-marker" ]] ||
+    fail "audio package omitted its prepared 7.1 source"
+  [[ -x "$dkms_root/prepare-dkms-build" ]] ||
+    fail "audio package omitted its DKMS series selector"
+  [[ -f "$dkms_root/Makefile" ]] || fail "audio package omitted its build interface"
+  grep -Fxq 'PACKAGE_VERSION="0.1"' "$dkms_root/dkms.conf" ||
+    fail "audio package did not set its DKMS version"
+  ! grep -Eq '(https?://|\b(curl|wget|git|uname)[[:space:]]|\$HOME)' \
+    "$dkms_root/prepare-dkms-build" "$dkms_root/Makefile" "$dkms_root/dkms.conf" ||
+    fail "installed DKMS build interface has a network, HOME, or uname dependency"
+  [[ -x "$work/pkg/usr/lib/omarchy/verify-snd-hda-macbookpro" ]] ||
+    fail "audio package omitted its post-DKMS verifier"
+  [[ -f "$work/pkg/usr/share/libalpm/hooks/75-snd-hda-macbookpro-verify.hook" ]] ||
+    fail "audio package omitted its post-DKMS pacman hook"
+  grep -Fxq 'NeedsTargets' \
+    "$work/pkg/usr/share/libalpm/hooks/75-snd-hda-macbookpro-verify.hook" ||
+    fail "post-DKMS hook does not pass transaction targets to the verifier"
+}
+
+test_audio_verifier_fails_when_stock_kernel_module_is_missing() {
+  local verifier="$repo_root/pkgbuilds/snd-hda-macbookpro-dkms/verify-kernel-modules"
+  local work modules output
+
+  [[ -x "$verifier" ]] || fail "post-DKMS verifier is missing"
+
+  work=$(mktemp -d)
+  trap 'rm -rf "$work"' RETURN
+  modules="$work/modules"
+  prepare_verifier_fixture "$modules" snd-hda-codec-cs8409.ko.zst
+  assert_stock_kernel_verifier \
+    "$verifier" "$modules" snd-hda-codec-cs8409 audio
+
+  mkdir -p "$modules/7.1.9-arch1-1"
+  printf 'linux\n' > "$modules/7.1.9-arch1-1/pkgbase"
+  if output=$(printf 'usr/src/snd_hda_macbookpro-0.1/dkms.conf\n' | \
+    "$verifier" --modules-root "$modules" 2>&1); then
+    fail "package upgrade ignored a stock kernel without headers or a DKMS module"
+  fi
+  grep -Fq 'Missing snd-hda-codec-cs8409 for stock kernel 7.1.9-arch1-1' <<< "$output" ||
+    fail "package upgrade did not identify an unbuilt stock kernel"
+}
+
+test_camera_packages_are_versioned_and_pinned
+test_camera_firmware_builds_before_driver
+test_camera_package_installs_post_dkms_verifier
+test_camera_verifier_fails_when_stock_kernel_module_is_missing
+test_audio_source_preparation_is_reproducible
+test_audio_package_pins_active_kernel_series
+test_audio_dkms_contract_is_offline_and_series_aware
+test_audio_package_installs_self_contained_dkms_source
+test_audio_verifier_fails_when_stock_kernel_module_is_missing
+echo "PASS: MacBookPro13,1 package checks"


### PR DESCRIPTION
## Summary

Add package-repository support for MacBookPro13,1 camera and audio hardware:

- package the FaceTime HD firmware with verified source inputs
- package the pinned FaceTime HD DKMS driver
- add a self-contained `snd-hda-macbookpro-dkms` package
- prepare audio source for the active Linux 7.1 kernel series at package-build time
- verify both DKMS modules after stock-kernel and driver-package transactions

Installed DKMS sources do not fetch from the network, depend on a user home directory, or infer the target kernel using `uname`.

## Testing

- `tests/macbookpro13-1-packages`
- `bin/sync-rebuilds --self-test`
- `bin/omarchy-pkgs self-test`
- containerized repository build: 3 built, 0 failed
- offline DKMS build and install for both drivers against:
  - `7.1.3-arch1-2`
  - `7.1.4-arch1-1`
  - `7.1.8-arch1-3`
- verified AUR patch replay and package build ordering
- verified missing-module failures for stock kernels