### PR TITLE
Add Link Studio to the fast ring

### DIFF
--- a/pkgbuilds/link-studio/.omarchy/package.json
+++ b/pkgbuilds/link-studio/.omarchy/package.json
@@ -1,0 +1,11 @@
+{
+  "source": "local",
+  "release_ring": "fast",
+  "upstream": {
+    "github": "jweaver60/link-studio",
+    "checksums": "SHA256SUMS",
+    "assets": {
+      "any": "dist/link-studio-{pkgver}.tar.gz"
+    }
+  }
+}

--- a/pkgbuilds/link-studio/PKGBUILD
+++ b/pkgbuilds/link-studio/PKGBUILD
@@ -1,0 +1,61 @@
+# Maintainer: Jake Weaver <jakeweaver at hey dot com>
+pkgname=link-studio
+pkgver=1.0.2
+pkgrel=1
+pkgdesc="Native Linux controller for Insta360 Link webcams"
+arch=('x86_64')
+url="https://jweaver60.github.io/link-studio/"
+license=('MIT')
+depends=(
+  'gst-libav'
+  'gst-plugins-bad'
+  'gst-plugins-base'
+  'gst-plugins-good'
+  'gtk4'
+  'libadwaita'
+  'python-gobject'
+  'python-mediapipe'
+  'python-numpy'
+  'python-opencv'
+  'python-pillow'
+  'python-qrcode'
+  'v4l-utils'
+)
+makedepends=('python-build' 'python-installer' 'python-setuptools' 'python-wheel')
+optdepends=(
+  'v4l2loopback-dkms: processed virtual-camera output'
+  'v4l2loopback-utils: virtual-camera controls'
+  'whisper-cpp: offline meeting transcription'
+)
+source=("${pkgname}-${pkgver}.tar.gz::https://github.com/jweaver60/link-studio/releases/download/v${pkgver}/${pkgname}-${pkgver}.tar.gz")
+sha256sums=('b0fc912d8b7924661b57e427280c9766cbb0f01b7a2b3f3cdb1885969f8cfdc6')
+
+build() {
+  cd "link_studio-${pkgver}"
+  python -m build --wheel --no-isolation
+}
+
+check() {
+  cd "link_studio-${pkgver}"
+  PYTHONPATH=src python -m unittest discover -v
+}
+
+package() {
+  cd "link_studio-${pkgver}"
+  python -m installer --destdir="$pkgdir" --prefix=/usr dist/*.whl
+  sed -i '1c#!/usr/bin/python' "$pkgdir/usr/bin/link-studio"
+
+  install -Dm644 data/io.github.linkstudio.LinkStudio.desktop \
+    "$pkgdir/usr/share/applications/io.github.linkstudio.LinkStudio.desktop"
+  install -Dm644 data/io.github.linkstudio.LinkStudio.metainfo.xml \
+    "$pkgdir/usr/share/metainfo/io.github.linkstudio.LinkStudio.metainfo.xml"
+  install -Dm755 scripts/setup-virtual-camera \
+    "$pkgdir/usr/bin/link-studio-setup-virtual-camera"
+  install -Dm755 scripts/setup-local-ai \
+    "$pkgdir/usr/bin/link-studio-setup-local-ai"
+  install -Dm644 LICENSE "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+  install -Dm644 THIRD_PARTY_NOTICES.md \
+    "$pkgdir/usr/share/licenses/$pkgname/THIRD_PARTY_NOTICES.md"
+  install -Dm644 README.md "$pkgdir/usr/share/doc/$pkgname/README.md"
+  install -Dm644 docs/PARITY.md "$pkgdir/usr/share/doc/$pkgname/PARITY.md"
+}

--- a/pkgbuilds/python-mediapipe/.omarchy/package.json
+++ b/pkgbuilds/python-mediapipe/.omarchy/package.json
@@ -1,0 +1,5 @@
+{
+  "source": "aur",
+  "release_ring": "fast",
+  "upstream_commit": "99700efde7dc0200719dfed1a1147ace2cd7b0c0"
+}

--- a/pkgbuilds/python-mediapipe/.omarchy/patches/verify-bazel-source.patch
+++ b/pkgbuilds/python-mediapipe/.omarchy/patches/verify-bazel-source.patch
@@ -1,0 +1,42 @@
+--- a/PKGBUILD
++++ b/PKGBUILD
+@@ -2,6 +2,7 @@
+ # Maintainer: Hu Butui <hot123tea123@gmail.com>
+ 
+ _pkgname=mediapipe
++_bazel_version=7.4.1
+ pkgname=python-mediapipe
+ pkgver=1.0.0
+ pkgrel=2
+@@ -27,10 +28,10 @@ makedepends=(
+   python-installer
+   python-setuptools
+   python-wheel
+-  wget
+ )
+ 
+ source=("${_pkgname}-${pkgver}.tar.gz::https://github.com/google-ai-edge/mediapipe/archive/refs/tags/v${pkgver}.tar.gz"
++  "bazel-${_bazel_version}-linux-x86_64::https://github.com/bazelbuild/bazel/releases/download/${_bazel_version}/bazel-${_bazel_version}-linux-x86_64"
+   "0004-use-opencv-headers.patch"
+   "0005-set-hermetic-python-version-and-disable-odml-converter.patch"
+   "0006-opencv5-geometry-header.patch"
+@@ -38,6 +39,7 @@ source=("${_pkgname}-${pkgver}.tar.gz::https://github.com/google-ai-edge/medi
+   "0007-bump-rules-java.patch"
+ )
+ sha256sums=('6343314dad0f4112610807ca723eee63feea00711dc2be9360928b6f0a5eba12'
++            'c97f02133adce63f0c28678ac1f21d65fa8255c80429b588aeeba8a1fac6202b'
+             'd18e88a217a00dc77cf2bfaa1d33b5fbc912deed5df686b0d2455fb0db75a677'
+             '62cbd43346e7a7705127656a74bec44852e5bbfc006c4723005fdd23af5258db'
+             'fb082d88d9cca47534ae01fca676a3afdb909bfc82d52c97cf0eaedf34571d5f'
+@@ -47,9 +49,8 @@ sha256sums=('6343314dad0f4112610807ca723eee63feea00711dc2be9360928b6f0a5eba12'
+ prepare() {
+   # bazel in the ArchLinux is not working
+   mkdir -p ${srcdir}/bin
+-  bazel_version=$(cat ${srcdir}/${_pkgname}-${pkgver}/.bazelversion)
+-  wget https://github.com/bazelbuild/bazel/releases/download/${bazel_version}/bazel-${bazel_version}-linux-x86_64 -O ${srcdir}/bin/bazel
+-  chmod +x ${srcdir}/bin/bazel
++  install -Dm755 "${srcdir}/bazel-${_bazel_version}-linux-x86_64" \
++    "${srcdir}/bin/bazel"
+   export PATH=${srcdir}/bin:${PATH}
+   cd "${srcdir}/${_pkgname}-${pkgver}"
+   patch -p1 -i "${srcdir}/0004-use-opencv-headers.patch"

--- a/pkgbuilds/python-mediapipe/0004-use-opencv-headers.patch
+++ b/pkgbuilds/python-mediapipe/0004-use-opencv-headers.patch
@@ -1,0 +1,41 @@
+From 454702a3fa207ae5553627a60cfd36b36e2b344c Mon Sep 17 00:00:00 2001
+From: Butui Hu <hot123tea123@gmail.com>
+Date: Wed, 21 Feb 2024 10:56:46 +0800
+Subject: [PATCH 4/5] use external opencv headers
+
+Arch packages OpenCV 5 headers under /usr/include/opencv5 and renamed
+libopencv_calib3d/libopencv_features2d to libopencv_calib/libopencv_features.
+
+---
+ third_party/opencv_linux.BUILD | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/third_party/opencv_linux.BUILD b/third_party/opencv_linux.BUILD
+--- a/third_party/opencv_linux.BUILD
++++ b/third_party/opencv_linux.BUILD
+@@ -18,19 +18,19 @@
+         #"include/aarch64-linux-gnu/opencv4/opencv2/cvconfig.h",
+         #"include/arm-linux-gnueabihf/opencv4/opencv2/cvconfig.h",
+         #"include/x86_64-linux-gnu/opencv4/opencv2/cvconfig.h",
+-        #"include/opencv4/opencv2/**/*.h*",
++        "include/opencv5/opencv2/**/*.h*",
+     ]),
+     includes = [
+         # For OpenCV 4.x
+         #"include/aarch64-linux-gnu/opencv4/",
+         #"include/arm-linux-gnueabihf/opencv4/",
+         #"include/x86_64-linux-gnu/opencv4/",
+-        #"include/opencv4/",
++        "include/opencv5/",
+     ],
+     linkopts = [
+         "-l:libopencv_core.so",
+-        "-l:libopencv_calib3d.so",
+-        "-l:libopencv_features2d.so",
++        "-l:libopencv_calib.so",
++        "-l:libopencv_features.so",
+         "-l:libopencv_highgui.so",
+         "-l:libopencv_imgcodecs.so",
+         "-l:libopencv_imgproc.so",
+-- 
+2.43.2

--- a/pkgbuilds/python-mediapipe/0005-set-hermetic-python-version-and-disable-odml-converter.patch
+++ b/pkgbuilds/python-mediapipe/0005-set-hermetic-python-version-and-disable-odml-converter.patch
@@ -1,0 +1,13 @@
+--- a/.bazelrc
++++ b/.bazelrc
+@@ -129,6 +129,10 @@
+ # with system Python 3.14+
+ common --repo_env=HERMETIC_PYTHON_VERSION=3.12
+ 
++# Force Bazel hermetic Python to use 3.12 to avoid incompatibility
++# with system Python 3.14+
++common --repo_env=HERMETIC_PYTHON_VERSION=3.12
++
+ # This bazelrc file is meant to be written by a setup script.
+ try-import %workspace%/.configure.bazelrc
+ 

--- a/pkgbuilds/python-mediapipe/0006-opencv5-geometry-header.patch
+++ b/pkgbuilds/python-mediapipe/0006-opencv5-geometry-header.patch
@@ -1,0 +1,10 @@
+--- a/mediapipe/framework/port/opencv_imgproc_inc.h
++++ b/mediapipe/framework/port/opencv_imgproc_inc.h
+@@ -25,6 +25,8 @@
+ #include <opencv2/imgproc.hpp>
+ #if CV_VERSION_MAJOR == 4
+ #include <opencv2/imgproc/types_c.h>
++#elif CV_VERSION_MAJOR >= 5
++#include <opencv2/geometry/2d.hpp>
+ #endif
+ #endif

--- a/pkgbuilds/python-mediapipe/0007-bump-rules-java.patch
+++ b/pkgbuilds/python-mediapipe/0007-bump-rules-java.patch
@@ -1,0 +1,32 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Butui Hu <hot123tea123@gmail.com>
+Date: Sun, 30 Aug 2026 11:22:50 +0800
+Subject: [PATCH] bump rules_java to 7.12.5 to fix local_jdk auto-config
+
+rules_java 7.10.0 emits a local_jdk/BUILD.bazel referencing the
+non-existent @rules_java//tools/jdk package when no local JDK is
+detected (a 7.10.0 regression). 7.11.0+ points at
+@rules_java//toolchains:bootstrap_runtime_toolchain_type (the correct
+location). 7.12.5 is the last 7.x with the label fully cleaned up.
+
+---
+ MODULE.bazel | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -13,10 +13,10 @@
+     version = "0.2.9",
+ )
+ 
+-bazel_dep(name = "rules_java", version = "7.10.0")
++bazel_dep(name = "rules_java", version = "7.12.5")
+ single_version_override(
+     module_name = "rules_java",
+-    version = "7.10.0",
++    version = "7.12.5",
+ )
+ 
+ bazel_dep(name = "rules_kotlin", version = "1.9.6")
+-- 
+2.43.2

--- a/pkgbuilds/python-mediapipe/PKGBUILD
+++ b/pkgbuilds/python-mediapipe/PKGBUILD
@@ -1,0 +1,87 @@
+# Maintainer: robertfoster
+# Maintainer: Hu Butui <hot123tea123@gmail.com>
+
+_pkgname=mediapipe
+_bazel_version=7.4.1
+pkgname=python-mediapipe
+pkgver=1.0.0
+pkgrel=2.1
+pkgdesc="A cross-platform, customizable ML solutions for live and streaming media"
+arch=('x86_64')
+url="https://github.com/google-ai-edge/mediapipe"
+license=("Apache-2.0")
+depends=(
+  absl-py
+  gcc-libs
+  glibc
+  libglvnd
+  opencv
+  opengl-driver
+  python-attrs
+  python-flatbuffers
+  python-matplotlib
+  python-numpy
+  python-opencv
+  python-pillow
+  python-protobuf
+  python-scipy
+  python-six
+  python-sounddevice
+  python-tensorflow
+)
+makedepends=(
+  patchelf
+  python-build
+  python-installer
+  python-setuptools
+  python-wheel
+)
+
+source=("${_pkgname}-${pkgver}.tar.gz::https://github.com/google-ai-edge/mediapipe/archive/refs/tags/v${pkgver}.tar.gz"
+  "bazel-${_bazel_version}-linux-x86_64::https://github.com/bazelbuild/bazel/releases/download/${_bazel_version}/bazel-${_bazel_version}-linux-x86_64"
+  "0004-use-opencv-headers.patch"
+  "0005-set-hermetic-python-version-and-disable-odml-converter.patch"
+  "0006-opencv5-geometry-header.patch"
+  "0007-bump-rules-java.patch"
+)
+sha256sums=('6343314dad0f4112610807ca723eee63feea00711dc2be9360928b6f0a5eba12'
+            'c97f02133adce63f0c28678ac1f21d65fa8255c80429b588aeeba8a1fac6202b'
+            'd18e88a217a00dc77cf2bfaa1d33b5fbc912deed5df686b0d2455fb0db75a677'
+            '62cbd43346e7a7705127656a74bec44852e5bbfc006c4723005fdd23af5258db'
+            'fb082d88d9cca47534ae01fca676a3afdb909bfc82d52c97cf0eaedf34571d5f'
+            'bdead49ac5370dc84d9facee962bf2def5d9055d7339a37b2ba3f3b4bb02f811')
+
+
+prepare() {
+  # bazel in the ArchLinux is not working
+  mkdir -p ${srcdir}/bin
+  install -Dm755 "${srcdir}/bazel-${_bazel_version}-linux-x86_64" \
+    "${srcdir}/bin/bazel"
+  export PATH=${srcdir}/bin:${PATH}
+  cd "${srcdir}/${_pkgname}-${pkgver}"
+  patch -p1 -i "${srcdir}/0004-use-opencv-headers.patch"
+  patch -p1 -i "${srcdir}/0005-set-hermetic-python-version-and-disable-odml-converter.patch"
+  patch -p1 -i "${srcdir}/0006-opencv5-geometry-header.patch"
+  patch -p1 -i "${srcdir}/0007-bump-rules-java.patch"
+  # set __version__
+  sed -i "s/__version__ = 'dev'/__version__ = '$pkgver'/" setup.py
+  # set link_opencv to True
+  sed -i "s/self.link_opencv = False/self.link_opencv = True/g" setup.py
+}
+
+build() {
+  cd "${srcdir}/${_pkgname}-${pkgver}"
+  # enable building with GPU support, using opengl-driver
+  # opengl-driver is provided by mesa or nvidia-utils
+  MEDIAPIPE_DISABLE_GPU=0 \
+    python -m build --wheel --no-isolation
+}
+
+package() {
+  cd "${srcdir}/${_pkgname}-${pkgver}"
+  python -m installer --destdir="${pkgdir}" dist/*.whl
+  # remove rpath and fix permission
+  find ${pkgdir} -type f -name "*.so" -exec patchelf --remove-rpath {} \;
+  find ${pkgdir} -type f -name "*.so" -exec chmod 755 {} \;
+}
+# vim:set ts=2 sw=2 et:

--- a/pkgbuilds/python-sounddevice/.nvchecker.toml
+++ b/pkgbuilds/python-sounddevice/.nvchecker.toml
@@ -1,0 +1,3 @@
+[python-sounddevice]
+source = "pypi"
+pypi = "sounddevice"

--- a/pkgbuilds/python-sounddevice/.omarchy/package.json
+++ b/pkgbuilds/python-sounddevice/.omarchy/package.json
@@ -1,0 +1,5 @@
+{
+  "source": "aur",
+  "release_ring": "fast",
+  "upstream_commit": "c3a5320f95ada9ccebd629b5722276e645388ced"
+}

--- a/pkgbuilds/python-sounddevice/PKGBUILD
+++ b/pkgbuilds/python-sounddevice/PKGBUILD
@@ -1,0 +1,22 @@
+# Maintainer: Alexander F. Rødseth <xyproto@archlinux.org>
+# Contributor: robertfoster <morf3089@gmail.com>
+# Contributor: Håvard Pettersson <mail@haavard.me>
+
+pkgname=python-sounddevice
+pkgver=0.5.5
+pkgrel=1
+pkgdesc='Record and play back sound'
+url='https://python-sounddevice.rtfd.io/'
+arch=(any)
+license=(MIT)
+depends=(portaudio python-cffi)
+makedepends=(python-setuptools)
+optdepends=('python-numpy: to play back and record NumPy arrays')
+source=("https://files.pythonhosted.org/packages/source/s/sounddevice/sounddevice-$pkgver.tar.gz")
+b2sums=('25da7f11bb20f115c828bfb4de00c7ced40224126b5da3a08027c0459d40e1300a4747305c25dab480f73db87c9ad6f0982d0af6adf8c3cc4d5de2e0e9ffaaff')
+
+package() {
+  cd sounddevice-$pkgver
+  python setup.py install --prefix=/usr --root="$pkgdir" --optimize=1
+  install -Dm644 LICENSE "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+}


### PR DESCRIPTION
Adds Link Studio 1.0.2 and the two AUR-only Python dependencies it needs.

- Builds Link Studio from tagged source and puts all three packages in the fast ring.
- Follows stable GitHub releases through the upstream `SHA256SUMS`; the dependencies stay on the scheduled AUR sync.
- Carries a small MediaPipe patch that turns its downloaded Bazel executable into a checksummed makepkg source.
- Keeps Link Studio and MediaPipe on x86_64, matching MediaPipe support.

Verified with the repository self-tests, upstream and AUR resyncs, source verification, a full clean x86 dependency-chain build, and all 69 Link Studio upstream unit tests.