### PR TITLE
grok-bot: aarch64 + 0.30.0 Linux deb names

### DIFF
--- a/pkgbuilds/grok-bot/PKGBUILD
+++ b/pkgbuilds/grok-bot/PKGBUILD
@@ -2,11 +2,11 @@
 # Contributor: Omarchy
 
 pkgname=grok-bot
-pkgver=0.29.0
+pkgver=0.30.0
 pkgrel=1
-_commit=f0e5bfcee649ea84c0c61369cf896cd146d72136
+_commit=2385d097738b3719cc5ecd9281a107aa106215f1
 pkgdesc='Grok Bot desktop agent'
-arch=('x86_64')
+arch=('x86_64' 'aarch64')
 url='https://x.ai/bot'
 license=('custom')
 depends=(
@@ -25,22 +25,35 @@ optdepends=('libappindicator-gtk3: tray support')
 provides=('sand')
 conflicts=('sand')
 options=('!strip' '!debug')
+
+_deb_x86_64="grok-bot_${pkgver}_amd64.deb"
+_deb_aarch64="grok-bot_${pkgver}_arm64.deb"
 source=(
-  "${pkgname}_${pkgver}.deb::https://downloads.cursor.com/grokbot/stable/${_commit}/linux/x64/Grok_Bot_${pkgver}.deb"
   'grok-bot.sh'
   'grok-bot.desktop'
 )
-sha256sums=('d223b5830282aef11d5c46d8f4d1edd239bf992e336405cbd288d4476b9233d4'
-            '6dfa6c305941afa6cbaefbeaae06d05ab5a88f31630005d25a819a160c20c7a3'
+source_x86_64=(
+  "${_deb_x86_64}::https://downloads.cursor.com/grokbot/stable/${_commit}/linux/x64/${_deb_x86_64}"
+)
+source_aarch64=(
+  "${_deb_aarch64}::https://downloads.cursor.com/grokbot/stable/${_commit}/linux/arm64/${_deb_aarch64}"
+)
+sha256sums=('6dfa6c305941afa6cbaefbeaae06d05ab5a88f31630005d25a819a160c20c7a3'
             '856056c9ca63dda5d01158ce8fb6a9a7cbb3f67c13a92b573cd196d3e50f26e7')
-noextract=("${pkgname}_${pkgver}.deb")
+sha256sums_x86_64=('fb888b2204c8a51c71a9f5f9a2913ac10561f3ef6939c1245ecae4e837d4ada2')
+sha256sums_aarch64=('7c4c81d576181a57b34b812258b2620626717cec84f100503a7363f37aa8e3fe')
+noextract=("${_deb_x86_64}" "${_deb_aarch64}")
 
 package() {
-  bsdtar -xOf "${srcdir}/${pkgname}_${pkgver}.deb" data.tar.xz |
+  local deb_var="_deb_${CARCH}"
+  local deb="${!deb_var}"
+
+  bsdtar -xOf "${srcdir}/${deb}" data.tar.xz |
     bsdtar -x -C "${pkgdir}" -f -
 
   rm -rf "${pkgdir}/usr/share/doc" \
-    "${pkgdir}/usr/share/applications/sand.desktop"
+         "${pkgdir}/usr/share/applications/sand.desktop" \
+         "${pkgdir}/usr/share/applications/grok-bot.desktop"
 
   local icon1024="${pkgdir}/usr/share/icons/hicolor/1024x1024/apps"
   if [[ -f "${icon1024}/sand.png" && ! -f "${icon1024}/grok-bot.png" ]]; then

--- a/pkgbuilds/grok-bot/update-pkgver.sh
+++ b/pkgbuilds/grok-bot/update-pkgver.sh
@@ -1,49 +1,136 @@
 #!/usr/bin/env bash
 # Resolve current Grok Bot stable from Cursor's update feed and pin PKGBUILD.
-# Linux has no latest alias (linux-x64 feed returns 204). The darwin-arm64
-# sand feed publishes version + commit; the Linux .deb lives at the same commit.
-# Darwin can ship first — HEAD-check the Linux URL and fail loudly if 404.
+#
+# Prefer the linux-x64 / linux-arm64 sand feeds: they include the 40-char
+# build id in the artifact URL. Darwin feeds currently publish a versioned
+# zip without that commit, so they cannot locate the Linux .deb.
+#
+# Deb filenames changed at 0.30.0:
+#   linux/x64/grok-bot_${ver}_amd64.deb
+#   linux/arm64/grok-bot_${ver}_arm64.deb
+# Older builds used Grok_Bot_${ver}.deb on both arches. HEAD-check new names
+# first, then the old name, and fail loudly if neither exists.
 set -euo pipefail
 
 PKGBUILD_PATH="${1:-PKGBUILD}"
 [[ -f "${PKGBUILD_PATH}" ]] || { echo "Error: PKGBUILD not found at '${PKGBUILD_PATH}'" >&2; exit 1; }
 
-FEED='https://api2.cursor.sh/updates/api/update/darwin-arm64/sand/0.0.0/00000000-0000-0000-0000-000000000000/stable'
-json="$(curl -fsSL -H 'cache-control: no-cache' "${FEED}")"
+MACHINE_ID='00000000-0000-0000-0000-000000000000'
+FEED_LINUX_X64="https://api2.cursor.sh/updates/api/update/linux-x64/sand/0.0.0/${MACHINE_ID}/stable"
+FEED_LINUX_ARM64="https://api2.cursor.sh/updates/api/update/linux-arm64/sand/0.0.0/${MACHINE_ID}/stable"
+FEED_DARWIN="https://api2.cursor.sh/updates/api/update/darwin-arm64/sand/0.0.0/${MACHINE_ID}/stable"
 
-ver="$(jq -er '.name // .version' <<<"${json}")"
-feed_url="$(jq -er '.url' <<<"${json}")"
-commit="$(sed -nE 's@.*/(grokbot|sand)/stable/([0-9a-f]{40})/.*@\2@p' <<<"${feed_url}")"
+http_code() {
+  curl -fsSIL -o /dev/null -w '%{http_code}' "$1" || true
+}
+
+parse_commit() {
+  sed -nE 's@.*/(grokbot|sand)/stable/([0-9a-f]{40})/.*@\2@p' <<<"$1"
+}
+
+fetch_feed() {
+  curl -fsSL -H 'cache-control: no-cache' "$1"
+}
+
+json="$(fetch_feed "${FEED_LINUX_X64}" || true)"
+ver=""
+feed_url=""
+commit=""
+if [[ -n "${json}" ]]; then
+  ver="$(jq -er '.name // .version // .productVersion' <<<"${json}" 2>/dev/null || true)"
+  feed_url="$(jq -er '.url' <<<"${json}" 2>/dev/null || true)"
+  commit="$(parse_commit "${feed_url}")"
+fi
+
+if [[ -z "${ver}" || -n "${ver}" && -z "${commit}" ]]; then
+  json="$(fetch_feed "${FEED_LINUX_ARM64}" || true)"
+  if [[ -n "${json}" ]]; then
+    ver="$(jq -er '.name // .version // .productVersion' <<<"${json}")"
+    feed_url="$(jq -er '.url' <<<"${json}")"
+    commit="$(parse_commit "${feed_url}")"
+  fi
+fi
+
+if [[ -z "${ver}" || -z "${commit}" ]]; then
+  json="$(fetch_feed "${FEED_DARWIN}")"
+  ver="$(jq -er '.name // .version' <<<"${json}")"
+  feed_url="$(jq -er '.url' <<<"${json}")"
+  commit="$(parse_commit "${feed_url}")"
+fi
 
 [[ -n "${ver}" && -n "${commit}" ]] || {
-  echo "Error: could not parse version/commit from feed: ${json}" >&2
+  echo "Error: could not parse version/commit from feeds" >&2
+  echo "${json}" >&2
   exit 1
 }
 
-deb_url="https://downloads.cursor.com/grokbot/stable/${commit}/linux/x64/Grok_Bot_${ver}.deb"
-code="$(curl -fsSIL -o /dev/null -w '%{http_code}' "${deb_url}")"
-[[ "${code}" == "200" ]] || {
-  echo "Error: Linux deb not fetchable (${code}): ${deb_url}" >&2
-  exit 1
+resolve_deb() {
+  local arch_dir="$1" new_name="$2" old_name="$3"
+  local base="https://downloads.cursor.com/grokbot/stable/${commit}/linux/${arch_dir}"
+  local new_url="${base}/${new_name}"
+  local old_url="${base}/${old_name}"
+  local code
+
+  code="$(http_code "${new_url}")"
+  if [[ "${code}" == "200" ]]; then
+    printf '%s\n' "${new_url}"
+    return 0
+  fi
+  code="$(http_code "${old_url}")"
+  if [[ "${code}" == "200" ]]; then
+    printf '%s\n' "${old_url}"
+    return 0
+  fi
+  echo "Error: Linux ${arch_dir} deb not fetchable (new=${new_url} old=${old_url})" >&2
+  return 1
 }
 
-tmp="$(mktemp)"
-trap 'rm -f "${tmp}"' EXIT
-curl -fL --retry 3 -o "${tmp}" "${deb_url}"
-sum="$(sha256sum "${tmp}" | awk '{print $1}')"
+deb_x64="$(resolve_deb x64 "grok-bot_${ver}_amd64.deb" "Grok_Bot_${ver}.deb")"
+deb_arm64="$(resolve_deb arm64 "grok-bot_${ver}_arm64.deb" "Grok_Bot_${ver}.deb")"
+
+hash_url() {
+  local tmp
+  tmp="$(mktemp)"
+  curl -fL --retry 3 -o "${tmp}" "$1"
+  sha256sum "${tmp}" | awk '{print $1}'
+  rm -f "${tmp}"
+}
+
+sum_x64="$(hash_url "${deb_x64}")"
+sum_arm64="$(hash_url "${deb_arm64}")"
 
 current_ver="$(sed -nE 's/^pkgver=([^[:space:]#]+).*/\1/p' "${PKGBUILD_PATH}" | head -n1)"
 
-sed -i -E \
-  -e "s/^_commit=.*/_commit=${commit}/" \
-  -e "s/^pkgver=.*/pkgver=${ver}/" \
-  -e "0,/^[[:space:]]*'[0-9a-f]{64}'/s//    '${sum}'/" \
-  "${PKGBUILD_PATH}"
+deb_x64_file="$(basename "${deb_x64}")"
+deb_arm64_file="$(basename "${deb_arm64}")"
+
+python3 - "${PKGBUILD_PATH}" "${commit}" "${ver}" "${deb_x64_file}" "${deb_arm64_file}" "${sum_x64}" "${sum_arm64}" <<'PY'
+import pathlib, re, sys
+
+path, commit, ver, deb_x64, deb_arm64, sum_x64, sum_arm64 = sys.argv[1:]
+text = pathlib.Path(path).read_text()
+
+def sub(pattern, repl, count=1):
+    global text
+    text, n = re.subn(pattern, repl, text, count=count, flags=re.M)
+    if n != count:
+        raise SystemExit(f"failed to rewrite {pattern!r} ({n} matches, wanted {count})")
+
+sub(r"^_commit=.*", f"_commit={commit}")
+sub(r"^pkgver=.*", f"pkgver={ver}")
+sub(r'^_deb_x86_64=.*', f'_deb_x86_64="{deb_x64}"')
+sub(r'^_deb_aarch64=.*', f'_deb_aarch64="{deb_arm64}"')
+sub(r"^sha256sums_x86_64=.*", f"sha256sums_x86_64=('{sum_x64}')")
+sub(r"^sha256sums_aarch64=.*", f"sha256sums_aarch64=('{sum_arm64}')")
+pathlib.Path(path).write_text(text)
+PY
 
 if [[ "${ver}" != "${current_ver}" ]]; then
   sed -i -E 's/^pkgrel=.*/pkgrel=1/' "${PKGBUILD_PATH}"
 fi
 
 echo "${ver} ${commit}"
-echo "${deb_url}"
-echo "${sum}"
+echo "${deb_x64}"
+echo "${sum_x64}"
+echo "${deb_arm64}"
+echo "${sum_arm64}"


### PR DESCRIPTION
Omarchy's Install > AI > Grok Bot menu runs `omarchy-pkg-add grok-bot`. That package was `arch=('x86_64')` and downloaded `Grok_Bot_${pkgver}.deb`, which 403s for 0.30.0.

Cursor now publishes official Linux debs:

- `linux/x64/grok-bot_0.30.0_amd64.deb`
- `linux/arm64/grok-bot_0.30.0_arm64.deb`

The arm64 binary is ELF AArch64 (`BuildID b45c284f…`). SHA-256:

- amd64 `fb888b2204c8a51c71a9f5f9a2913ac10561f3ef6939c1245ecae4e837d4ada2`
- arm64 `7c4c81d576181a57b34b812258b2620626717cec84f100503a7363f37aa8e3fe`

This updates the recipe to 0.30.0, adds `aarch64`, and reads version/commit from the linux sand update feeds. Darwin feeds no longer embed the 40-char build id, so the old updater could not locate the Linux artifacts.

`update-pkgver.sh` HEAD-checks the new filenames first, then falls back to `Grok_Bot_${ver}.deb`.
