### PR TITLE
omarchy-nvim: Add iron.nvim configuration for interactive REPL

### DIFF
--- a/pkgbuilds/omarchy-nvim/PKGBUILD
+++ b/pkgbuilds/omarchy-nvim/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Ryan Hughes <ryan@omarchy.org>
 pkgname=omarchy-nvim
-pkgver=2026.8.13
+pkgver=2026.8.23
 pkgrel=1
 pkgdesc="Pre-built LazyVim configuration with cached plugins"
 arch=('any')

--- a/pkgbuilds/omarchy-nvim/lua/plugins/iron.lua
+++ b/pkgbuilds/omarchy-nvim/lua/plugins/iron.lua
@@ -1,0 +1,68 @@
+return {
+  "Vigemus/iron.nvim",
+  cmd = { "IronRepl", "IronRestart", "IronFocus", "IronHide" },
+  keys = {
+    { "<leader>r", desc = "+repl" },
+    { "<leader>rr", "<cmd>IronRepl<cr>", desc = "Toggle REPL" },
+    { "<leader>rR", "<cmd>IronRestart<cr>", desc = "Restart REPL" },
+    { "<leader>rf", "<cmd>IronFocus<cr>", desc = "Focus REPL" },
+    { "<leader>rh", "<cmd>IronHide<cr>", desc = "Hide REPL" },
+    { "<leader>rs", desc = "+send" },
+    { "<leader>rsl", "<cmd>lua require('iron.core').send_line()<cr>", desc = "Send Line" },
+    { "<leader>rsf", "<cmd>lua require('iron.core').send_file()<cr>", desc = "Send File" },
+    { "<leader>rsp", "<cmd>lua require('iron.core').send_paragraph()<cr>", desc = "Send Paragraph" },
+    { "<leader>rsu", "<cmd>lua require('iron.core').send_until_cursor()<cr>", desc = "Send Until Cursor" },
+    { "<leader>rsb", "<cmd>lua require('iron.core').send_code_block(false)<cr>", desc = "Send Code Block" },
+    { "<leader>rsn", "<cmd>lua require('iron.core').send_code_block(true)<cr>", desc = "Send Code Block & Move Next" },
+    { "<leader>rsm", "<cmd>lua require('iron.core').run_motion('send_motion')<cr>", desc = "Send Motion" },
+    { "<leader>rs", "<cmd>lua require('iron.core').visual_send()<cr>", mode = "v", desc = "Send Selection" },
+    { "<leader>rsv", "<cmd>lua require('iron.core').visual_send()<cr>", mode = "v", desc = "Send Selection" },
+    { "<leader>rm", desc = "+marks" },
+    { "<leader>rmm", "<cmd>lua require('iron.core').run_motion('mark_motion')<cr>", desc = "Mark Motion" },
+    { "<leader>rmv", "<cmd>lua require('iron.core').mark_visual()<cr>", mode = "v", desc = "Mark Visual" },
+    { "<leader>rmd", "<cmd>lua require('iron.marks').drop_last()<cr>", desc = "Remove Mark" },
+    { "<leader>rmr", "<cmd>lua require('iron.core').send_mark()<cr>", desc = "Send Mark" },
+    { "<leader>rq", "<cmd>lua require('iron.core').send(nil, string.char(03))<cr>", desc = "Interrupt REPL" },
+    { "<leader>rx", "<cmd>lua require('iron.core').close_repl()<cr>", desc = "Exit REPL" },
+    { "<leader>rcc", "<cmd>lua require('iron.core').send(nil, string.char(12))<cr>", desc = "Clear REPL" },
+    { "<leader>rcl", "<cmd>lua require('iron.marks').clear_hl()<cr>", desc = "Clear Highlight" },
+  },
+  opts = function()
+    local python_cmd = vim.fn.executable("ipython") == 1 and { "ipython", "--no-autoindent" } or { "python3" }
+    local sh_cmd = vim.fn.executable("zsh") == 1 and { "zsh" } or { vim.env.SHELL or "bash" }
+
+    return {
+      config = {
+        scratch_repl = true,
+        repl_definition = {
+          sh = {
+            command = sh_cmd,
+            block_dividers = { "# %%" },
+          },
+          python = {
+            command = python_cmd,
+            format = function(lines, extras)
+              local result = require("iron.fts.common").bracketed_paste_python(lines, extras)
+              return vim.tbl_filter(function(line)
+                return not string.match(line, "^%s*#")
+              end, result)
+            end,
+            block_dividers = { "# %%", "#%%" },
+          },
+        },
+        repl_filetype = function(bufnr, ft)
+          return ft
+        end,
+        repl_open_cmd = "vertical split",
+      },
+      highlight = {
+        italic = true,
+      },
+      ignore_blank_lines = true,
+    }
+  end,
+  config = function(_, opts)
+    require("iron.core").setup(opts)
+    vim.keymap.set("t", "<esc>", "<C-\\><C-n>", { desc = "Exit terminal mode" })
+  end,
+}

--- a/pkgbuilds/omarchy-nvim/lua/plugins/iron.lua
+++ b/pkgbuilds/omarchy-nvim/lua/plugins/iron.lua
@@ -16,7 +16,6 @@ return {
     { "<leader>rsn", "<cmd>lua require('iron.core').send_code_block(true)<cr>", desc = "Send Code Block & Move Next" },
     { "<leader>rsm", "<cmd>lua require('iron.core').run_motion('send_motion')<cr>", desc = "Send Motion" },
     { "<leader>rs", "<cmd>lua require('iron.core').visual_send()<cr>", mode = "v", desc = "Send Selection" },
-    { "<leader>rsv", "<cmd>lua require('iron.core').visual_send()<cr>", mode = "v", desc = "Send Selection" },
     { "<leader>rm", desc = "+marks" },
     { "<leader>rmm", "<cmd>lua require('iron.core').run_motion('mark_motion')<cr>", desc = "Mark Motion" },
     { "<leader>rmv", "<cmd>lua require('iron.core').mark_visual()<cr>", mode = "v", desc = "Mark Visual" },
@@ -24,6 +23,7 @@ return {
     { "<leader>rmr", "<cmd>lua require('iron.core').send_mark()<cr>", desc = "Send Mark" },
     { "<leader>rq", "<cmd>lua require('iron.core').send(nil, string.char(03))<cr>", desc = "Interrupt REPL" },
     { "<leader>rx", "<cmd>lua require('iron.core').close_repl()<cr>", desc = "Exit REPL" },
+    { "<leader>rc", desc = "+clear" },
     { "<leader>rcc", "<cmd>lua require('iron.core').send(nil, string.char(12))<cr>", desc = "Clear REPL" },
     { "<leader>rcl", "<cmd>lua require('iron.marks').clear_hl()<cr>", desc = "Clear Highlight" },
   },
@@ -41,17 +41,15 @@ return {
           },
           python = {
             command = python_cmd,
-            format = function(lines, extras)
-              local result = require("iron.fts.common").bracketed_paste_python(lines, extras)
-              return vim.tbl_filter(function(line)
-                return not string.match(line, "^%s*#")
-              end, result)
-            end,
+            -- Python 3.13+ defaults to the auto-indenting PyREPL, which
+            -- re-indents pasted blocks and breaks them; force the basic REPL.
+            env = { PYTHON_BASIC_REPL = "1" },
+            format = require("iron.fts.common").bracketed_paste_python,
             block_dividers = { "# %%", "#%%" },
           },
         },
         repl_filetype = function(bufnr, ft)
-          return ft
+          return "iron"
         end,
         repl_open_cmd = "vertical split",
       },
@@ -63,6 +61,13 @@ return {
   end,
   config = function(_, opts)
     require("iron.core").setup(opts)
-    vim.keymap.set("t", "<esc>", "<C-\\><C-n>", { desc = "Exit terminal mode" })
+    -- Buffer-local to iron's REPL buffers only: a global terminal-mode <esc>
+    -- mapping would swallow Escape in every :terminal (TUIs, nested vim).
+    vim.api.nvim_create_autocmd("FileType", {
+      pattern = "iron",
+      callback = function(ev)
+        vim.keymap.set("t", "<esc>", "<C-\\><C-n>", { buffer = ev.buf, desc = "Exit terminal mode" })
+      end,
+    })
   end,
 }


### PR DESCRIPTION
### Summary

Adds [`iron.nvim`](https://github.com/Vigemus/iron.nvim) plugin configuration to the `omarchy-nvim` package to provide an out-of-the-box interactive REPL (supporting Python/IPython and Shell with `# %%` code cell blocks).

### Changes
* Added `pkgbuilds/omarchy-nvim/lua/plugins/iron.lua` with:
  * Dynamic fallbacks (`ipython` -> `python3`, `zsh` -> `$SHELL`/`bash`).
  * On-demand lazy loading via `cmd` and `keys`.
  * Which-key group descriptions under `<leader>r`.
  * Dedicated terminal mode escape mapping (`<Esc>` -> normal mode).

### Companion PR
* `basecamp/omarchy`: https://github.com/basecamp/omarchy/pull/7690