### PR TITLE
Install the omarchy(1) man page

### DIFF
--- a/pkgbuilds/omarchy/PKGBUILD
+++ b/pkgbuilds/omarchy/PKGBUILD
@@ -145,4 +145,9 @@ package() {
 
   # Runtime version file.
   install -Dm644 version "$pkgdir/usr/share/omarchy/version"
+
+  # omarchy(1) man page. Generated from `omarchy commands --all --json` by
+  # tools/man-gen in the source repo — see that tool's README for how to
+  # regenerate it. Not built here; installed as committed at _commit.
+  install -Dm644 man/man1/omarchy.1 "$pkgdir/usr/share/man/man1/omarchy.1"
 }


### PR DESCRIPTION
# PR mot omacom-io/omarchy-pkgs (branch: man-page-install)

## Tittel
Install the omarchy(1) man page

## Beskrivelse

Companion to basecamp/omarchy#8064: that PR generates `man/man1/omarchy.1`
in the source repo (see its `tools/man-gen/`). This just installs the
already-generated file to the standard path:

```
install -Dm644 man/man1/omarchy.1 "$pkgdir/usr/share/man/man1/omarchy.1"
```

Nothing is built here — the man page ships as committed in the source tree
at whatever `_commit` this PKGBUILD points at.

### Sequencing

This will fail to build against the current `_commit` (`286b8c2b...`), since
that predates the man page existing in the source repo. This only needs to
land — or just be bumped in — once `_commit` here is updated to a commit
that includes `man/man1/omarchy.1`. Flagging this so it doesn't get merged
and immediately break a build; happy to hold this until after the other PR
merges and a release is cut, whatever's easiest for you.
