### PR TITLE
sync-upstream: confirm the repository behind a release feed

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,6 +331,20 @@ or the sync fails. A maintainer deliberately shipping inside the window runs
 `BYPASS_MIN_RELEASE_AGE=1 bin/sync-upstream <package>` locally and merges the
 result through a normal PR; scheduled automation never sets the bypass.
 
+Before a release is adopted, the provider confirms the repository serving the
+feed is still the one that was declared. A repository that GitHub reports under a
+different `full_name` was renamed or transferred: the declared name still
+resolves through GitHub's redirect, so nothing else in the sync notices, while
+the abandoned name is free for anyone to register and inherit the feed. And an
+archived repository cannot publish anything, so a feed that appears to ship a new
+release from one is not the feed we believe we are reading. Either fails the
+sync, as does a repository response that cannot be read at all. The check costs
+one API call, made only when a new release is about to be adopted.
+
+Repository age and release count are deliberately not checked. Neither says
+anything about whether an artifact is safe, and a threshold on either would
+reject sound young projects while stopping no attacker willing to wait.
+
 A vendor whose feed fits no convention (a Debian package index, a bare
 version.txt) instead provides `.omarchy/upstream.sh`, a hook that reports the
 newest upstream release as JSON on stdout — declaring both an `upstream` block
@@ -360,7 +374,8 @@ it describes. Hooks honoring `min_release_age` receive the window as
 `MIN_RELEASE_AGE_SECONDS` and report `published_at` alongside `pkgver`.
 
 `bin/sync-upstream self-test` runs offline fixture tests over the release
-selection, quarantine backstop, duration parsing, and manifest validation.
+selection, repository identity, quarantine backstop, duration parsing, and
+manifest validation.
 
 ### Sync Rebuild Triggers
 

--- a/bin/sync-upstream
+++ b/bin/sync-upstream
@@ -49,8 +49,8 @@ Arguments:
   PACKAGE    One or more package names to update (optional)
 
 Commands:
-  self-test  Run the offline fixture tests for release selection, the
-             quarantine backstop, and metadata parsing
+  self-test  Run the offline fixture tests for release selection, repository
+             identity, the quarantine backstop, and metadata parsing
 
 Examples:
   $0                          # Update every package with an upstream source
@@ -460,9 +460,10 @@ sync_package() {
 # are swapped for fixture readers, everything else runs the production code
 # paths. Covers release selection (fallback past quarantined releases,
 # draft/prerelease filtering, bypass, unchanged version), failure paths
-# (unusable tags/timestamps, missing checksums), checksum template mapping
-# for both architectures, the min_release_age backstop, the duration parser,
-# and manifest validation.
+# (unusable tags/timestamps, missing checksums), repository identity (rename,
+# archive, unreadable metadata), checksum template mapping for both
+# architectures, the min_release_age backstop, the duration parser, and
+# manifest validation.
 cmd_self_test() {
   local failures=0
 
@@ -522,6 +523,15 @@ EOF
 
   github_fetch_releases() { printf '%s' "$FIXTURE_RELEASES"; }
   github_fetch_checksums() { printf '%s\n' "$FIXTURE_CHECKSUMS"; }
+  # Unset FIXTURE_REPO means "the declared repository, live and not archived",
+  # so every case that is not about the repository itself stays unaffected.
+  github_fetch_repo() {
+    if [[ -n "${FIXTURE_REPO:-}" ]]; then
+      printf '%s' "$FIXTURE_REPO"
+    else
+      jq -n --arg r "$1" '{full_name: $r, archived: false}'
+    fi
+  }
 
   echo "Release selection:"
   local out
@@ -561,6 +571,43 @@ EOF
   FIXTURE_CHECKSUMS="$sum_x19  ./tool-v1.9.0-x64.tar.xz"
   rc=0; github_upstream_release "$pkg" 86400 >/dev/null 2>&1 || rc=$?
   check "missing aarch64 checksum fails the sync" "1" "$rc"
+
+  echo "Repository identity:"
+  local rs
+  repo_facts() { jq -n --arg n "$1" --argjson a "$2" '{full_name: $n, archived: $a}'; }
+
+  rs=0; github_repo_identity_status "$(repo_facts "example/tool" false)" "example/tool" 2>/dev/null || rs=$?
+  check "the declared repository passes" "0" "$rs"
+
+  rs=0; github_repo_identity_status "$(repo_facts "Example/Tool" false)" "example/tool" 2>/dev/null || rs=$?
+  check "a difference in case is not a rename" "0" "$rs"
+
+  # The declared name still resolves through GitHub's redirect, so nothing else
+  # in the sync notices; the abandoned name is what an attacker can register.
+  rs=0; github_repo_identity_status "$(repo_facts "newowner/tool" false)" "example/tool" 2>/dev/null || rs=$?
+  check "a renamed or transferred repository fails the sync" "1" "$rs"
+
+  rs=0; github_repo_identity_status "$(repo_facts "example/tool" true)" "example/tool" 2>/dev/null || rs=$?
+  check "an archived repository fails the sync" "1" "$rs"
+
+  rs=0; github_repo_identity_status '{}' "example/tool" 2>/dev/null || rs=$?
+  check "unreadable repository metadata fails the sync" "1" "$rs"
+
+  rs=0; github_repo_identity_status '{"full_name": "example/tool"}' "example/tool" 2>/dev/null || rs=$?
+  check "a response missing archived fails rather than assuming live" "1" "$rs"
+
+  # End to end through the provider: the release feed is impeccable and the
+  # repository behind it is the thing that is wrong.
+  FIXTURE_RELEASES=$(jq -n --arg old2 "$old2d" '[
+    {tag_name: "v1.9.0", published_at: $old2, draft: false, prerelease: false}
+  ]')
+  FIXTURE_CHECKSUMS=$(printf '%s\n' \
+    "$sum_x19  ./tool-v1.9.0-x64.tar.xz" \
+    "$sum_a19  tool-v1.9.0-arm64.tar.xz")
+  FIXTURE_REPO=$(repo_facts "attacker/tool" false)
+  rc=0; github_upstream_release "$pkg" 86400 >/dev/null 2>&1 || rc=$?
+  check "a good feed under a hijackable name fails the whole sync" "1" "$rc"
+  FIXTURE_REPO=""
 
   echo "Quarantine backstop:"
   local rel st

--- a/helpers/upstream-github.sh
+++ b/helpers/upstream-github.sh
@@ -43,6 +43,64 @@ github_fetch_checksums() {
   curl -fsSL "https://github.com/$repo/releases/download/$tag/$asset"
 }
 
+github_fetch_repo() {
+  local repo="$1"
+  curl -fsSL "https://api.github.com/repos/$repo"
+}
+
+# Confirms the repository serving a feed is still the one that was declared.
+#
+# upstream.github is metadata a person wrote once, in a pull request, and has no
+# reason to revisit. Two things change underneath it without anything in the
+# sync noticing, and neither is a judgement call:
+#
+#   renamed   GitHub redirects a renamed or transferred repository, so a stale
+#             owner/repo keeps resolving and every sync keeps passing. The
+#             abandoned name is then free for anyone to register, and whoever
+#             takes it inherits this package's release feed. Comparing the
+#             full_name GitHub returns against what is declared is the whole
+#             defense, and it costs one field.
+#
+#   archived  An archived repository cannot publish anything, so a feed that
+#             appears to ship a new release from one is not the feed we believe
+#             we are reading -- the same class of anomaly this provider already
+#             treats as a loud error.
+#
+# Deliberately not checked: repository age and release count. Neither says
+# anything about whether an artifact is safe -- a project can be new and sound,
+# or old and never once reviewed -- and a threshold on either would reject
+# perfectly good young upstreams while stopping no attacker who is willing to
+# wait. Every check here reports a fact about the repository as it is now.
+github_repo_identity_status() {
+  local repo_json="$1" declared="$2"
+  local full_name archived
+
+  full_name=$(jq -r '.full_name // ""' <<<"$repo_json")
+  archived=$(jq -r 'if has("archived") then .archived else "missing" end' <<<"$repo_json")
+
+  # Fail closed on a response this cannot read, for the same reason an unusable
+  # tag fails the sync: a repository we cannot verify is not one to adopt a
+  # release from.
+  if [[ -z "$full_name" || "$archived" == "missing" ]]; then
+    echo "could not read repository metadata for $declared" >&2
+    return 1
+  fi
+
+  # GitHub treats owner and repository names case-insensitively, so a difference
+  # in case is not a rename.
+  if [[ "${full_name,,}" != "${declared,,}" ]]; then
+    echo "upstream.github declares $declared but GitHub serves $full_name: the repository was renamed or transferred, and the declared name is now free for anyone to register" >&2
+    return 1
+  fi
+
+  if [[ "$archived" == "true" ]]; then
+    echo "$declared is archived upstream and cannot be publishing new releases" >&2
+    return 1
+  fi
+
+  return 0
+}
+
 # Emits the newest qualifying release as hook-contract JSON. min_release_age
 # is honored during selection (newest release older than the window wins,
 # even when a younger one exists) and BYPASS_MIN_RELEASE_AGE=1 lifts it.
@@ -128,6 +186,16 @@ github_upstream_release() {
     echo '{}'
     return 0
   fi
+
+  # Confirmed here rather than before selection so a scheduled sync over every
+  # package pays for the extra call only when a release is actually about to be
+  # adopted -- the same place the checksum manifest is already fetched.
+  local repo_json
+  if ! repo_json=$(github_fetch_repo "$repo"); then
+    echo "could not fetch repository metadata for $repo" >&2
+    return 1
+  fi
+  github_repo_identity_status "$repo_json" "$repo" || return 1
 
   local checksums
   if ! checksums=$(github_fetch_checksums "$repo" "$best_tag" "$checksums_name"); then


### PR DESCRIPTION
`upstream.github` names the repository a package's releases come from. It is
written once, in the pull request that adds the package, and there is no reason
for anyone to look at it again.

Two things change underneath it without anything in the sync noticing.

**A repository gets renamed or transferred.** GitHub keeps serving the old
`owner/repo` through a redirect, so the feed still resolves and every sync keeps
passing. Meanwhile the old name is released back into the namespace: anyone can
register an account under the old owner and recreate the repository, and from
that point the redirect stops and `sync-upstream` reads their releases instead.
The package keeps building, keeps getting signed, and nothing in the pipeline has
a reason to complain.

**A repository gets archived.** An archived repository cannot publish a release,
so a feed that appears to ship one from it is not the feed we think we are
reading — the same class of anomaly this provider already treats as a loud error
when a tag or a timestamp is unusable.

Both are one field away from being detectable, so this checks them:

- the `full_name` GitHub returns must match what `upstream.github` declares
  (case-insensitively, since GitHub does not distinguish case)
- the repository must not be archived
- a repository response that cannot be read fails the sync, on the same grounds
  an unusable tag does

## What this deliberately does not check

Repository age and release count. Neither is evidence about an artifact — a
project can be new and sound, or years old and never once reviewed — and a
threshold on either rejects sound young upstreams while stopping no attacker who
is willing to wait. Every check here reports a fact about the repository as it is
right now, which is the only kind of claim it can honestly make.

## Cost

One `GET /repos/:owner/:repo`, on the path that already fetches the checksum
manifest, so it runs only when a release is actually about to be adopted rather
than once per package on a scheduled sync.

## Testing

`bin/sync-upstream self-test` gains 8 cases covering the rename, the archive, a
response missing `archived`, an unreadable response, the case-insensitivity rule,
and an end-to-end run where the release feed is impeccable and the repository
behind it is the thing that is wrong. The fetch sits behind a function like the
existing two, so the path stays offline; an unset fixture reports the declared
repository live and unarchived, which leaves every existing case unchanged.

48 assertions pass, verified on Arch with bash 5.3.8 and pacman's `vercmp`.

## Known limitation

The check runs when a new release is adopted, which means a repository that is
renamed while its feed is dormant is not noticed until the next release. Covering
that needs a periodic re-verification of every package rather than a check on the
adoption path, which seemed like a separate change rather than something to fold
in here. Happy to follow up with it if you want it.
