### PR TITLE
Add Omakade to the fast ring

### DIFF
--- a/pkgbuilds/omakade/.omarchy/package.json
+++ b/pkgbuilds/omakade/.omarchy/package.json
@@ -1,0 +1,11 @@
+{
+  "source": "local",
+  "release_ring": "fast",
+  "upstream": {
+    "github": "tsouth89/omakade",
+    "checksums": "SHA256SUMS",
+    "assets": {
+      "any": "omakade-{pkgver}.tar.gz"
+    }
+  }
+}

--- a/pkgbuilds/omakade/PKGBUILD
+++ b/pkgbuilds/omakade/PKGBUILD
@@ -1,0 +1,24 @@
+pkgname=omakade
+pkgver=1.2.0
+pkgrel=1
+pkgdesc='A beautiful, local-first game library for Omarchy'
+arch=('x86_64')
+url='https://tsouth89.github.io/omakade/'
+license=('GPL-3.0-or-later')
+depends=('glib2' 'libsecret' 'qt6-base' 'qt6-declarative' 'qt6-wayland' 'sdl3')
+makedepends=('cmake' 'ninja' 'pkgconf')
+options=('!debug')
+source=("$pkgname-$pkgver.tar.gz::https://github.com/tsouth89/omakade/releases/download/v$pkgver/$pkgname-$pkgver.tar.gz")
+sha256sums=('292b62b7598e2f27dabe46aaa131d33180f49082ed09efc5727a7925e365edac')
+
+build() {
+  cmake -S "$pkgname-$pkgver" -B build -G Ninja \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_INSTALL_PREFIX=/usr \
+    -DBUILD_TESTING=OFF
+  cmake --build build
+}
+
+package() {
+  DESTDIR="$pkgdir" cmake --install build
+}


### PR DESCRIPTION
Adds Omakade 1.2.0 from its tagged source release.

- Builds the native x86_64 Qt application from source
- Places Omakade in the fast ring for edge, rc, and stable
- Tracks stable GitHub releases through the upstream SHA256SUMS manifest

Verified with the repository self-tests, makepkg source verification, a clean OPR Docker build, and the packaged application smoke test.