### PR TITLE
Fix Copilot platform payload cleanup

### DIFF
--- a/pkgbuilds/github-copilot-cli/.omarchy/patches/0001-fix-platform-payload-cleanup.patch
+++ b/pkgbuilds/github-copilot-cli/.omarchy/patches/0001-fix-platform-payload-cleanup.patch
@@ -1,0 +1,6 @@
+diff --git a/PKGBUILD b/PKGBUILD
+index 9194cc8..b38f3e9 100644
+--- a/PKGBUILD
++++ b/PKGBUILD
+@@ -52,0 +53 @@ package() {
++	_moddir="${_moddir}/node_modules/@github/copilot-linux-${_arch}"

--- a/pkgbuilds/github-copilot-cli/PKGBUILD
+++ b/pkgbuilds/github-copilot-cli/PKGBUILD
@@ -7,7 +7,7 @@ pkgname=github-copilot-cli
 _pkgexec=copilot
 
 pkgver=1.0.80
-pkgrel=1
+pkgrel=1.1
 
 pkgdesc="GitHub Copilot CLI brings the power of Copilot coding agent directly to your terminal."
 
@@ -50,6 +50,7 @@ package() {
 		aarch64) _arch="arm64" ;;
 		*)       error "Unsupported architecture: $CARCH"; exit 1 ;;
 	esac
+	_moddir="${_moddir}/node_modules/@github/copilot-linux-${_arch}"
 
 	msg2 "Cleaning non-native prebuilds for ${_arch}"
 	if [ -d "${_moddir}/prebuilds" ]; then


### PR DESCRIPTION
This fixes the dead cleanup block identified in #195. `_moddir` currently points at the package root, while the prebuild and platform payloads being pruned live under `node_modules/@github/copilot-linux-${_arch}`. Pointing `_moddir` at that actual payload root makes the existing cleanup operations effective.

The change is kept separate from #195 as requested there: it does not alter `arch=()`. If #195 lands first, this branch will need a small rebase because both changes touch the same PKGBUILD and carry separate durable AUR patches.

Verification:
- built `github-copilot-cli` 1.0.80-1.1 successfully in `archlinux:base-devel`
- confirmed the package contains no Darwin, Windows, or ARM64 platform payloads on the x86_64 build
- ran the staged CLI and confirmed version 1.0.80
- replayed the pinned AUR source through `bin/package-worktree`; `patched/` matches `current/`
- separately confirmed the overlay applies to the pinned raw recipe with `patch --dry-run --fuzz=0`
- passed `omarchy-pkgs self-test`, `omarchy-release self-test`, and package-scoped edge and stable release dry-runs in the Arch environment