### PR TITLE
Add OpenVINO GenAI runtime package

### DIFF
--- a/pkgbuilds/openvino-genai/.omarchy/package.json
+++ b/pkgbuilds/openvino-genai/.omarchy/package.json
@@ -1,0 +1,3 @@
+{
+  "source": "local"
+}

--- a/pkgbuilds/openvino-genai/PKGBUILD
+++ b/pkgbuilds/openvino-genai/PKGBUILD
@@ -1,0 +1,78 @@
+# Maintainer: Spencer Bull <spencerbull2554@gmail.com>
+
+pkgname=openvino-genai
+pkgver=2026.3.0.0
+pkgrel=1
+pkgdesc="OpenVINO GenAI C and C++ runtime libraries"
+arch=('x86_64')
+url="https://github.com/openvinotoolkit/openvino.genai"
+license=('Apache-2.0')
+options=('!debug' '!lto')
+depends=(
+    'gcc-libs'
+    'glibc'
+    'onetbb'
+    'openvino=2026.3.0'
+)
+makedepends=(
+    'cmake'
+    'git'
+    'ninja'
+    'python'
+)
+optdepends=(
+    'openvino-intel-gpu-plugin: inference on Intel GPUs'
+    'openvino-intel-npu-plugin: inference on Intel NPUs'
+)
+
+_commit=bd8d6542e3ca1ac30042d5d8d4202ce00b5f4af0
+source=(
+    "openvino.genai::git+$url.git#commit=$_commit"
+    'gcc-16-char8_t.patch'
+)
+sha256sums=(
+    'SKIP'
+    '6e685c1e45d4b2314fd55e2f791846cc9086413ba62a6bb5e31be5a5878a243c'
+)
+
+prepare() {
+    cd openvino.genai
+    patch -Np1 -i "$srcdir/gcc-16-char8_t.patch"
+    git submodule update --init --recursive
+}
+
+build() {
+    CFLAGS+=" -ffile-prefix-map=$srcdir=/usr/src/$pkgname"
+    CXXFLAGS+=" -ffile-prefix-map=$srcdir=/usr/src/$pkgname"
+
+    cmake -S openvino.genai -B build -G Ninja \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_INSTALL_PREFIX=/usr \
+        -DCMAKE_SKIP_RPATH=ON \
+        -DENABLE_JS=OFF \
+        -DENABLE_MISAKI_CPP=OFF \
+        -DENABLE_PYTHON=OFF \
+        -DENABLE_SAMPLES=OFF \
+        -DENABLE_TESTS=OFF \
+        -DENABLE_TOOLS=OFF \
+        -DENABLE_XGRAMMAR=OFF
+
+    cmake --build build
+}
+
+package() {
+    install -d "$pkgdir/usr/lib" "$pkgdir/usr/share/licenses/$pkgname"
+
+    cp -a build/openvino_genai/libopenvino_genai.so* "$pkgdir/usr/lib/"
+    cp -a build/openvino_genai/libopenvino_tokenizers.so* "$pkgdir/usr/lib/"
+    cp -a build/src/c/libopenvino_genai_c.so* "$pkgdir/usr/lib/"
+
+    install -Dm644 openvino.genai/LICENSE \
+        "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+    install -Dm644 openvino.genai/third-party-programs.txt \
+        "$pkgdir/usr/share/licenses/$pkgname/third-party-programs.txt"
+    install -Dm644 openvino.genai/thirdparty/openvino_tokenizers/LICENSE \
+        "$pkgdir/usr/share/licenses/$pkgname/openvino-tokenizers-LICENSE"
+    install -Dm644 openvino.genai/thirdparty/openvino_tokenizers/third-party-programs.txt \
+        "$pkgdir/usr/share/licenses/$pkgname/openvino-tokenizers-third-party-programs.txt"
+}

--- a/pkgbuilds/openvino-genai/gcc-16-char8_t.patch
+++ b/pkgbuilds/openvino-genai/gcc-16-char8_t.patch
@@ -1,0 +1,7 @@
+diff --git a/src/cpp/src/whisper/word_level_timestamps.cpp b/src/cpp/src/whisper/word_level_timestamps.cpp
+index 7b3da124..d1f9212f 100644
+--- a/src/cpp/src/whisper/word_level_timestamps.cpp
++++ b/src/cpp/src/whisper/word_level_timestamps.cpp
+@@ -327 +327 @@ std::pair<std::vector<std::string>, std::vector<std::vector<int64_t>>> split_toke
+-    const std::string replacement_char = u8"\uFFFD";
++    const std::string replacement_char = "\xEF\xBF\xBD";


### PR DESCRIPTION
## Summary

- add a release-pinned OpenVINO GenAI 2026.3.0.0 native runtime package
- ship `libopenvino_genai_c.so`, `libopenvino_genai.so`, and `libopenvino_tokenizers.so`
- link against Arch's `openvino=2026.3.0` and `onetbb` packages
- keep Intel GPU and NPU plugins optional instead of bundling their driver stacks
- carry a narrow GCC 16 compatibility patch for a `char8_t` conversion rejected by the current toolchain

## Motivation

Intel's OpenVINO GenAI Rust bindings with runtime linking require `libopenvino_genai_c.so`. Arch packages core OpenVINO and its device plugins, but not this native GenAI C API.

This provides a clean system-package dependency for consumers such as https://github.com/peteonrails/voxtype/pull/592 without packaging or changing Voxtype here.

## Verification

- `./bin/build --package openvino-genai`
- built `openvino-genai 2026.3.0.0-1` successfully (one built, zero failed)
- archive contains only the three runtime libraries, their symlinks, and license files under `/usr`
- ELF dependencies resolve against Arch OpenVINO/oneTBB and contain no build RPATH
- archive contains no bundled OpenVINO core library and no temporary build path
- no package was installed on the host; live NPU inference remains a downstream integration check
