### PR TITLE
Update JetBrains Mono Nerd Font to 3.5.1

### DIFF
--- a/pkgbuilds/ttf-jetbrains-mono-nerd-basic/.omarchy/package.json
+++ b/pkgbuilds/ttf-jetbrains-mono-nerd-basic/.omarchy/package.json
@@ -1,3 +1,11 @@
 {
-  "source": "local"
+  "source": "local",
+  "min_release_age": "24h",
+  "upstream": {
+    "github": "ryanoasis/nerd-fonts",
+    "checksums": "SHA-256.txt",
+    "assets": {
+      "any": "JetBrainsMono.zip"
+    }
+  }
 }

--- a/pkgbuilds/ttf-jetbrains-mono-nerd-basic/PKGBUILD
+++ b/pkgbuilds/ttf-jetbrains-mono-nerd-basic/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Omarchy <hello@omarchy.org>
 
 pkgname=ttf-jetbrains-mono-nerd-basic
-pkgver=3.5.0
+pkgver=3.5.1
 pkgrel=1
 pkgdesc="Basic JetBrains Mono Nerd Font family"
 arch=("any")
@@ -11,7 +11,7 @@ groups=("nerd-fonts")
 provides=("ttf-font-nerd" "ttf-jetbrains-mono-nerd=$pkgver")
 conflicts=("ttf-jetbrains-mono-nerd" "nerd-fonts-jetbrains-mono")
 source=("JetBrainsMono-${pkgver}.zip::https://github.com/ryanoasis/nerd-fonts/releases/download/v${pkgver}/JetBrainsMono.zip")
-sha256sums=("9577de1ae84ec523df16fc69bac5338b89497a5b4fb91489e2dcb79dc06ac2b5")
+sha256sums=('fab782a66f7d3019da64f6572db9fc5d3a4bcb19f9fa13e2d8a62e3693d6396e')
 
 package() {
   local font


### PR DESCRIPTION
## Summary

- update the basic JetBrains Mono Nerd Font package from 3.5.0 to the 3.5.1 bugfix release
- bind the archive to the checksum published in Nerd Fonts `SHA-256.txt`
- add a declarative GitHub release provider with a 24-hour quarantine so future releases flow through the scheduled update PR

## Verification

- `bin/sync-upstream ttf-jetbrains-mono-nerd-basic` selected `3.5.1` and then reported no further update
- provider checksum: `fab782a66f7d3019da64f6572db9fc5d3a4bcb19f9fa13e2d8a62e3693d6396e`
- full `makepkg --cleanbuild` passed
- package contents contain the four intended Regular/Bold/Italic/BoldItalic fonts and the OFL license
- upstream-sync, release, and package-management self-tests passed
