### PR TITLE
Package automatic brightness service

### DIFF
--- a/pkgbuilds/omarchy-settings-dev/PKGBUILD
+++ b/pkgbuilds/omarchy-settings-dev/PKGBUILD
@@ -157,6 +157,7 @@ package() {
   install -Dm644 default/xdg-terminal-exec/hyprland-xdg-terminals.list "$pkgdir/usr/share/xdg-terminal-exec/hyprland-xdg-terminals.list"
   install -Dm644 default/applications/mimeapps.list "$pkgdir/usr/share/applications/mimeapps.list"
   install -Dm644 default/systemd/user/bt-agent.service "$pkgdir/usr/lib/systemd/user/bt-agent.service"
+  install -Dm644 default/systemd/user/omarchy-brightness-auto.service "$pkgdir/usr/lib/systemd/user/omarchy-brightness-auto.service"
   install -Dm644 default/systemd/user/omarchy-sleep-lock.service "$pkgdir/usr/lib/systemd/user/omarchy-sleep-lock.service"
   install -Dm644 default/systemd/user/omarchy-recover-internal-monitor.service "$pkgdir/usr/lib/systemd/user/omarchy-recover-internal-monitor.service"
   install -Dm644 default/systemd/user/omarchy-migrate-notify.service "$pkgdir/usr/lib/systemd/user/omarchy-migrate-notify.service"


### PR DESCRIPTION
## Changes

- Install `omarchy-brightness-auto.service` in `omarchy-settings-dev`.
- Keep the stable package unchanged because its pinned Omarchy source does not include the service yet.

Companion to [basecamp/omarchy#8025](https://github.com/basecamp/omarchy/pull/8025).

## Development

OpenAI GPT-5.6 Sol wrote the code at xhigh reasoning effort under my supervision.

## Testing

- `bash -n pkgbuilds/omarchy-settings/PKGBUILD pkgbuilds/omarchy-settings-dev/PKGBUILD`
- Ran Omarchy `./test/all` (191 test files) with `OMARCHY_PKGS_PATH` pointing to this branch.
