### PR TITLE
Update grok-bot to 0.30.0

### DIFF
--- a/pkgbuilds/grok-bot/PKGBUILD
+++ b/pkgbuilds/grok-bot/PKGBUILD
@@ -2,9 +2,9 @@
 # Contributor: Omarchy
 
 pkgname=grok-bot
-pkgver=0.29.0
+pkgver=0.30.0
 pkgrel=1
-_commit=f0e5bfcee649ea84c0c61369cf896cd146d72136
+_commit=2385d097738b3719cc5ecd9281a107aa106215f1
 pkgdesc='Grok Bot desktop agent'
 arch=('x86_64')
 url='https://x.ai/bot'
@@ -26,11 +26,11 @@ provides=('sand')
 conflicts=('sand')
 options=('!strip' '!debug')
 source=(
-  "${pkgname}_${pkgver}.deb::https://downloads.cursor.com/grokbot/stable/${_commit}/linux/x64/Grok_Bot_${pkgver}.deb"
+  "${pkgname}_${pkgver}.deb::https://downloads.cursor.com/grokbot/stable/${_commit}/linux/x64/grok-bot_${pkgver}_amd64.deb"
   'grok-bot.sh'
   'grok-bot.desktop'
 )
-sha256sums=('d223b5830282aef11d5c46d8f4d1edd239bf992e336405cbd288d4476b9233d4'
+sha256sums=('fb888b2204c8a51c71a9f5f9a2913ac10561f3ef6939c1245ecae4e837d4ada2'
             '6dfa6c305941afa6cbaefbeaae06d05ab5a88f31630005d25a819a160c20c7a3'
             '856056c9ca63dda5d01158ce8fb6a9a7cbb3f67c13a92b573cd196d3e50f26e7')
 noextract=("${pkgname}_${pkgver}.deb")

--- a/pkgbuilds/grok-bot/update-pkgver.sh
+++ b/pkgbuilds/grok-bot/update-pkgver.sh
@@ -1,17 +1,16 @@
 #!/usr/bin/env bash
 # Resolve current Grok Bot stable from Cursor's update feed and pin PKGBUILD.
-# Linux has no latest alias (linux-x64 feed returns 204). The darwin-arm64
-# sand feed publishes version + commit; the Linux .deb lives at the same commit.
-# Darwin can ship first — HEAD-check the Linux URL and fail loudly if 404.
+# The linux-x64 sand feed publishes version + commit via its AppImage zsync URL;
+# the Linux .deb lives at the same commit with a predictable filename.
 set -euo pipefail
 
 PKGBUILD_PATH="${1:-PKGBUILD}"
 [[ -f "${PKGBUILD_PATH}" ]] || { echo "Error: PKGBUILD not found at '${PKGBUILD_PATH}'" >&2; exit 1; }
 
-FEED='https://api2.cursor.sh/updates/api/update/darwin-arm64/sand/0.0.0/00000000-0000-0000-0000-000000000000/stable'
+FEED='https://api2.cursor.sh/updates/api/update/linux-x64/sand/0.0.0/00000000-0000-0000-0000-000000000000/stable'
 json="$(curl -fsSL -H 'cache-control: no-cache' "${FEED}")"
 
-ver="$(jq -er '.name // .version' <<<"${json}")"
+ver="$(jq -er '.version // .name' <<<"${json}")"
 feed_url="$(jq -er '.url' <<<"${json}")"
 commit="$(sed -nE 's@.*/(grokbot|sand)/stable/([0-9a-f]{40})/.*@\2@p' <<<"${feed_url}")"
 
@@ -20,7 +19,7 @@ commit="$(sed -nE 's@.*/(grokbot|sand)/stable/([0-9a-f]{40})/.*@\2@p' <<<"${feed
   exit 1
 }
 
-deb_url="https://downloads.cursor.com/grokbot/stable/${commit}/linux/x64/Grok_Bot_${ver}.deb"
+deb_url="https://downloads.cursor.com/grokbot/stable/${commit}/linux/x64/grok-bot_${ver}_amd64.deb"
 code="$(curl -fsSIL -o /dev/null -w '%{http_code}' "${deb_url}")"
 [[ "${code}" == "200" ]] || {
   echo "Error: Linux deb not fetchable (${code}): ${deb_url}" >&2
@@ -37,7 +36,7 @@ current_ver="$(sed -nE 's/^pkgver=([^[:space:]#]+).*/\1/p' "${PKGBUILD_PATH}" | 
 sed -i -E \
   -e "s/^_commit=.*/_commit=${commit}/" \
   -e "s/^pkgver=.*/pkgver=${ver}/" \
-  -e "0,/^[[:space:]]*'[0-9a-f]{64}'/s//    '${sum}'/" \
+  -e "s/^sha256sums=\\('[0-9a-f]{64}'/sha256sums=('${sum}'/" \
   "${PKGBUILD_PATH}"
 
 if [[ "${ver}" != "${current_ver}" ]]; then


### PR DESCRIPTION
Bump Grok Bot from 0.29.0 to current Cursor stable **0.30.0**.

Cursor now publishes a working `linux-x64` sand update feed again. This release changes the Debian artifact filename from `Grok_Bot_<version>.deb` to `grok-bot_<version>_amd64.deb`, so this also keeps the manual updater aligned with the new feed and artifact layout.

## Changes

- Pin `https://downloads.cursor.com/grokbot/stable/2385d097738b3719cc5ecd9281a107aa106215f1/linux/x64/grok-bot_0.30.0_amd64.deb`
- Update `update-pkgver.sh` to resolve `linux-x64` directly and use the new Debian filename.
- Fix the updater's checksum substitution so it replaces the first `sha256sums` entry rather than the wrapper checksum.
- Keep the packaging layout, Wayland wrapper, desktop entry, icons, and `/usr/bin/sand` compatibility symlink unchanged.

Still edge-only. Linux desktop remains unofficial.

## Tested

On Omarchy/Hyprland x86_64:

- Vendor `.deb` reports version `0.30.0`; SHA-256 `fb888b2204c8a51c71a9f5f9a2913ac10561f3ef6939c1245ecae4e837d4ada2`.
- Ran `update-pkgver.sh` end-to-end twice; it resolves `0.30.0`, commit `2385d097738b3719cc5ecd9281a107aa106215f1`, the new `.deb` URL, and remains idempotent.
- `makepkg --verifysource` and `makepkg` pass.
- Package contains the wrapper, `sand` symlink, desktop entry, icons, and `/opt/Grok Bot/grok-bot`; no legacy `sand.desktop`.
- `ldd` found no unresolved libraries in the main executable or native modules.
- Isolated packaged-binary launch stayed up for 12 seconds: `appVersion=0.30.0`, `crashSeen=false`.
- Repository self-tests pass: `sync-upstream`, `omarchy-pkgs`, and `omarchy-release`.