### PR TITLE
Add FAM_OS package

### DIFF
--- a/pkgbuilds/fam-os/.omarchy/package.json
+++ b/pkgbuilds/fam-os/.omarchy/package.json
@@ -1,0 +1,5 @@
+{
+  "source": "local",
+  "release_ring": "fast",
+  "channels": ["edge", "rc", "stable"]
+}

--- a/pkgbuilds/fam-os/.omarchy/upstream.sh
+++ b/pkgbuilds/fam-os/.omarchy/upstream.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+set -euo pipefail
+
+repo=${FAM_OS_GITHUB_REPOSITORY:-demimagic-ML/FAM-os}
+release=$(curl -fsSL "https://api.github.com/repos/$repo/releases/latest")
+tag=$(jq -er '.tag_name' <<<"$release")
+[[ $tag =~ ^v([0-9]+\.[0-9]+\.[0-9]+)$ ]] || {
+  echo "FAM_OS latest release tag is not a stable semantic version: $tag" >&2
+  exit 1
+}
+version=${BASH_REMATCH[1]}
+current=$(awk -F= '/^pkgver=/ { gsub(/["'\'' ]/, "", $2); print $2; exit }' PKGBUILD)
+if [[ -n $current ]] && (( $(vercmp "$version" "$current") <= 0 )); then
+  echo '{}'
+  exit 0
+fi
+
+checksum_url=$(jq -er '.assets[] | select(.name == "SHA256SUMS") | .browser_download_url' <<<"$release")
+checksums=$(curl -fsSL "$checksum_url")
+asset="fam-os-${version}.tar.gz"
+sha256=$(awk -v asset="$asset" \
+  '{name=$2; sub(/^\*/, "", name); sub(/^\.\//, "", name)} name == asset { print $1; exit }' \
+  <<<"$checksums")
+[[ $sha256 =~ ^[0-9a-f]{64}$ ]] || {
+  echo "SHA256SUMS contains no valid digest for $asset" >&2
+  exit 1
+}
+
+jq -n --arg pkgver "$version" --arg sha256 "$sha256" \
+  '{pkgver: $pkgver, sha256sums: {any: [$sha256]}}'

--- a/pkgbuilds/fam-os/PKGBUILD
+++ b/pkgbuilds/fam-os/PKGBUILD
@@ -1,5 +1,5 @@
 pkgname=fam-os
-pkgver=0.1.0
+pkgver=0.1.1
 pkgrel=1
 pkgdesc='Local-first Linux intelligence and durable engineering agent for Omarchy'
 arch=('x86_64')
@@ -30,7 +30,7 @@ install=fam-os.install
 # Omarchy publishes only recipes pinned to the deterministic release archive.
 # The updater refreshes this concrete digest from the signed release manifest.
 source=("$pkgname-$pkgver.tar.gz::$url/releases/download/v$pkgver/$pkgname-$pkgver.tar.gz")
-sha256sums=('2819b9cda62ceda9215449fbf7b7e08bb0687d321b2956a5fb480d19786acc01')
+sha256sums=('81f1af76184604157be4354b19762d26afc894c32b7d449b87d0f74424218b2c')
 
 build() {
   cd "$pkgname-$pkgver"
@@ -53,6 +53,8 @@ package() {
   install -Dm644 README.md "$pkgdir/usr/share/doc/fam-os/README.md"
   cp -a docs "$pkgdir/usr/share/doc/fam-os/"
   install -Dm644 integrations/omarchy/desktop/fam-os.desktop "$pkgdir/usr/share/fam-os/omarchy/desktop/fam-os.desktop"
+  install -Dm644 integrations/omarchy/menu/omarchy-menu.json "$pkgdir/usr/share/fam-os/omarchy/menu/omarchy-menu.json"
+  install -Dm755 integrations/omarchy/hooks/fam-os "$pkgdir/usr/share/fam-os/omarchy/hooks/fam-os"
   install -Dm644 packaging/arch/arch-package.json "$pkgdir/usr/share/fam-os/arch-package.json"
   install -Dm755 integrations/omarchy/launcher/omarchy-fam "$pkgdir/usr/bin/omarchy-fam"
   install -Dm755 integrations/omarchy/usage-collector/omarchy-agent-usage-fam "$pkgdir/usr/bin/omarchy-agent-usage-fam"

--- a/pkgbuilds/fam-os/PKGBUILD
+++ b/pkgbuilds/fam-os/PKGBUILD
@@ -1,0 +1,59 @@
+pkgname=fam-os
+pkgver=0.1.0
+pkgrel=1
+pkgdesc='Local-first Linux intelligence and durable engineering agent for Omarchy'
+arch=('x86_64')
+url='https://github.com/demimagic-ML/FAM-os'
+license=('MIT')
+depends=(
+  'python>=3.12' 'python-cryptography' 'python-jsonschema' 'python-mcp'
+  'python-sympy' 'python-playwright' 'chromium' 'bubblewrap'
+  'systemd' 'xdg-utils' 'curl'
+  'git' 'gnupg'
+)
+optdepends=(
+  'ollama: local model inference'
+  'openai-codex: hosted native engineering provider'
+  'omarchy: Omarchy lifecycle, launcher, snapshots, and shell integration'
+  'quickshell: Omarchy status widget'
+  'uwsm: Wayland application lifecycle'
+  'hyprland: native Omarchy window observation'
+  'python-gobject: AT-SPI native application testing'
+  'at-spi2-core: AT-SPI native application testing'
+  'grim: native application screenshot evidence'
+  'wtype: controlled Wayland input fallback'
+  'ydotool: controlled pointer input fallback'
+)
+makedepends=('python-build' 'python-installer' 'python-setuptools' 'python-wheel')
+options=('docs')
+install=fam-os.install
+# Omarchy publishes only recipes pinned to the deterministic release archive.
+# The updater refreshes this concrete digest from the signed release manifest.
+source=("$pkgname-$pkgver.tar.gz::$url/releases/download/v$pkgver/$pkgname-$pkgver.tar.gz")
+sha256sums=('2819b9cda62ceda9215449fbf7b7e08bb0687d321b2956a5fb480d19786acc01')
+
+build() {
+  cd "$pkgname-$pkgver"
+  export PYTHONHASHSEED=0
+  python -m build --wheel --no-isolation
+}
+
+package() {
+  cd "$pkgname-$pkgver"
+  python -m installer --destdir="$pkgdir" dist/*.whl
+  install -Dm644 packaging/systemd/fam-os.service "$pkgdir/usr/lib/systemd/user/fam-os.service"
+  install -Dm644 packaging/systemd/fam-os-desktop.service "$pkgdir/usr/lib/systemd/user/fam-os-desktop.service"
+  install -Dm644 packaging/systemd/fam-os-usage.service "$pkgdir/usr/lib/systemd/user/fam-os-usage.service"
+  install -Dm644 packaging/systemd/fam-os-usage.timer "$pkgdir/usr/lib/systemd/user/fam-os-usage.timer"
+  install -Dm644 packaging/desktop/fam-os.desktop "$pkgdir/usr/share/applications/fam-os.desktop"
+  install -Dm644 packaging/icons/fam-os.png "$pkgdir/usr/share/icons/hicolor/512x512/apps/fam-os.png"
+  install -Dm644 packaging/keys/fam-os-release.asc "$pkgdir/usr/share/fam-os/keys/fam-os-release.asc"
+  install -Dm644 packaging/keys/fam-os-release.fingerprint "$pkgdir/usr/share/fam-os/keys/fam-os-release.fingerprint"
+  install -Dm644 LICENSE "$pkgdir/usr/share/licenses/fam-os/LICENSE"
+  install -Dm644 README.md "$pkgdir/usr/share/doc/fam-os/README.md"
+  cp -a docs "$pkgdir/usr/share/doc/fam-os/"
+  install -Dm644 integrations/omarchy/desktop/fam-os.desktop "$pkgdir/usr/share/fam-os/omarchy/desktop/fam-os.desktop"
+  install -Dm644 packaging/arch/arch-package.json "$pkgdir/usr/share/fam-os/arch-package.json"
+  install -Dm755 integrations/omarchy/launcher/omarchy-fam "$pkgdir/usr/bin/omarchy-fam"
+  install -Dm755 integrations/omarchy/usage-collector/omarchy-agent-usage-fam "$pkgdir/usr/bin/omarchy-agent-usage-fam"
+}

--- a/pkgbuilds/fam-os/fam-os.install
+++ b/pkgbuilds/fam-os/fam-os.install
@@ -1,0 +1,20 @@
+post_install() {
+  echo 'FAM_OS installed. As the desktop user, run:'
+  echo '  fam-os setup omarchy --yes --enable-widget'
+}
+
+post_upgrade() {
+  echo 'FAM_OS upgraded. Existing user state and configuration were preserved.'
+  echo 'As each configured desktop user, run:'
+  echo '  systemctl --user daemon-reload && fam-os repair omarchy --service'
+}
+
+post_remove() {
+  echo 'FAM_OS system files were removed. User goals and history remain preserved.'
+  echo 'To erase them explicitly before uninstalling, use: fam-os purge --user-data --yes'
+}
+
+pre_remove() {
+  echo 'FAM_OS package removal preserves owner data under ~/.local/share/fam-os.'
+  echo 'Remove the Omarchy integration first with: fam-os remove omarchy-integration'
+}


### PR DESCRIPTION
## Summary

Add the x86_64 FAM_OS package for Omarchy 4 with:

- a release-archive-pinned PKGBUILD
- normal pacman install, upgrade, and removal messages
- Omarchy package updater metadata for stable, rc, and edge channels
- automatic checksum refresh from the signed FAM_OS release manifest
- no root-time writes into a desktop user home

Project site: [fam-os.demimagic.chatgpt.site](https://fam-os.demimagic.chatgpt.site)

## Why FAM

FAM_OS is a Linux-native engineering agent built around durable, resumable goals: it works in isolated candidate workspaces, invokes local models or Codex, executes OS and application tools, and applies changes only after file, command, browser-level, or application-level verification. Packaging it for Omarchy provides a reproducible system installation for the service, launchers, application-testing dependencies, user units, native widget integration, and lifecycle hooks while preserving user-owned configuration and goal state across upgrades and removals.

The recipe consumes the signed [FAM_OS v0.1.1 release](https://github.com/demimagic-ML/FAM-os/releases/tag/v0.1.1) and pins its deterministic source archive to SHA-256 `81f1af76184604157be4354b19762d26afc894c32b7d449b87d0f74424218b2c`. FAM installation and Omarchy user setup remain separate lifecycle steps; package installation does not silently enable plugins or mutate user configuration.

## Verification

The v0.1.1 release workflow completed:

- the complete 87-test Omarchy contract, integration, and unit suite
- the real browser project build and behavior lifecycle
- deterministic source archive and checksum generation
- x86_64 Arch package build, installation, and runtime verification
- signed source/package artifacts and signed SHA256SUMS using the pinned FAM release key
- GitHub build provenance attestations

The submitted Omarchy recipe was also selected correctly by `bin/repo build --dry-run --package fam-os`. A local full upstream-builder attempt stopped in the builder image's existing `keys.openpgp.org` bootstrap before the FAM recipe was executed; the release workflow's Arch build and install passed. aarch64 remains experimental and is intentionally not part of this Omarchy package recipe.