### PR TITLE
Require inotify-tools for snapshot watching

### DIFF
--- a/pkgbuilds/limine-snapper-sync/.omarchy/patches/require-inotify-tools.patch
+++ b/pkgbuilds/limine-snapper-sync/.omarchy/patches/require-inotify-tools.patch
@@ -1,0 +1,9 @@
+diff --git a/PKGBUILD b/PKGBUILD
+--- a/PKGBUILD
++++ b/PKGBUILD
+@@ -19 +19,2 @@
+-	'libnotify')
++	'libnotify'
++	'inotify-tools')
+@@ -23 +24,0 @@
+-	'inotify-tools: Monitors when snapshots are created or deleted.'

--- a/pkgbuilds/limine-snapper-sync/PKGBUILD
+++ b/pkgbuilds/limine-snapper-sync/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Zesko
 pkgname="limine-snapper-sync"
 pkgver=1.31.0
-pkgrel=1
+pkgrel=1.1
 pkgdesc="Integrates Limine boot entries with Snapper snapshots."
 arch=('x86_64' 'aarch64')
 url="https://gitlab.com/Zesko/limine-snapper-sync"
@@ -16,11 +16,11 @@ depends=(
 	'limine'
 	'snapper'
 	'btrfs-progs'
-	'libnotify')
+	'libnotify'
+	'inotify-tools')
 optdepends=(
 	'limine-dracut-support: Automates kernel installation/removal and Limine boot entry management.'
 	'limine-mkinitcpio-hook: Automates kernel installation/removal and Limine boot entry management.'
-	'inotify-tools: Monitors when snapshots are created or deleted.'
 	'rsync: Alternative method for restoring snapshots.'
 	'b3sum: Fast Blake3 hash function to prevent duplication.'
 	'xxhash: Fast hashing utility for deduplication with shorter hashes.'


### PR DESCRIPTION
## Summary

- move `inotify-tools` from optional to required dependencies for `limine-snapper-sync`
- preserve the correction as an Omarchy overlay across future AUR syncs
- publish the customized build as `1.31.0-1.1`

The watcher explicitly needs `inotifywait`; without it, the service exits and falls back instead of watching snapshot changes. This addresses the package-dependency portion of basecamp/omarchy#6629. Creating a Snapper root configuration remains a separate system-policy concern.

## Verification

- exact AUR commit `35aff513bf1f0284380c8592d3de213f00bb6a7b`
- overlay applies with `--fuzz=0`
- `bin/sync-aur limine-snapper-sync` is idempotent
- emitted `.SRCINFO` lists `inotify-tools` under `depends`, not `optdepends`
- `makepkg --verifysource` passed for the Git source and x86_64 GraalVM archive
