### PR TITLE
Number asdcontrol's sudoers policy and add it to the fast ring

### DIFF
--- a/pkgbuilds/asdcontrol/.omarchy/package.json
+++ b/pkgbuilds/asdcontrol/.omarchy/package.json
@@ -1,3 +1,4 @@
 {
-  "source": "local"
+  "source": "local",
+  "release_ring": "fast"
 }

--- a/pkgbuilds/asdcontrol/PKGBUILD
+++ b/pkgbuilds/asdcontrol/PKGBUILD
@@ -16,7 +16,7 @@ source=(
 )
 sha256sums=(
   '3112a6d5fc51a204c96ef9d27187577c6efc80b952e37a77969efbd0124e81d3'
-  'dff3a5ecbe77825b4ea82235d5fd8589832a0462108ab573140488ae54989d23'
+  '70d6838f91cf4b5e51974b9b62b141924cec844a2e60de79607839584ede847f'
 )
 
 build() {
@@ -29,5 +29,5 @@ package() {
 
   install -Dm755 asdcontrol "$pkgdir/usr/bin/asdcontrol"
   install -dm750 "$pkgdir/etc/sudoers.d"
-  install -m440 "$srcdir/asdcontrol.sudoers" "$pkgdir/etc/sudoers.d/zz-asdcontrol"
+  install -m440 "$srcdir/asdcontrol.sudoers" "$pkgdir/etc/sudoers.d/50-asdcontrol"
 }

--- a/pkgbuilds/asdcontrol/asdcontrol.sudoers
+++ b/pkgbuilds/asdcontrol/asdcontrol.sudoers
@@ -1,4 +1,3 @@
 # Deny arbitrary asdcontrol arguments before allowing only the operations Omarchy uses.
-# Keep this filename late-sorting so it also overrides stale broader grants.
 ALL ALL=(ALL) !/usr/bin/asdcontrol
 %wheel ALL=(root) NOPASSWD: /usr/bin/asdcontrol ^--detect (/dev/(usb/)?hiddev[0-9]+)( /dev/(usb/)?hiddev[0-9]+)*$, /usr/bin/asdcontrol ^/dev/(usb/)?hiddev[0-9]+$, /usr/bin/asdcontrol ^/dev/(usb/)?hiddev[0-9]+ -- [+-]?[0-9]{1,3}%$


### PR DESCRIPTION
## Summary

Follow up #242 with two packaging adjustments:

- Rename the scoped sudoers drop-in from `zz-asdcontrol` to `50-asdcontrol`, using the normal numeric convention and leaving room for policy that must run later.
- Mark the local `asdcontrol` package with `"release_ring": "fast"` so stable-to-RC parity builds include security/package updates promptly.

This no longer relies on the restricted rule sorting after every future policy. Omarchy PR https://github.com/omacom/omarchy/pull/9200 removes the separate legacy Omarchy grant as the coordinated half of the fix.

## Verification

- `visudo -cf pkgbuilds/asdcontrol/asdcontrol.sudoers` — pass
- Rebuilt `asdcontrol 1:0.6.0-2`; the archive contains mode-`0440` `/etc/sudoers.d/50-asdcontrol` and neither legacy filename
- Confirmed `package_is_fast_ring pkgbuilds/asdcontrol`
- `./bin/sync-upstream self-test` — pass
- `./bin/sync-rebuilds --self-test` — pass
- `./bin/omarchy-pkgs self-test` — pass
- `./bin/omarchy-release self-test` — pass
