### PR TITLE
Add omabook book library and reader package

### DIFF
--- a/pkgbuilds/omabook/.omarchy/package.json
+++ b/pkgbuilds/omabook/.omarchy/package.json
@@ -1,0 +1,3 @@
+{
+  "source": "local"
+}

--- a/pkgbuilds/omabook/PKGBUILD
+++ b/pkgbuilds/omabook/PKGBUILD
@@ -1,0 +1,103 @@
+# Maintainer: Newton Ramos Garcia <n@newx.sh>
+
+pkgname=omabook
+pkgver=0.1.0
+pkgrel=1
+pkgdesc='Book library and reader for EPUB, PDF and MOBI, built with Qt Quick'
+# Only x86_64 has been built and tested. The build is plain qmake6 + make, so
+# aarch64 is plausible, but unproven, and so not claimed here.
+arch=('x86_64')
+url='https://github.com/newx/omabook'
+license=('MIT')
+install='omabook.install'
+# The release binary carries no useful debug symbols, and the split -debug
+# package trips namcap's empty-package rule.
+options=('!debug')
+depends=(
+  'hicolor-icon-theme'
+  # Not optional: pdftotext and pdftoppm are how PDF covers, page text and
+  # text-quality assessment work, and PDFs are half of a typical library.
+  'poppler'
+  'qt6-base'
+  'qt6-declarative'
+  # Some EPUB covers are WebP. Without this, QImageReader decodes them to
+  # nothing and the book gets no cover, with no error anywhere.
+  'qt6-imageformats'
+  'qt6-svg'
+  # The reader is a QWebEngineView talking to C++ over a QWebChannel.
+  'qt6-webchannel'
+  'qt6-webengine'
+  # File dialogs and the light/dark system setting go through the portal.
+  'xdg-desktop-portal'
+)
+makedepends=(
+  'gcc'
+  'make'
+  'qt6-base'
+  'qt6-declarative'
+  'qt6-webchannel'
+  'qt6-webengine'
+)
+
+# The reader engine. foliate-js is a separate project with its own history, so
+# omabook gitignores it rather than vendoring it, which means the release
+# tarball above does not contain it -- and without this second source the
+# package builds cleanly, the library works, and opening a book renders nothing
+# at all. Pinned to the commit this release was developed and tested against;
+# bin/install in the source tree clones HEAD instead, which is right for a
+# working copy and wrong for a package.
+_foliate_commit=78914aef4466eb960965702401634c2cb348e9b1
+
+source=(
+  "$pkgname-$pkgver.tar.gz::$url/archive/refs/tags/v$pkgver.tar.gz"
+  "foliate-js-$_foliate_commit.tar.gz::https://github.com/johnfactotum/foliate-js/archive/$_foliate_commit.tar.gz"
+)
+sha256sums=('31de3b86e8cfa8b3f4c48c409a5cb7549e0972d6aecf528bd62eb213f09a3fcd'
+            '4878cd5f04073af5046ea543da73a963a7f9e1a4b30ddc63ac86cea5adf02f38')
+
+prepare() {
+  # reader.html imports './foliate-js/view.js' relative to itself, so the engine
+  # has to sit inside assets/reader/ under exactly that name.
+  rm -rf "$pkgname-$pkgver/assets/reader/foliate-js"
+  mv "foliate-js-$_foliate_commit" "$pkgname-$pkgver/assets/reader/foliate-js"
+}
+
+build() {
+  cd "$pkgname-$pkgver"
+  ./bin/build
+}
+
+check() {
+  cd "$pkgname-$pkgver"
+  # QtTest over src/core, plus the check that core never reaches for QML. The
+  # script sets QT_QPA_PLATFORM=offscreen itself, so this needs no display.
+  ./bin/test
+}
+
+package() {
+  cd "$pkgname-$pkgver"
+
+  install -Dm755 build/omabook "$pkgdir/usr/bin/omabook"
+  install -Dm644 LICENSE "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+  # The reader engine ships inside the package, so its licence ships with it.
+  install -Dm644 assets/reader/foliate-js/LICENSE \
+    "$pkgdir/usr/share/licenses/$pkgname/LICENSE.foliate-js"
+  install -Dm644 pkgbuild/omabook.svg \
+    "$pkgdir/usr/share/icons/hicolor/scalable/apps/omabook.svg"
+  install -Dm644 pkgbuild/omabook.desktop \
+    "$pkgdir/usr/share/applications/omabook.desktop"
+
+  # The reader loads from disk rather than from qrc:, because a qrc: page cannot
+  # read book files off the filesystem. src/app/assets.cpp resolves this path.
+  install -dm755 "$pkgdir/usr/share/omabook"
+  cp -r assets/reader "$pkgdir/usr/share/omabook/reader"
+
+  # Neither foliate-js's repository metadata nor its test pages are of any use
+  # to someone installing a book reader.
+  local _fj="$pkgdir/usr/share/omabook/reader/foliate-js"
+  rm -rf "$_fj/.git" "$_fj/.github" "$_fj/.gitignore" "$_fj/.gitattributes" \
+         "$_fj/tests" "$_fj/node_modules"
+
+  find "$pkgdir/usr/share/omabook" -type d -exec chmod 755 {} +
+  find "$pkgdir/usr/share/omabook" -type f -exec chmod 644 {} +
+}

--- a/pkgbuilds/omabook/omabook.install
+++ b/pkgbuilds/omabook/omabook.install
@@ -1,0 +1,12 @@
+post_install() {
+  command -v update-desktop-database >/dev/null 2>&1 && update-desktop-database -q
+  command -v gtk-update-icon-cache >/dev/null 2>&1 && gtk-update-icon-cache -q -t -f usr/share/icons/hicolor
+}
+
+post_upgrade() {
+  post_install
+}
+
+post_remove() {
+  post_install
+}


### PR DESCRIPTION
[omabook](https://github.com/newx/omabook) is a book library and reader for EPUB, PDF and MOBI, built with C++17 and Qt Quick the same way omawrite is, one `.pro`, one `make`, one binary at `/usr/bin/omabook`. Local only: no network, no telemetry, no accounts.


**One thing worth a look.** The reader engine, foliate-js, is a second source pinned to a commit rather than part of the release tarball. It is a separate upstream project that omabook gitignores rather than vendors, so the tag tarball does not carry it , and without it the package builds cleanly, the library works, and opening a book renders nothing at all. Pinning by commit (rather than a `git+https` HEAD clone) keeps the dependency checksummed and reproducible, and its MIT licence ships as `LICENSE.foliate-js`.

### Verified

- `makepkg -f` on a clean copy: both sources fetched, built, the QtTest suite passed (25 tests, run through the package's `check()`), packaged at 3.6 MB with no debug split.
- Package contents: binary, `.desktop`, scalable icon, both licences, and the reader tree at `/usr/share/omabook/reader` with foliate-js's repository metadata and test pages stripped.
- `desktop-file-validate` clean; `bin/list-packages` picks it up at `0.1.0-1`; `bin/omarchy-pkgs`, `bin/sync-upstream` and `bin/omarchy-release` self-tests pass.

Happy to adjust anything, the release ring, the aarch64 claim (only x86_64 has been built and tested), or the foliate-js approach.

