### PR TITLE
omamorph: add local media converter and compressor

### DIFF
--- a/pkgbuilds/omamorph/.omarchy/package.json
+++ b/pkgbuilds/omamorph/.omarchy/package.json
@@ -1,0 +1,3 @@
+{
+  "source": "local"
+}

--- a/pkgbuilds/omamorph/PKGBUILD
+++ b/pkgbuilds/omamorph/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: JoeJoeflyn <https://github.com/JoeJoeflyn>
 pkgname=omamorph
-pkgver=1.0.2
+pkgver=1.0.3
 pkgrel=1
 pkgdesc='Local media converter and compressor built with Qt Quick'
 arch=('x86_64')
@@ -13,7 +13,7 @@ optdepends=('libreoffice-still: PDF export for documents'
             'ghostscript: PDF compression support')
 makedepends=('gcc' 'make' 'qt6-base' 'qt6-declarative')
 source=("${pkgname}-${pkgver}.tar.gz::https://github.com/JoeJoeflyn/omamorph/archive/refs/tags/v${pkgver}.tar.gz")
-sha256sums=('ea42316ad0c9cb2247d2bf046e88b9020b037b4bd8bb89efebba0acd72147485')
+sha256sums=('b7f084977c0ddf7edf40733160b0f73f9a6dd4feca570bbdce712a722c283c7c')
 
 build() {
     cd "${pkgname}-${pkgver}"

--- a/pkgbuilds/omamorph/PKGBUILD
+++ b/pkgbuilds/omamorph/PKGBUILD
@@ -1,18 +1,19 @@
 # Maintainer: JoeJoeflyn <https://github.com/JoeJoeflyn>
 pkgname=omamorph
-pkgver=1.0.1
+pkgver=1.0.2
 pkgrel=1
-pkgdesc='Dead-simple universal converter and media compressor built with Qt Quick'
-arch=('x86_64' 'aarch64')
+pkgdesc='Local media converter and compressor built with Qt Quick'
+arch=('x86_64')
 url='https://github.com/JoeJoeflyn/omamorph'
 license=('MIT' 'OFL-1.1')
-depends=('ffmpeg' 'imagemagick' 'pandoc' 'qt6-base' 'qt6-declarative' 'xdg-desktop-portal')
+options=('!debug')
+depends=('ffmpeg' 'imagemagick' 'pandoc' 'qt6-base' 'qt6-declarative' 'xdg-desktop-portal' 'hicolor-icon-theme')
 optdepends=('libreoffice-still: PDF export for documents'
             'poppler: pdftotext support for PDF extraction'
             'ghostscript: PDF compression support')
 makedepends=('gcc' 'make' 'qt6-base' 'qt6-declarative')
 source=("${pkgname}-${pkgver}.tar.gz::https://github.com/JoeJoeflyn/omamorph/archive/refs/tags/v${pkgver}.tar.gz")
-sha256sums=('9459fc981dc7bd0cc29ec39a9c51d65322cf752204fa88d18099cb5b41ca3e12')
+sha256sums=('ea42316ad0c9cb2247d2bf046e88b9020b037b4bd8bb89efebba0acd72147485')
 
 build() {
     cd "${pkgname}-${pkgver}"

--- a/pkgbuilds/omamorph/PKGBUILD
+++ b/pkgbuilds/omamorph/PKGBUILD
@@ -1,0 +1,31 @@
+# Maintainer: JoeJoeflyn <https://github.com/JoeJoeflyn>
+pkgname=omamorph
+pkgver=1.0.1
+pkgrel=1
+pkgdesc='Dead-simple universal converter and media compressor built with Qt Quick'
+arch=('x86_64' 'aarch64')
+url='https://github.com/JoeJoeflyn/omamorph'
+license=('MIT' 'OFL-1.1')
+depends=('ffmpeg' 'imagemagick' 'pandoc' 'qt6-base' 'qt6-declarative' 'xdg-desktop-portal')
+optdepends=('libreoffice-still: PDF export for documents'
+            'poppler: pdftotext support for PDF extraction'
+            'ghostscript: PDF compression support')
+makedepends=('gcc' 'make' 'qt6-base' 'qt6-declarative')
+source=("${pkgname}-${pkgver}.tar.gz::https://github.com/JoeJoeflyn/omamorph/archive/refs/tags/v${pkgver}.tar.gz")
+sha256sums=('9459fc981dc7bd0cc29ec39a9c51d65322cf752204fa88d18099cb5b41ca3e12')
+
+build() {
+    cd "${pkgname}-${pkgver}"
+    mkdir -p build && cd build
+    qmake6 ../omaMorph.pro
+    make -j$(nproc)
+}
+
+package() {
+    cd "${pkgname}-${pkgver}"
+    install -Dm755 build/omaMorph "${pkgdir}/usr/bin/omaMorph"
+    install -Dm644 LICENSE "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"
+    install -Dm644 fonts/OFL.txt "${pkgdir}/usr/share/licenses/${pkgname}/OFL.txt"
+    install -Dm644 pkgbuild/omamorph.svg "${pkgdir}/usr/share/icons/hicolor/scalable/apps/omamorph.svg"
+    install -Dm644 pkgbuild/omamorph.desktop "${pkgdir}/usr/share/applications/omamorph.desktop"
+}

--- a/pkgbuilds/omamorph/PKGBUILD
+++ b/pkgbuilds/omamorph/PKGBUILD
@@ -1,14 +1,15 @@
 # Maintainer: JoeJoeflyn <https://github.com/JoeJoeflyn>
 pkgname=omamorph
 pkgver=1.0.3
-pkgrel=1
+pkgrel=2
 pkgdesc='Local media converter and compressor built with Qt Quick'
 arch=('x86_64')
 url='https://github.com/JoeJoeflyn/omamorph'
 license=('MIT' 'OFL-1.1')
 options=('!debug')
-depends=('ffmpeg' 'imagemagick' 'pandoc' 'qt6-base' 'qt6-declarative' 'xdg-desktop-portal' 'hicolor-icon-theme')
-optdepends=('libreoffice-still: PDF export for documents'
+depends=('ffmpeg' 'imagemagick' 'qt6-base' 'qt6-declarative' 'xdg-desktop-portal' 'hicolor-icon-theme')
+optdepends=('pandoc: document conversion (Markdown, HTML, DOCX)'
+            'libreoffice-still: PDF export for documents'
             'poppler: pdftotext support for PDF extraction'
             'ghostscript: PDF compression support')
 makedepends=('gcc' 'make' 'qt6-base' 'qt6-declarative')
@@ -24,9 +25,10 @@ build() {
 
 package() {
     cd "${pkgname}-${pkgver}"
-    install -Dm755 build/omaMorph "${pkgdir}/usr/bin/omaMorph"
+    install -Dm755 build/omaMorph "${pkgdir}/usr/bin/omamorph"
     install -Dm644 LICENSE "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"
     install -Dm644 fonts/OFL.txt "${pkgdir}/usr/share/licenses/${pkgname}/OFL.txt"
     install -Dm644 pkgbuild/omamorph.svg "${pkgdir}/usr/share/icons/hicolor/scalable/apps/omamorph.svg"
     install -Dm644 pkgbuild/omamorph.desktop "${pkgdir}/usr/share/applications/omamorph.desktop"
+    sed -i 's/Exec=omaMorph/Exec=omamorph/; s/StartupWMClass=omaMorph/StartupWMClass=omamorph/' "${pkgdir}/usr/share/applications/omamorph.desktop"
 }


### PR DESCRIPTION
### Summary
Adds the `omamorph` package recipe.

**omaMorph** is a local media converter and compressor for Omarchy (Video, Audio, Images, Documents).

**Repo**: https://github.com/JoeJoeflyn/omamorph