### PR TITLE
Add rime-ice-installer, the Rime Ice Chinese input method setup TUI

### DIFF
--- a/pkgbuilds/rime-ice-installer/.omarchy/package.json
+++ b/pkgbuilds/rime-ice-installer/.omarchy/package.json
@@ -1,0 +1,4 @@
+{
+  "source": "aur",
+  "upstream_commit": "bd1c1b46d5cc681e397e83c6ab0d35a68fb56644"
+}

--- a/pkgbuilds/rime-ice-installer/PKGBUILD
+++ b/pkgbuilds/rime-ice-installer/PKGBUILD
@@ -1,0 +1,54 @@
+# Maintainer: Andy Stewart <lazycat.manatee@gmail.com>
+
+pkgname=rime-ice-installer
+pkgver=0.1.6
+pkgrel=1
+pkgdesc='TUI installer for Fcitx5, Rime Ice and Wanxiang on Arch Linux'
+arch=('x86_64')
+url='https://github.com/manateelazycat/rime-ice-installer'
+license=('custom:unknown')
+depends=('curl' 'dbus' 'dialog' 'git' 'glib2' 'sudo' 'unzip')
+makedepends=('go')
+source=("$pkgname-$pkgver.tar.gz::$url/archive/refs/tags/v$pkgver.tar.gz")
+sha256sums=('b0637b19e524b552137639d73c4ebea7c6f1258e49de7f1916519acd7966c1f4')
+
+_setup_go_env() {
+  export GOPATH="$srcdir"
+  export GOMODCACHE="$srcdir/pkg/mod"
+  export GOFLAGS='-buildmode=pie -trimpath -mod=readonly -modcacherw'
+}
+
+prepare() {
+  cd "$srcdir/$pkgname-$pkgver"
+
+  _setup_go_env
+
+  go mod download
+}
+
+build() {
+  cd "$srcdir/$pkgname-$pkgver"
+
+  _setup_go_env
+  export CGO_CPPFLAGS="${CPPFLAGS}"
+  export CGO_CFLAGS="${CFLAGS}"
+  export CGO_CXXFLAGS="${CXXFLAGS}"
+  export CGO_LDFLAGS="${LDFLAGS}"
+
+  go build -o "$pkgname" .
+}
+
+check() {
+  cd "$srcdir/$pkgname-$pkgver"
+
+  _setup_go_env
+
+  go test ./...
+}
+
+package() {
+  cd "$srcdir/$pkgname-$pkgver"
+
+  install -Dm755 "$pkgname" "$pkgdir/usr/bin/$pkgname"
+  install -Dm644 README.md "$pkgdir/usr/share/doc/$pkgname/README.md"
+}


### PR DESCRIPTION
## Summary

@manateelazycat's [rime-ice-installer](https://github.com/manateelazycat/rime-ice-installer), the dialog TUI that installs Fcitx5, Rime Ice and the Wanxiang grammar model on Arch. Synced from the AUR with `bin/add-package`.

omacom/omarchy#9695 installs it through `omarchy-pkg-add`, which only sees this repo.

