### PR TITLE
omarchy-nvim: only suggest inline when an AI source can

### DIFF
--- a/pkgbuilds/omarchy-nvim/PKGBUILD
+++ b/pkgbuilds/omarchy-nvim/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Ryan Hughes <ryan@omarchy.org>
 pkgname=omarchy-nvim
-pkgver=2026.8.13
+pkgver=2026.8.28
 pkgrel=1
 pkgdesc="Pre-built LazyVim configuration with cached plugins"
 arch=('any')

--- a/pkgbuilds/omarchy-nvim/lua/config/options.lua
+++ b/pkgbuilds/omarchy-nvim/lua/config/options.lua
@@ -3,3 +3,10 @@ require("config.remote_clipboard").setup()
 
 vim.opt.relativenumber = false
 vim.g.autoformat = false
+
+-- Only preview completions inline when an AI source is actually installed.
+-- LazyVim's ai_cmp routes AI suggestions through the completion menu and turns
+-- on blink's ghost text to preview them; with no AI extra enabled that ghost
+-- text just echoes buffer words back at you while you type. Off, the AI extras
+-- use their own native inline suggestions instead, still accepted with <Tab>.
+vim.g.ai_cmp = false


### PR DESCRIPTION
Stock Omarchy ghosts words at you while you type, and there is nothing behind the guess.

LazyVim defaults `vim.g.ai_cmp = true`, which routes AI completions through the completion menu and switches on blink.cmp's ghost text so the selected item previews inline. Omarchy enables no AI extra — `lazyvim.json` lists only `editor.neo-tree` — so the sources are `lsp`, `path`, `snippets`, `buffer`, and the inline preview spends its time writing words already on screen back into the line you are typing.

Typing `Notes on cons` on line 3, stock `omarchy-nvim` 2026.8.13:

```
  1   The constitutional convention met in Philadelphia.
  2
  3   Notes on constitutional      <- only "cons" was typed
            constitutional
            convention
          󱄽  caution~
```

With `vim.g.ai_cmp = false`:

```
  1   The constitutional convention met in Philadelphia.
  2
  3   Notes on cons
            constitutional
            convention
          󱄽  caution~
```

The menu is untouched. Only the text that wrote itself ahead of the cursor is gone.

It is worst in prose. Writing a commit message, a note, a prompt in markdown, the buffer guesses the rest of the word every few keystrokes off nothing but the words already in the file, and the eye follows it every time.

### Why this switch rather than turning ghost text off directly

`ai_cmp` is LazyVim's own flag for exactly this question. Its AI extras read it — copilot, supermaven and codeium all set `suggestion.enabled = not vim.g.ai_cmp` — so with it off, a user who enables one of those extras gets that provider's native inline suggestions, still accepted with `<Tab>` through `LazyVim.cmp.actions.ai_accept`. Inline suggestions when something can genuinely predict the next words; none when nothing can.

### Doesn't change

- the completion menu, its sources, its keymaps
- `<Tab>`, `<CR>`, `<C-y>` behaviour
- anything for users who have enabled an AI extra, beyond moving their suggestions from the menu preview to the provider's own inline rendering

### Verified

Built nothing — this is config. Ran stock `/etc/skel/.config/nvim` and the patched copy side by side against the shipped plugin cache; the captures above are `tmux capture-pane` of those two sessions. `require("blink.cmp.config").completion.ghost_text.enabled()` returns `true` before and `false` after.

### Existing installs

`~/.config/nvim` is user-owned and `/etc/skel` only seeds new users, so this reaches fresh installs only. Happy to follow up with a migration in `basecamp/omarchy` that appends the line to an unmodified `lua/config/options.lua`, in the shape of `1781587663.sh`, if you want existing users covered.
