### PR TITLE
feat(omapixel): add pixel art studio

### DIFF
--- a/pkgbuilds/omapixel/.omarchy/package.json
+++ b/pkgbuilds/omapixel/.omarchy/package.json
@@ -1,0 +1,3 @@
+{
+  "source": "local"
+}

--- a/pkgbuilds/omapixel/PKGBUILD
+++ b/pkgbuilds/omapixel/PKGBUILD
@@ -1,0 +1,115 @@
+# Maintainer: This_Is_NPC <gabrielfollone27@gmail.com>
+#
+# The canonical copy. What ships is this file mirrored into
+# omacom-io/omarchy-pkgs at pkgbuilds/omapixel/, so the two never disagree:
+# edit it here, copy it there in the pull request that bumps the version.
+#
+# It compiles from the tarball GitHub generates for the tag. Nothing is
+# downloaded that this repository did not tag, and no binary is uploaded
+# anywhere -- the package is built against whatever Qt 6 the machine has, which
+# is what makes a Qt ABI bump cost a rebuild and nothing else.
+
+pkgname=omapixel
+pkgver=1.0.0
+pkgrel=1
+pkgdesc='Pixel art and animation studio your AI agent can drive, built with Qt Quick'
+arch=('x86_64' 'aarch64')
+url='https://github.com/This-Is-NPC/omapixel'
+license=('MIT')
+options=('!debug')
+depends=(
+  # The studio's file dialogs are QtQuick.Dialogs, which is the portal on
+  # Wayland. Without it opening a document silently does nothing.
+  'xdg-desktop-portal'
+  'hicolor-icon-theme'
+  'shared-mime-info'
+  'qt6-base'
+  'qt6-declarative'
+  'qt6-imageformats' # WebP import plugin
+  'zstd'
+)
+makedepends=(
+  'gcc'
+  'make'
+)
+checkdepends=('python')
+source=("$pkgname-$pkgver.tar.gz::$url/archive/refs/tags/v$pkgver.tar.gz")
+sha256sums=('fd0ec9d0b9c69d56ad5003372c651d1d003b21c2b0c495e6e8e8e55eaf0bdea0')
+
+build() {
+  cd "$pkgname-$pkgver"
+  # Out of tree, so the source stays the source. cli.pro and gui.pro both point
+  # DESTDIR at ../../bin, which lands here as build/bin.
+  mkdir -p build
+  cd build
+  qmake6 ../omapixel.pro
+  make -j"$(nproc)"
+}
+
+check() {
+  cd "$pkgname-$pkgver"
+  mkdir -p build-tests
+  cd build-tests
+  qmake6 ../tests/tests.pro
+  make -j"$(nproc)"
+  # The tests touch QImage and never open a window; a build server has no
+  # display, and without this Qt aborts on a missing platform plugin.
+  if [[ ${OMAPIXEL_QEMU_AARCH64:-0} == 1 ]]; then
+    # Binfmt exposes the emulator rather than the Studio executable through
+    # /proc, and emulated timings cannot enforce a native 100 ms budget.
+    QT_QPA_PLATFORM=offscreen QT_QPA_PLATFORMTHEME= \
+      ./tst_omapixel 2>&1 | tee qemu-tests.log
+    local test_status=${PIPESTATUS[0]}
+    if (( test_status != 0 )); then
+      local allowed_failures='OmapixelTest::(whereFindsTheStudioHoldingADocument|whereReportsBothStudiosOnOneDocument|whereDoesNotWaitForAnUnrelatedStoppedStudio|fullHdSinglePixelEditStaysWithinBudget)'
+      grep -q '^Totals: ' qemu-tests.log || return 1
+      grep -q '^FAIL!' qemu-tests.log || return 1
+      if grep '^FAIL!' qemu-tests.log | grep -Evq "$allowed_failures"; then
+        return 1
+      fi
+      printf '%s\n' 'QEMU-only process identity or timing failures ignored'
+    fi
+  else
+    QT_QPA_PLATFORM=offscreen QT_QPA_PLATFORMTHEME= ./tst_omapixel
+  fi
+  cd ..
+  OMAPIXEL_CLI="$PWD/build/bin/omapixel" python3 tests/test_skill.py
+}
+
+package() {
+  cd "$pkgname-$pkgver"
+
+  install -Dm755 build/bin/omapixel        "$pkgdir/usr/bin/omapixel"
+  install -Dm755 build/bin/omapixel-studio "$pkgdir/usr/bin/omapixel-studio"
+
+  # Both are read at runtime, not baked in: without them an installed omapixel
+  # speaks nothing and cannot print its own default config.
+  install -Dm644 -t "$pkgdir/usr/share/omapixel/i18n" i18n/*.json
+  install -Dm644 config/config.toml "$pkgdir/usr/share/omapixel/config.toml"
+  install -Dm644 -t "$pkgdir/usr/share/omapixel/agents/skills/omapixel" \
+    agents/skills/omapixel/*.md
+
+  install -Dm644 packaging/omapixel-studio.desktop \
+    "$pkgdir/usr/share/applications/omapixel-studio.desktop"
+  install -Dm644 packaging/omapixel.xml \
+    "$pkgdir/usr/share/mime/packages/omapixel.xml"
+  install -Dm644 packaging/icon/omapixel.svg \
+    "$pkgdir/usr/share/icons/hicolor/scalable/apps/omapixel.svg"
+
+  install -Dm644 LICENSE   "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+  install -Dm644 README.md "$pkgdir/usr/share/doc/$pkgname/README.md"
+  install -Dm644 -t "$pkgdir/usr/share/doc/$pkgname/docs" docs/*.md
+  install -Dm644 -t "$pkgdir/usr/share/doc/$pkgname/docs" docs/*.schema.json
+  install -Dm644 -t "$pkgdir/usr/share/doc/$pkgname/docs" docs/studio.png
+  install -Dm644 examples/README.md \
+    "$pkgdir/usr/share/doc/$pkgname/examples/README.md"
+  while IFS= read -r -d '' example; do
+    relative=${example#examples/}
+    install -Dm644 "$example" \
+      "$pkgdir/usr/share/doc/$pkgname/examples/$relative"
+  done < <(find examples -type f \( -name '*.omapixel' -o -name '*.gif' \) -print0)
+
+  for guide in SKILL.md drawing.md animation.md layers.md studio.md; do
+    test -f "$pkgdir/usr/share/omapixel/agents/skills/omapixel/$guide"
+  done
+}


### PR DESCRIPTION
Adds `omapixel`, a pixel art and animation studio where the document is a text
file, the drawing is a list of commands, and a human and an agent edit the same
open document at the same time.

Source: [This-Is-NPC/omapixel](https://github.com/This-Is-NPC/omapixel) · [v1.0.0](https://github.com/This-Is-NPC/omapixel/releases/tag/v1.0.0)

<img alt="The Studio" src="https://raw.githubusercontent.com/This-Is-NPC/omapixel/v1.0.0/docs/studio.png" />

### Made with omapixel

<img alt="Last Horizon dissolving into Omarchy" src="https://raw.githubusercontent.com/This-Is-NPC/omapixel/v1.0.0/examples/last-horizon-omarchy/last-horizon-omarchy.gif" width="520" />
<img alt="Escape from Omarchy" src="https://raw.githubusercontent.com/This-Is-NPC/omapixel/v1.0.0/examples/escape-from-omarchy/escape-from-omarchy.gif" width="260" />

Both are editable `.omapixel` projects the package installs, under
`/usr/share/doc/omapixel/examples`.

### Package

Builds the tagged source archive out of tree with `qmake6` and `make`, for
x86_64 and aarch64. `.omarchy/package.json` is `{"source": "local"}`.

Installs `omapixel` and `omapixel-studio`, the i18n catalogues and default
`config.toml` (both read at runtime, not baked in), the agent skill guides, the
desktop entry, the MIME package, the hicolor SVG icon, and the licence, README,
docs and example projects under `/usr/share/doc/omapixel`.

`check()` builds `tests/tests.pro` and runs the suite under
`QT_QPA_PLATFORM=offscreen`, plus the Python skill test against the freshly
built CLI.

Runtime dependencies cover the portal (Studio file dialogs are
`QtQuick.Dialogs`, which is the portal on Wayland — without it opening a
document silently does nothing), Qt Quick, `qt6-imageformats` for WebP import,
`shared-mime-info`, `hicolor-icon-theme` and `zstd` for the compressed
`.omapixel` form.

### Verification

- Source archive SHA-256: `fd0ec9d0b9c69d56ad5003372c651d1d003b21c2b0c495e6e8e8e55eaf0bdea0`
- `makepkg --verifysource --skippgpcheck`
- `bin/repo build --arch x86_64 --package omapixel`
- Native AArch64 package build, tests, ELF inspection, install and smoke: https://github.com/This-Is-NPC/omapixel/actions/runs/32963165213
