### PR TITLE
Add omazed to fast release ring

### DIFF
--- a/pkgbuilds/omazed/.omarchy/package.json
+++ b/pkgbuilds/omazed/.omarchy/package.json
@@ -1,4 +1,5 @@
 {
   "source": "aur",
+  "release_ring": "fast",
   "upstream_commit": "8ca767b734d455000b37919c2aa71038b9a04290"
 }


### PR DESCRIPTION
Changes in the theme file position and the palette in Omarchy quattro broke omazed on release. And while I did push a fix on August 15 hoping that it would be picked up by the OPR soon I didn't realize that it would be stuck on edge for so long. 
Considering the nature of the package I think it would make sense to put omazed on the fast release ring, which is what this pr does. But I would request to at least migrate version 2.1.0-2 to stable so that the fix can reach everyone. 