### PR TITLE
Add linux-aarch64 kernel compatibility shim

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,9 +25,16 @@ jobs:
             -w /workspace \
             archlinux:base-devel bash -lc '
               set -euo pipefail
-              pacman -Syu --noconfirm git jq
+              pacman -Syu --noconfirm git jq python-yaml xz zstd
               ./bin/sync-upstream self-test
               ./bin/sync-rebuilds --self-test
               ./bin/omarchy-pkgs self-test
               ./bin/omarchy-release self-test
+              shopt -s nullglob
+              for test in pkgbuilds/*/test.sh; do
+                bash "$test"
+              done
+              if [[ -d test ]]; then
+                runuser -u nobody -- python -m unittest discover -s test -v
+              fi
             '

--- a/pkgbuilds/linux-aarch64-pkgbase-shim/.omarchy/package.json
+++ b/pkgbuilds/linux-aarch64-pkgbase-shim/.omarchy/package.json
@@ -1,0 +1,3 @@
+{
+  "source": "local"
+}

--- a/pkgbuilds/linux-aarch64-pkgbase-shim/85-linux-aarch64-pkgbase-shim.hook
+++ b/pkgbuilds/linux-aarch64-pkgbase-shim/85-linux-aarch64-pkgbase-shim.hook
@@ -1,0 +1,20 @@
+# Ordered before 90-mkinitcpio-install (limine-mkinitcpio-hook's override of
+# it included) so the pkgbase and vmlinuz it writes are there when that hook
+# globs usr/lib/modules/*/pkgbase.
+[Trigger]
+Type = Path
+Operation = Install
+Operation = Upgrade
+Target = usr/lib/modules/*/
+
+[Trigger]
+Type = Package
+Operation = Install
+Operation = Upgrade
+Target = linux-aarch64-pkgbase-shim
+
+[Action]
+Description = Writing pkgbase and vmlinuz for Arch Linux ARM kernels...
+When = PostTransaction
+Exec = /usr/share/libalpm/scripts/linux-aarch64-pkgbase-shim
+NeedsTargets

--- a/pkgbuilds/linux-aarch64-pkgbase-shim/85-linux-aarch64-pkgbase-shim.hook
+++ b/pkgbuilds/linux-aarch64-pkgbase-shim/85-linux-aarch64-pkgbase-shim.hook
@@ -1,6 +1,4 @@
-# Ordered before 90-mkinitcpio-install (limine-mkinitcpio-hook's override of
-# it included) so the pkgbase and vmlinuz it writes are there when that hook
-# globs usr/lib/modules/*/pkgbase.
+# Run before mkinitcpio and Limine discover installed kernels.
 [Trigger]
 Type = Path
 Operation = Install

--- a/pkgbuilds/linux-aarch64-pkgbase-shim/85-linux-aarch64-pkgbase-shim.hook
+++ b/pkgbuilds/linux-aarch64-pkgbase-shim/85-linux-aarch64-pkgbase-shim.hook
@@ -3,6 +3,7 @@
 Type = Path
 Operation = Install
 Operation = Upgrade
+Operation = Remove
 Target = usr/lib/modules/*/
 
 [Trigger]

--- a/pkgbuilds/linux-aarch64-pkgbase-shim/PKGBUILD
+++ b/pkgbuilds/linux-aarch64-pkgbase-shim/PKGBUILD
@@ -1,0 +1,35 @@
+# Maintainer: Jimmy Van Veen
+
+# Arch Linux ARM's kernel packages install the kernel as /boot/Image and ship
+# no usr/lib/modules/<ver>/{pkgbase,vmlinuz}, the two files mkinitcpio and
+# limine-entry-tool find kernels through. Without them an installed aarch64
+# Omarchy never gets an initramfs, a UKI or a Limine entry for a new kernel.
+# This package is a pacman hook that writes both files before mkinitcpio's
+# 90-mkinitcpio-install hook runs. It does nothing when pkgbase exists.
+#
+# RETIRE when Arch Linux ARM's linux-aarch64 ships pkgbase and vmlinuz itself
+# (archlinuxarm/PKGBUILDs#2215 or its successor), together with
+# limine-mkinitcpio-hook's 0002-accept-pkgbase-in-package-owned-kernel-dir.patch.
+
+pkgname=linux-aarch64-pkgbase-shim
+pkgver=1
+pkgrel=1
+pkgdesc="Writes usr/lib/modules/<ver>/{pkgbase,vmlinuz} for Arch Linux ARM kernels so mkinitcpio and Limine hooks find them"
+arch=('aarch64')
+url="https://github.com/omacom-io/omarchy-pkgs"
+license=('MIT')
+depends=('bash' 'pacman')
+optdepends=('limine-mkinitcpio-hook: rebuild the UKI and Limine entry when the shim is installed after the kernel')
+options=('!debug')
+source=(
+  '85-linux-aarch64-pkgbase-shim.hook'
+  'linux-aarch64-pkgbase-shim'
+  'README.package.md'
+)
+sha256sums=('SKIP' 'SKIP' 'SKIP')
+
+package() {
+  install -Dm644 85-linux-aarch64-pkgbase-shim.hook "${pkgdir}/usr/share/libalpm/hooks/85-linux-aarch64-pkgbase-shim.hook"
+  install -Dm755 linux-aarch64-pkgbase-shim "${pkgdir}/usr/share/libalpm/scripts/linux-aarch64-pkgbase-shim"
+  install -Dm644 README.package.md "${pkgdir}/usr/share/doc/${pkgname}/README.md"
+}

--- a/pkgbuilds/linux-aarch64-pkgbase-shim/PKGBUILD
+++ b/pkgbuilds/linux-aarch64-pkgbase-shim/PKGBUILD
@@ -13,7 +13,7 @@
 
 pkgname=linux-aarch64-pkgbase-shim
 pkgver=1
-pkgrel=1
+pkgrel=2
 pkgdesc="Writes usr/lib/modules/<ver>/{pkgbase,vmlinuz} for Arch Linux ARM kernels so mkinitcpio and Limine hooks find them"
 arch=('aarch64')
 url="https://github.com/omacom-io/omarchy-pkgs"

--- a/pkgbuilds/linux-aarch64-pkgbase-shim/PKGBUILD
+++ b/pkgbuilds/linux-aarch64-pkgbase-shim/PKGBUILD
@@ -1,15 +1,6 @@
 # Maintainer: Jimmy Van Veen
 
-# Arch Linux ARM's kernel packages install the kernel as /boot/Image and ship
-# no usr/lib/modules/<ver>/{pkgbase,vmlinuz}, the two files mkinitcpio and
-# limine-entry-tool find kernels through. Without them an installed aarch64
-# Omarchy never gets an initramfs, a UKI or a Limine entry for a new kernel.
-# This package is a pacman hook that writes both files before mkinitcpio's
-# 90-mkinitcpio-install hook runs. It does nothing when pkgbase exists.
-#
-# RETIRE when Arch Linux ARM's linux-aarch64 ships pkgbase and vmlinuz itself
-# (archlinuxarm/PKGBUILDs#2215 or its successor), together with
-# limine-mkinitcpio-hook's 0002-accept-pkgbase-in-package-owned-kernel-dir.patch.
+# Add kernel metadata required by mkinitcpio and Limine on Arch Linux ARM.
 
 pkgname=linux-aarch64-pkgbase-shim
 pkgver=1

--- a/pkgbuilds/linux-aarch64-pkgbase-shim/PKGBUILD
+++ b/pkgbuilds/linux-aarch64-pkgbase-shim/PKGBUILD
@@ -4,12 +4,12 @@
 
 pkgname=linux-aarch64-pkgbase-shim
 pkgver=1
-pkgrel=2
+pkgrel=3
 pkgdesc="Writes usr/lib/modules/<ver>/{pkgbase,vmlinuz} for Arch Linux ARM kernels so mkinitcpio and Limine hooks find them"
 arch=('aarch64')
-url="https://github.com/omacom-io/omarchy-pkgs"
+url="https://github.com/omacom/omarchy-pkgs"
 license=('MIT')
-depends=('bash' 'pacman')
+depends=('bash' 'diffutils' 'pacman')
 optdepends=('limine-mkinitcpio-hook: rebuild the UKI and Limine entry when the shim is installed after the kernel')
 options=('!debug')
 source=(

--- a/pkgbuilds/linux-aarch64-pkgbase-shim/README.package.md
+++ b/pkgbuilds/linux-aarch64-pkgbase-shim/README.package.md
@@ -1,0 +1,32 @@
+# linux-aarch64-pkgbase-shim
+
+Arch Linux ARM's kernel packages install the kernel as `/boot/Image` and ship
+no `usr/lib/modules/<ver>/pkgbase` or `usr/lib/modules/<ver>/vmlinuz`.
+mkinitcpio's and limine-entry-tool's pacman hooks find kernels through those
+two files, so on an Arch Linux ARM system nothing builds an initramfs or UKI,
+and nothing writes a Limine entry, when a kernel is installed or upgraded.
+
+This package is one pacman hook. After a kernel package is installed or
+upgraded (`usr/lib/modules/*/`), and when the shim itself is installed, it
+writes into every package-owned modules directory that lacks `pkgbase`:
+
+- `pkgbase`: the name of the package that owns the directory
+- `vmlinuz`: a copy of `/boot/Image` (the owner must own that too)
+
+It runs as `85-`, before `90-mkinitcpio-install`, so the usual hook then builds
+the initramfs/UKI and the Limine entry. If that hook would not run in the same
+transaction (the shim installed after the kernel, or a kernel package that
+does not touch `usr/lib/initcpio/`), the script runs
+`limine-mkinitcpio-install` itself. Leftover directories of removed kernels
+that hold nothing but these two files are cleaned up.
+
+`limine-mkinitcpio-hook` needs its carried
+`0002-accept-pkgbase-in-package-owned-kernel-dir.patch` to accept a `pkgbase`
+that no package owns.
+
+## Retirement
+
+Delete this package, and the limine-mkinitcpio-hook patch above, when Arch
+Linux ARM's `linux-aarch64` ships `pkgbase` and `vmlinuz` itself
+(archlinuxarm/PKGBUILDs#2215 or its successor). A directory that already has
+`pkgbase` is never touched, so the two can coexist during the transition.

--- a/pkgbuilds/linux-aarch64-pkgbase-shim/README.package.md
+++ b/pkgbuilds/linux-aarch64-pkgbase-shim/README.package.md
@@ -1,16 +1,14 @@
 # linux-aarch64-pkgbase-shim
 
-Arch Linux ARM's kernel packages install the kernel as `/boot/Image` and ship
-no `usr/lib/modules/<ver>/pkgbase` or `usr/lib/modules/<ver>/vmlinuz`.
-mkinitcpio's and limine-entry-tool's pacman hooks find kernels through those
-two files, so on an Arch Linux ARM system nothing builds an initramfs or UKI,
-and nothing writes a Limine entry, when a kernel is installed or upgraded.
+Arch Linux ARM installs its kernel as `/boot/Image` instead of
+`usr/lib/modules/<ver>/vmlinuz`. Limine discovers the kernel through
+`modules.builtin`, but needs `vmlinuz` beside it to build a boot entry.
 
 This package is one pacman hook. After a kernel package is installed or
 upgraded (`usr/lib/modules/*/`), and when the shim itself is installed, it
 writes into every package-owned modules directory that lacks `pkgbase`:
 
-- `pkgbase`: the name of the package that owns the directory
+- `pkgbase`: compatibility metadata naming the package that owns the directory
 - `vmlinuz`: a copy of `/boot/Image` (the owner must own that too)
 
 It runs as `85-`, before `90-mkinitcpio-install`, so the usual hook then builds
@@ -20,13 +18,8 @@ does not touch `usr/lib/initcpio/`), the script runs
 `limine-mkinitcpio-install` itself. Leftover directories of removed kernels
 that hold nothing but these two files are cleaned up.
 
-`limine-mkinitcpio-hook` needs its carried
-`0002-accept-pkgbase-in-package-owned-kernel-dir.patch` to accept a `pkgbase`
-that no package owns.
-
 ## Retirement
 
-Delete this package, and the limine-mkinitcpio-hook patch above, when Arch
-Linux ARM's `linux-aarch64` ships `pkgbase` and `vmlinuz` itself
-(archlinuxarm/PKGBUILDs#2215 or its successor). A directory that already has
-`pkgbase` is never touched, so the two can coexist during the transition.
+Delete this package when `linux-aarch64` ships `vmlinuz` in its kernel module
+directory. Existing metadata is never modified, so both approaches can coexist
+during the transition.

--- a/pkgbuilds/linux-aarch64-pkgbase-shim/README.package.md
+++ b/pkgbuilds/linux-aarch64-pkgbase-shim/README.package.md
@@ -6,10 +6,13 @@ Arch Linux ARM installs its kernel as `/boot/Image` instead of
 
 This package is one pacman hook. After a kernel package is installed or
 upgraded (`usr/lib/modules/*/`), and when the shim itself is installed, it
-writes into every package-owned modules directory that lacks `pkgbase`:
+writes into each package-owned modules directory without native kernel metadata:
 
 - `pkgbase`: compatibility metadata naming the package that owns the directory
 - `vmlinuz`: a copy of `/boot/Image` (the owner must own that too)
+
+Reinstalling a kernel refreshes the shim's copy when the image changes, even
+if the module-directory version is unchanged. Package-owned files are preserved.
 
 It runs as `85-`, before `90-mkinitcpio-install`, so the usual hook then builds
 the initramfs/UKI and the Limine entry. If that hook would not run in the same
@@ -21,5 +24,5 @@ that hold nothing but these two files are cleaned up.
 ## Retirement
 
 Delete this package when `linux-aarch64` ships `vmlinuz` in its kernel module
-directory. Existing metadata is never modified, so both approaches can coexist
+directory. Package-owned metadata is never modified, so both approaches can coexist
 during the transition.

--- a/pkgbuilds/linux-aarch64-pkgbase-shim/linux-aarch64-pkgbase-shim
+++ b/pkgbuilds/linux-aarch64-pkgbase-shim/linux-aarch64-pkgbase-shim
@@ -86,6 +86,14 @@ for dir in /usr/lib/modules/*/; do
 	rm -f "$dir/pkgbase" "$dir/vmlinuz" && rmdir "$dir" && echo "$SELF: removed leftover $dir"
 done
 
+# Omarchy's installer defers boot-image builds by pointing this hook at
+# /dev/null and runs limine-update itself afterwards; honour that.
+deferred_hook=/etc/pacman.d/hooks/90-mkinitcpio-install.hook
+if ((rebuild)) && [[ -L $deferred_hook && $(readlink "$deferred_hook") == /dev/null ]]; then
+	echo "$SELF: $deferred_hook is masked, leaving the rebuild to limine-update"
+	rebuild=0
+fi
+
 if ((rebuild)); then
 	if [[ -x $LIMINE_INSTALL_SCRIPT ]]; then
 		echo rebuild | "$LIMINE_INSTALL_SCRIPT"

--- a/pkgbuilds/linux-aarch64-pkgbase-shim/linux-aarch64-pkgbase-shim
+++ b/pkgbuilds/linux-aarch64-pkgbase-shim/linux-aarch64-pkgbase-shim
@@ -1,16 +1,5 @@
 #!/usr/bin/env bash
-# linux-aarch64-pkgbase-shim -- pacman PostTransaction hook script.
-#
-# Arch Linux ARM's kernel packages install the kernel as /boot/Image and ship
-# no usr/lib/modules/<ver>/{pkgbase,vmlinuz}. mkinitcpio and limine-entry-tool
-# find kernels through exactly those two files, so on Arch Linux ARM neither
-# builds an initramfs/UKI nor writes a Limine entry for a new kernel. This
-# script writes both files into the package-owned modules directory. It runs
-# before 90-mkinitcpio-install (hook name 85-), which then builds as usual.
-#
-# RETIRE when Arch Linux ARM's linux-aarch64 ships pkgbase and vmlinuz itself
-# (archlinuxarm/PKGBUILDs#2215 or its successor): a directory that already
-# has pkgbase is left alone, so the package can simply be removed.
+# Supply pkgbase and vmlinuz metadata missing from Arch Linux ARM kernels.
 set -u
 
 readonly SELF=linux-aarch64-pkgbase-shim
@@ -26,8 +15,7 @@ owner_of() {
 	pacman -Qqo "$1" 2>/dev/null
 }
 
-# Targets arrive on stdin (NeedsTargets). Read all of them: stopping early
-# makes pacman report a broken pipe.
+# NeedsTargets requires consuming every line from stdin.
 while IFS= read -r line; do
 	case $line in
 	usr/lib/modules/*)
@@ -42,7 +30,7 @@ while IFS= read -r line; do
 	esac
 done
 
-# Installing or upgrading the shim itself: cover kernels already present.
+# Cover kernels already present when the shim itself is installed.
 if ((self_in_transaction)); then
 	for d in /usr/lib/modules/*/; do
 		[[ -d $d ]] && DIRS["${d%/}"]=1
@@ -51,7 +39,7 @@ fi
 
 for dir in "${!DIRS[@]}"; do
 	[[ -d $dir ]] || continue
-	# The kernel package ships pkgbase (retirement), or we already wrote it.
+	# Leave existing kernel metadata untouched.
 	[[ -e $dir/pkgbase ]] && continue
 	# Not a packaged kernel (a leftover or DKMS-only directory).
 	owner=$(owner_of "$dir") || continue
@@ -66,17 +54,13 @@ for dir in "${!DIRS[@]}"; do
 	fi
 	printf '%s\n' "$owner" >"$dir/pkgbase"
 	echo "$SELF: wrote pkgbase ($owner) and vmlinuz in $dir"
-	# 90-mkinitcpio-install runs later in this transaction only if the kernel
-	# package trips one of its triggers; Arch Linux ARM's ships a file under
-	# usr/lib/initcpio/ for exactly that. Otherwise nothing else builds the
-	# initramfs/UKI now (the shim installed after the kernel, for instance).
+	# Rebuild when the transaction will not trigger mkinitcpio itself.
 	if ! ((modules_in_transaction)) || ! pacman -Qlq "$owner" 2>/dev/null | grep -q '^/usr/lib/initcpio/'; then
 		rebuild=1
 	fi
 done
 
-# A removed or upgraded kernel leaves its directory behind because our two
-# files are in it. Drop them when nothing else is left.
+# Remove directories containing only stale shim metadata.
 for dir in /usr/lib/modules/*/; do
 	dir=${dir%/}
 	[[ -f $dir/pkgbase && -f $dir/vmlinuz ]] || continue
@@ -86,8 +70,7 @@ for dir in /usr/lib/modules/*/; do
 	rm -f "$dir/pkgbase" "$dir/vmlinuz" && rmdir "$dir" && echo "$SELF: removed leftover $dir"
 done
 
-# Omarchy's installer defers boot-image builds by pointing this hook at
-# /dev/null and runs limine-update itself afterwards; honour that.
+# Respect the installer's deferred boot-image build.
 deferred_hook=/etc/pacman.d/hooks/90-mkinitcpio-install.hook
 if ((rebuild)) && [[ -L $deferred_hook && $(readlink "$deferred_hook") == /dev/null ]]; then
 	echo "$SELF: $deferred_hook is masked, leaving the rebuild to limine-update"

--- a/pkgbuilds/linux-aarch64-pkgbase-shim/linux-aarch64-pkgbase-shim
+++ b/pkgbuilds/linux-aarch64-pkgbase-shim/linux-aarch64-pkgbase-shim
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# linux-aarch64-pkgbase-shim -- pacman PostTransaction hook script.
+#
+# Arch Linux ARM's kernel packages install the kernel as /boot/Image and ship
+# no usr/lib/modules/<ver>/{pkgbase,vmlinuz}. mkinitcpio and limine-entry-tool
+# find kernels through exactly those two files, so on Arch Linux ARM neither
+# builds an initramfs/UKI nor writes a Limine entry for a new kernel. This
+# script writes both files into the package-owned modules directory. It runs
+# before 90-mkinitcpio-install (hook name 85-), which then builds as usual.
+#
+# RETIRE when Arch Linux ARM's linux-aarch64 ships pkgbase and vmlinuz itself
+# (archlinuxarm/PKGBUILDs#2215 or its successor): a directory that already
+# has pkgbase is left alone, so the package can simply be removed.
+set -u
+
+readonly SELF=linux-aarch64-pkgbase-shim
+readonly IMAGE=/boot/Image
+readonly LIMINE_INSTALL_SCRIPT=/usr/share/libalpm/scripts/limine-mkinitcpio-install
+
+declare -A DIRS=()
+modules_in_transaction=0
+self_in_transaction=0
+rebuild=0
+
+owner_of() {
+	pacman -Qqo "$1" 2>/dev/null
+}
+
+# Targets arrive on stdin (NeedsTargets). Read all of them: stopping early
+# makes pacman report a broken pipe.
+while IFS= read -r line; do
+	case $line in
+	usr/lib/modules/*)
+		v=${line#usr/lib/modules/}
+		v=${v%%/*}
+		[[ -n $v ]] && DIRS["/usr/lib/modules/$v"]=1
+		modules_in_transaction=1
+		;;
+	"$SELF")
+		self_in_transaction=1
+		;;
+	esac
+done
+
+# Installing or upgrading the shim itself: cover kernels already present.
+if ((self_in_transaction)); then
+	for d in /usr/lib/modules/*/; do
+		[[ -d $d ]] && DIRS["${d%/}"]=1
+	done
+fi
+
+for dir in "${!DIRS[@]}"; do
+	[[ -d $dir ]] || continue
+	# The kernel package ships pkgbase (retirement), or we already wrote it.
+	[[ -e $dir/pkgbase ]] && continue
+	# Not a packaged kernel (a leftover or DKMS-only directory).
+	owner=$(owner_of "$dir") || continue
+	if [[ $(owner_of "$IMAGE") != "$owner" ]]; then
+		echo "$SELF: $owner owns $dir but not $IMAGE, leaving it alone" >&2
+		continue
+	fi
+	if ! cp -f "$IMAGE" "$dir/.vmlinuz.tmp" || ! mv -f "$dir/.vmlinuz.tmp" "$dir/vmlinuz"; then
+		echo "$SELF: failed to copy $IMAGE to $dir/vmlinuz" >&2
+		rm -f "$dir/.vmlinuz.tmp"
+		continue
+	fi
+	printf '%s\n' "$owner" >"$dir/pkgbase"
+	echo "$SELF: wrote pkgbase ($owner) and vmlinuz in $dir"
+	# 90-mkinitcpio-install runs later in this transaction only if the kernel
+	# package trips one of its triggers; Arch Linux ARM's ships a file under
+	# usr/lib/initcpio/ for exactly that. Otherwise nothing else builds the
+	# initramfs/UKI now (the shim installed after the kernel, for instance).
+	if ! ((modules_in_transaction)) || ! pacman -Qlq "$owner" 2>/dev/null | grep -q '^/usr/lib/initcpio/'; then
+		rebuild=1
+	fi
+done
+
+# A removed or upgraded kernel leaves its directory behind because our two
+# files are in it. Drop them when nothing else is left.
+for dir in /usr/lib/modules/*/; do
+	dir=${dir%/}
+	[[ -f $dir/pkgbase && -f $dir/vmlinuz ]] || continue
+	owner_of "$dir" >/dev/null && continue
+	owner_of "$dir/pkgbase" >/dev/null && continue
+	[[ -z $(find "$dir" -mindepth 1 ! -name pkgbase ! -name vmlinuz -print -quit) ]] || continue
+	rm -f "$dir/pkgbase" "$dir/vmlinuz" && rmdir "$dir" && echo "$SELF: removed leftover $dir"
+done
+
+if ((rebuild)); then
+	if [[ -x $LIMINE_INSTALL_SCRIPT ]]; then
+		echo rebuild | "$LIMINE_INSTALL_SCRIPT"
+	else
+		echo "$SELF: $LIMINE_INSTALL_SCRIPT not found; run mkinitcpio for the new kernel yourself" >&2
+	fi
+fi
+
+exit 0

--- a/pkgbuilds/linux-aarch64-pkgbase-shim/linux-aarch64-pkgbase-shim
+++ b/pkgbuilds/linux-aarch64-pkgbase-shim/linux-aarch64-pkgbase-shim
@@ -1,18 +1,20 @@
-#!/usr/bin/env bash
+#!/bin/bash
 # Supply pkgbase and vmlinuz metadata missing from Arch Linux ARM kernels.
-set -u
+set -uo pipefail
 
 readonly SELF=linux-aarch64-pkgbase-shim
-readonly IMAGE=/boot/Image
-readonly LIMINE_INSTALL_SCRIPT=/usr/share/libalpm/scripts/limine-mkinitcpio-install
+readonly ROOT=${OMARCHY_KERNEL_SHIM_ROOT:-}
+readonly IMAGE=$ROOT/boot/Image
+readonly LIMINE_INSTALL_SCRIPT=$ROOT/usr/share/libalpm/scripts/limine-mkinitcpio-install
 
 declare -A DIRS=()
 modules_in_transaction=0
 self_in_transaction=0
 rebuild=0
+failed=0
 
 owner_of() {
-	pacman -Qqo "$1" 2>/dev/null
+	pacman -Qqo "${1#"$ROOT"}" 2>/dev/null
 }
 
 # NeedsTargets requires consuming every line from stdin.
@@ -21,7 +23,7 @@ while IFS= read -r line; do
 	usr/lib/modules/*)
 		v=${line#usr/lib/modules/}
 		v=${v%%/*}
-		[[ -n $v ]] && DIRS["/usr/lib/modules/$v"]=1
+		[[ -n $v ]] && DIRS["$ROOT/usr/lib/modules/$v"]=1
 		modules_in_transaction=1
 		;;
 	"$SELF")
@@ -32,46 +34,59 @@ done
 
 # Cover kernels already present when the shim itself is installed.
 if ((self_in_transaction)); then
-	for d in /usr/lib/modules/*/; do
+	for d in "$ROOT"/usr/lib/modules/*/; do
 		[[ -d $d ]] && DIRS["${d%/}"]=1
 	done
 fi
 
 for dir in "${!DIRS[@]}"; do
 	[[ -d $dir ]] || continue
-	# Leave existing kernel metadata untouched.
-	[[ -e $dir/pkgbase ]] && continue
 	# Not a packaged kernel (a leftover or DKMS-only directory).
 	owner=$(owner_of "$dir") || continue
 	if [[ $(owner_of "$IMAGE") != "$owner" ]]; then
 		echo "$SELF: $owner owns $dir but not $IMAGE, leaving it alone" >&2
 		continue
 	fi
-	if ! cp -f "$IMAGE" "$dir/.vmlinuz.tmp" || ! mv -f "$dir/.vmlinuz.tmp" "$dir/vmlinuz"; then
-		echo "$SELF: failed to copy $IMAGE to $dir/vmlinuz" >&2
-		rm -f "$dir/.vmlinuz.tmp"
+	# Preserve package-owned files; refresh metadata previously written by the shim.
+	owner_of "$dir/pkgbase" >/dev/null && continue
+	owner_of "$dir/vmlinuz" >/dev/null && continue
+	if [[ -e $dir/pkgbase && $(<"$dir/pkgbase") != "$owner" ]]; then
 		continue
 	fi
-	printf '%s\n' "$owner" >"$dir/pkgbase"
+	if [[ -f $dir/pkgbase ]] && cmp -s "$IMAGE" "$dir/vmlinuz"; then
+		continue
+	fi
+	image_tmp=$(mktemp "$dir/.vmlinuz.XXXXXX") || { failed=1; continue; }
+	if ! cp --preserve=mode "$IMAGE" "$image_tmp" || ! mv -f "$image_tmp" "$dir/vmlinuz"; then
+		echo "$SELF: failed to copy $IMAGE to $dir/vmlinuz" >&2
+		rm -f "$image_tmp"
+		failed=1
+		continue
+	fi
+	if ! printf '%s\n' "$owner" >"$dir/pkgbase"; then
+		failed=1
+		continue
+	fi
 	echo "$SELF: wrote pkgbase ($owner) and vmlinuz in $dir"
 	# Rebuild when the transaction will not trigger mkinitcpio itself.
-	if ! ((modules_in_transaction)) || ! pacman -Qlq "$owner" 2>/dev/null | grep -q '^/usr/lib/initcpio/'; then
+	if ! ((modules_in_transaction)) || ! pacman -Qlq "$owner" 2>/dev/null | grep '^/usr/lib/initcpio/' >/dev/null; then
 		rebuild=1
 	fi
 done
 
 # Remove directories containing only stale shim metadata.
-for dir in /usr/lib/modules/*/; do
+for dir in "$ROOT"/usr/lib/modules/*/; do
 	dir=${dir%/}
 	[[ -f $dir/pkgbase && -f $dir/vmlinuz ]] || continue
 	owner_of "$dir" >/dev/null && continue
 	owner_of "$dir/pkgbase" >/dev/null && continue
+	owner_of "$dir/vmlinuz" >/dev/null && continue
 	[[ -z $(find "$dir" -mindepth 1 ! -name pkgbase ! -name vmlinuz -print -quit) ]] || continue
 	rm -f "$dir/pkgbase" "$dir/vmlinuz" && rmdir "$dir" && echo "$SELF: removed leftover $dir"
 done
 
 # Respect the installer's deferred boot-image build.
-deferred_hook=/etc/pacman.d/hooks/90-mkinitcpio-install.hook
+deferred_hook=$ROOT/etc/pacman.d/hooks/90-mkinitcpio-install.hook
 if ((rebuild)) && [[ -L $deferred_hook && $(readlink "$deferred_hook") == /dev/null ]]; then
 	echo "$SELF: $deferred_hook is masked, leaving the rebuild to limine-update"
 	rebuild=0
@@ -79,10 +94,10 @@ fi
 
 if ((rebuild)); then
 	if [[ -x $LIMINE_INSTALL_SCRIPT ]]; then
-		echo rebuild | "$LIMINE_INSTALL_SCRIPT"
+		echo rebuild | "$LIMINE_INSTALL_SCRIPT" || failed=1
 	else
 		echo "$SELF: $LIMINE_INSTALL_SCRIPT not found; run mkinitcpio for the new kernel yourself" >&2
 	fi
 fi
 
-exit 0
+exit "$failed"

--- a/pkgbuilds/linux-aarch64-pkgbase-shim/test.sh
+++ b/pkgbuilds/linux-aarch64-pkgbase-shim/test.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+set -euo pipefail
+
+package_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+scratch=$(mktemp -d)
+trap 'rm -rf "$scratch"' EXIT
+export OMARCHY_KERNEL_SHIM_ROOT=$scratch
+export SHIM_NATIVE=0 SHIM_KERNEL_PRESENT=1
+
+pacman() {
+  if [[ $1 == -Qlq ]]; then
+    printf '/usr/lib/initcpio/install/test\n'
+    return 0
+  fi
+  case $2 in
+    /boot/Image | /usr/lib/modules/test)
+      ((SHIM_KERNEL_PRESENT)) || return 1
+      printf 'linux-aarch64\n'
+      ;;
+    /usr/lib/modules/test/pkgbase | /usr/lib/modules/test/vmlinuz)
+      ((SHIM_NATIVE)) || return 1
+      printf 'linux-aarch64\n'
+      ;;
+    *) return 1 ;;
+  esac
+}
+export -f pacman
+
+modules=$scratch/usr/lib/modules/test
+mkdir -p "$modules" "$scratch/boot" "$scratch/etc/pacman.d/hooks" \
+  "$scratch/usr/share/libalpm/scripts"
+printf 'first-kernel' >"$scratch/boot/Image"
+cat >"$scratch/usr/share/libalpm/scripts/limine-mkinitcpio-install" <<'SCRIPT'
+#!/bin/bash
+cat >>"$OMARCHY_KERNEL_SHIM_ROOT/rebuilds"
+SCRIPT
+chmod +x "$scratch/usr/share/libalpm/scripts/limine-mkinitcpio-install"
+
+run_shim() {
+  printf '%s\n' "$1" | bash "$package_dir/linux-aarch64-pkgbase-shim"
+}
+
+run_shim usr/lib/modules/test/
+[[ $(<"$modules/pkgbase") == linux-aarch64 ]]
+cmp "$scratch/boot/Image" "$modules/vmlinuz"
+[[ $(stat -c %a "$modules/vmlinuz") == $(stat -c %a "$scratch/boot/Image") ]]
+[[ ! -e $scratch/rebuilds ]]
+echo 'ok - kernel installation supplies metadata before the normal rebuild hook'
+
+printf 'replacement-kernel' >"$scratch/boot/Image"
+run_shim usr/lib/modules/test/
+cmp "$scratch/boot/Image" "$modules/vmlinuz"
+echo 'ok - reinstalling the same kernel version refreshes its image'
+
+printf 'shim-upgrade' >"$scratch/boot/Image"
+run_shim linux-aarch64-pkgbase-shim
+[[ $(<"$scratch/rebuilds") == rebuild ]]
+run_shim linux-aarch64-pkgbase-shim
+[[ $(wc -l <"$scratch/rebuilds") == 1 ]]
+echo 'ok - unchanged images do not trigger redundant rebuilds'
+
+ln -s /dev/null "$scratch/etc/pacman.d/hooks/90-mkinitcpio-install.hook"
+printf 'deferred-kernel' >"$scratch/boot/Image"
+run_shim linux-aarch64-pkgbase-shim
+cmp "$scratch/boot/Image" "$modules/vmlinuz"
+[[ $(wc -l <"$scratch/rebuilds") == 1 ]]
+echo 'ok - the installer can defer boot-image regeneration'
+
+SHIM_NATIVE=1
+printf 'package-owned' >"$modules/vmlinuz"
+run_shim usr/lib/modules/test/
+[[ $(<"$modules/vmlinuz") == package-owned ]]
+echo 'ok - native package-owned kernel files are preserved'
+
+SHIM_NATIVE=0
+SHIM_KERNEL_PRESENT=0
+run_shim usr/lib/modules/test/
+[[ ! -d $modules ]]
+echo 'ok - kernel removal cleans up leftover shim metadata'

--- a/pkgbuilds/linux-aarch64-pkgbase-shim/test.sh
+++ b/pkgbuilds/linux-aarch64-pkgbase-shim/test.sh
@@ -6,6 +6,7 @@ scratch=$(mktemp -d)
 trap 'rm -rf "$scratch"' EXIT
 export OMARCHY_KERNEL_SHIM_ROOT=$scratch
 export SHIM_NATIVE=0 SHIM_KERNEL_PRESENT=1
+export SHIM_IMAGE_OWNER=linux-aarch64
 
 pacman() {
   if [[ $1 == -Qlq ]]; then
@@ -13,12 +14,15 @@ pacman() {
     return 0
   fi
   case $2 in
-    /boot/Image | /usr/lib/modules/test)
+    /boot/Image)
+      printf '%s\n' "$SHIM_IMAGE_OWNER"
+      ;;
+    /usr/lib/modules/test)
       ((SHIM_KERNEL_PRESENT)) || return 1
       printf 'linux-aarch64\n'
       ;;
     /usr/lib/modules/test/pkgbase | /usr/lib/modules/test/vmlinuz)
-      ((SHIM_NATIVE)) || return 1
+      [[ $SHIM_NATIVE == 1 || $2 == /usr/lib/modules/test/"$SHIM_NATIVE" ]] || return 1
       printf 'linux-aarch64\n'
       ;;
     *) return 1 ;;
@@ -66,14 +70,38 @@ cmp "$scratch/boot/Image" "$modules/vmlinuz"
 [[ $(wc -l <"$scratch/rebuilds") == 1 ]]
 echo 'ok - the installer can defer boot-image regeneration'
 
-SHIM_NATIVE=1
-printf 'package-owned' >"$modules/vmlinuz"
-run_shim usr/lib/modules/test/
-[[ $(<"$modules/vmlinuz") == package-owned ]]
-echo 'ok - native package-owned kernel files are preserved'
+for SHIM_NATIVE in pkgbase vmlinuz; do
+  printf 'package-owned' >"$modules/vmlinuz"
+  run_shim usr/lib/modules/test/
+  [[ $(<"$modules/vmlinuz") == package-owned ]]
+done
+echo 'ok - either package-owned metadata file prevents replacement'
 
 SHIM_NATIVE=0
+SHIM_IMAGE_OWNER=another-kernel
+run_shim usr/lib/modules/test/
+[[ $(<"$modules/vmlinuz") == package-owned ]]
+SHIM_IMAGE_OWNER=linux-aarch64
+echo 'ok - a different kernel image owner prevents replacement'
+
+(
+  # shellcheck disable=SC2329 # Invoked by the shim in a child shell.
+  cp() { return 1; }
+  export -f cp
+  if run_shim usr/lib/modules/test/; then
+    echo 'not ok - a failed image copy was accepted' >&2
+    exit 1
+  fi
+  [[ $(<"$modules/vmlinuz") == package-owned ]]
+)
+echo 'ok - failed copies preserve the previous kernel image'
+
 SHIM_KERNEL_PRESENT=0
+mkdir -p "$modules/updates/dkms"
+run_shim usr/lib/modules/test/
+[[ -d $modules/updates/dkms && -f $modules/vmlinuz ]]
+rmdir "$modules/updates/dkms" "$modules/updates"
+echo 'ok - kernel removal preserves DKMS leftovers'
 run_shim usr/lib/modules/test/
 [[ ! -d $modules ]]
 echo 'ok - kernel removal cleans up leftover shim metadata'


### PR DESCRIPTION
## Summary

Adds `linux-aarch64-pkgbase-shim` so mkinitcpio and Limine can use Arch Linux ARM kernels shipped as `/boot/Image`.

- Supplies module-directory `pkgbase` and `vmlinuz`, refreshing the image on kernel upgrades and changed same-version reinstalls.
- Preserves package-owned files, copies atomically with original permissions, and removes stale shim-only metadata without deleting DKMS leftovers.
- Defers regeneration when the installer masks the normal hook and reports rebuild failures.

The shim remains needed until the kernel package provides the discoverable image directly.

## Dependencies

Targets `omarchy-pkgs/master`. The installer in omacom/omarchy-iso#129 is merged into `dragon` and installs this package. It can land and be published independently of #221 and #223.

Jim Martin's #380 addresses a separate update-safety problem: retaining encryption and UKI configuration. The shim does not replace that fix.

Jimmy Van Veen authored the original shim; original authorship is preserved.

## Validation

September 16 verification passed against master `5fe2367`: native ARM64 build of 1-3, shim regressions, ShellCheck and whitespace checks. [Hosted self-tests and build-isolation checks pass](https://github.com/omacom/omarchy-pkgs/actions/runs/35038354164).

An isolated ARM container tested a real 7.2.3-to-7.2.4 kernel upgrade and same-version reinstall alongside a local #380 refresh for settings 4.0.4. Metadata was refreshed before the rebuild hook; real mkinitcpio output retained encryption and Plymouth support, and settings preserved a local edit.

This used a Limine backend fixture. Physical update/reboot, ESP deployment and Asahi boot remain untested.

<details>
<summary>Earlier validation</summary>

The [September 6 integration build](https://github.com/birkskyum/omarchy-pkgs/actions/runs/34003828582) built the shim and extractor. September 10 container tests also covered kernel upgrade/reinstall, stale-metadata cleanup and encrypted-root initramfs generation alongside #380.

The shim was included in the September 10 image that booted on the Yoga. That did not test upgrading the installed system. [Integrated results and limits](https://github.com/omacom/omarchy-iso/pull/129) retain that distinction.

</details>

