### PR TITLE
Add snd-hda-macbookpro-dkms for pre-T2 MacBook and iMac speakers

### DIFF
--- a/pkgbuilds/snd-hda-macbookpro-dkms/.omarchy/package.json
+++ b/pkgbuilds/snd-hda-macbookpro-dkms/.omarchy/package.json
@@ -1,0 +1,3 @@
+{
+  "source": "local"
+}

--- a/pkgbuilds/snd-hda-macbookpro-dkms/PKGBUILD
+++ b/pkgbuilds/snd-hda-macbookpro-dkms/PKGBUILD
@@ -4,7 +4,9 @@
 # The AUR package (snd-hda-macbookpro-dkms-git) copies only a subset of
 # the tree and does not depend on wget, which PRE_BUILD needs to fetch
 # matching kernel sources. This package installs the whole driver and
-# pins the commit verified on MacBookPro14,3 / linux 7.1.8.
+# pins the commit verified on MacBookPro14,3 / linux 7.1.8. The same
+# Apple CS8409 path covers 2017–2019 iMacs (e.g. iMac18,3 subsystem
+# 0x106b1000).
 
 _pkgbase=snd-hda-macbookpro
 # Must match PACKAGE_NAME in upstream dkms.conf. The AUR dest uses hyphens
@@ -14,8 +16,8 @@ _pkgbase=snd-hda-macbookpro
 _srcname=snd_hda_macbookpro
 pkgname=${_pkgbase}-dkms
 pkgver=0.1
-pkgrel=2
-pkgdesc="DKMS driver for Cirrus CS8409 HDA on 2016–2017 MacBook Pros"
+pkgrel=3
+pkgdesc="DKMS driver for Cirrus CS8409 HDA on 2016–2017 MacBook Pros and 2017–2019 iMacs"
 arch=('x86_64')
 url="https://github.com/davidjo/snd_hda_macbookpro"
 license=('GPL-2.0-only')

--- a/pkgbuilds/snd-hda-macbookpro-dkms/PKGBUILD
+++ b/pkgbuilds/snd-hda-macbookpro-dkms/PKGBUILD
@@ -1,0 +1,38 @@
+# Maintainer: Omarchy <https://omarchy.org>
+# Upstream: https://github.com/davidjo/snd_hda_macbookpro
+#
+# The AUR package (snd-hda-macbookpro-dkms-git) copies only a subset of
+# the tree and does not depend on wget, which PRE_BUILD needs to fetch
+# matching kernel sources. This package installs the whole driver and
+# pins the commit verified on MacBookPro14,3 / linux 7.1.8.
+
+_pkgbase=snd-hda-macbookpro
+pkgname=${_pkgbase}-dkms
+pkgver=0.1
+pkgrel=1
+pkgdesc="DKMS driver for Cirrus CS8409 HDA on 2016–2017 MacBook Pros"
+arch=('x86_64')
+url="https://github.com/davidjo/snd_hda_macbookpro"
+license=('GPL-2.0-only')
+depends=('dkms' 'wget' 'patch')
+makedepends=('git')
+optdepends=('linux-headers: build against the Arch kernel')
+provides=('snd-hda-macbookpro-dkms-git')
+conflicts=('snd-hda-macbookpro-dkms-git')
+# 6c324f6: dkms.conf for current kernels; 6.17+ install path.
+_commit=6c324f6c9262faa853fdd74d798c5686937a9d0f
+source=("git+https://github.com/davidjo/snd_hda_macbookpro.git#commit=${_commit}")
+sha256sums=('SKIP')
+
+package() {
+    local dest="${pkgdir}/usr/src/${_pkgbase}-${pkgver}"
+
+    install -dm755 "$dest"
+    cp -a snd_hda_macbookpro/. "$dest/"
+    rm -rf "$dest/.git" "$dest/build"
+
+    # PRE_BUILD runs install.cirrus.driver.sh; the AUR package left these 0644.
+    chmod 755 "$dest"/install.cirrus.driver.sh \
+              "$dest"/install.cirrus.driver.pre617.sh \
+              "$dest"/dkms.sh
+}

--- a/pkgbuilds/snd-hda-macbookpro-dkms/PKGBUILD
+++ b/pkgbuilds/snd-hda-macbookpro-dkms/PKGBUILD
@@ -7,9 +7,14 @@
 # pins the commit verified on MacBookPro14,3 / linux 7.1.8.
 
 _pkgbase=snd-hda-macbookpro
+# Must match PACKAGE_NAME in upstream dkms.conf. The AUR dest uses hyphens
+# (snd-hda-macbookpro-0.1); Arch's alpm hook then runs
+# `dkms install snd-hda-macbookpro/0.1`, which exits 7 because PACKAGE_NAME
+# is snd_hda_macbookpro. omarchy-pkg-add relies on that hook.
+_srcname=snd_hda_macbookpro
 pkgname=${_pkgbase}-dkms
 pkgver=0.1
-pkgrel=1
+pkgrel=2
 pkgdesc="DKMS driver for Cirrus CS8409 HDA on 2016–2017 MacBook Pros"
 arch=('x86_64')
 url="https://github.com/davidjo/snd_hda_macbookpro"
@@ -25,7 +30,7 @@ source=("git+https://github.com/davidjo/snd_hda_macbookpro.git#commit=${_commit}
 sha256sums=('SKIP')
 
 package() {
-    local dest="${pkgdir}/usr/src/${_pkgbase}-${pkgver}"
+    local dest="${pkgdir}/usr/src/${_srcname}-${pkgver}"
 
     install -dm755 "$dest"
     cp -a snd_hda_macbookpro/. "$dest/"


### PR DESCRIPTION
## Summary
- Adds `snd-hda-macbookpro-dkms` for the Cirrus CS8409 Apple speaker path ([davidjo/snd_hda_macbookpro](https://github.com/davidjo/snd_hda_macbookpro)).
- Includes @shawnyeager's packaging from #155 (full tree, `wget`/`patch` deps, correct `PACKAGE_NAME` install path) and widens `pkgdesc` / comments for **2017–2019 iMacs** as well as 2016–2017 MacBook Pros.
- Pairs with the omarchy install hook PR that detects `MacBookPro13,x` / `14,x` and `iMac18,x` / `iMac19,x`.

Pins commit `6c324f6` (verified on MacBookPro14,3 / linux 7.1.8). Same Apple CS8409 path applies to iMacs such as iMac18,3 (subsystem `0x106b1000`).

`source: local` so an AUR sync does not replace it. Provides/conflicts with `snd-hda-macbookpro-dkms-git`.

## Test plan
- [ ] Package builds in omarchy-pkgs pipeline
- [ ] On a CS8409 Mac: `omarchy-pkg-add linux-headers snd-hda-macbookpro-dkms` → DKMS install succeeds → reboot → speakers work

Can close #155 in favor of this once reviewed.

Made with [Cursor](https://cursor.com)