### PR TITLE
Build the omarchy package pair for aarch64

### DIFF
--- a/pkgbuilds/omarchy-dev/PKGBUILD
+++ b/pkgbuilds/omarchy-dev/PKGBUILD
@@ -5,7 +5,10 @@ pkgrel=1
 _pkgver_base=4.0.0
 _pkgver_base_tag=v3.8.2
 pkgdesc='Beautiful, modern, and opinionated Arch Linux by DHH (quattro branch tip)'
-arch=('any')
+# The payload is architecture-independent, but the dependency set is not: the
+# boot stack differs per architecture (see depends_x86_64 / depends_aarch64),
+# and makepkg only honours arch-suffixed arrays on arch-specific packages.
+arch=('x86_64' 'aarch64')
 url='https://github.com/basecamp/omarchy'
 license=('MIT')
 provides=('omarchy')
@@ -16,18 +19,6 @@ depends=(
   # Omarchy meta
   'omarchy-keyring'
   'omarchy-settings-dev'
-
-  # Bootloader stack. Lives here rather than on omarchy-settings because
-  # omarchy-settings is also installed into the live ISO env (for plymouth
-  # / /etc/skel seeding), where the limine-mkinitcpio-hook would fail with
-  # 'Cannot detect an ESP path' inside the chroot. The omarchy-settings
-  # config drop-ins under /etc/mkinitcpio.conf.d/, /etc/limine-entry-tool.d/,
-  # and /etc/snapper/config-templates/ only do anything when these are
-  # installed alongside.
-  'limine'
-  'limine-mkinitcpio-hook'
-  'limine-snapper-sync'
-  'snapper'
 
   # Wayland / Hyprland core
   'hyprland'
@@ -53,6 +44,29 @@ depends=(
 
   # System font (UI assumes it)
   'ttf-jetbrains-mono-nerd-basic'
+)
+
+# Bootloader stack. Lives here rather than on omarchy-settings because
+# omarchy-settings is also installed into the live ISO env (for plymouth
+# / /etc/skel seeding), where the limine-mkinitcpio-hook would fail with
+# 'Cannot detect an ESP path' inside the chroot. The omarchy-settings
+# config drop-ins under /etc/mkinitcpio.conf.d/, /etc/limine-entry-tool.d/,
+# and /etc/snapper/config-templates/ only do anything when these are
+# installed alongside.
+depends_x86_64=(
+  'limine'
+  'limine-mkinitcpio-hook'
+  'limine-snapper-sync'
+  'snapper'
+)
+
+# Apple Silicon boots through m1n1 + GRUB from the Asahi packages and keeps
+# Arch Linux ARM's kernel and boot layout, so the Limine/Snapper stack does not
+# apply. Wi-Fi on the Broadcom parts only scans reliably through the iwd
+# backend, which install/hardware/network.sh selects on Apple Silicon.
+depends_aarch64=(
+  'iwd'
+  'networkmanager'
 )
 
 makedepends=(

--- a/pkgbuilds/omarchy-settings-dev/PKGBUILD
+++ b/pkgbuilds/omarchy-settings-dev/PKGBUILD
@@ -5,7 +5,12 @@ pkgrel=1
 _pkgver_base=4.0.0
 _pkgver_base_tag=v3.8.2
 pkgdesc='Omarchy user defaults, /etc/skel content, fonts, plymouth theme, and support helpers (quattro branch tip)'
-arch=('any')
+# Arch-specific because the shipped /etc tree is not the same on every
+# architecture: the Limine, mkinitcpio, zram and oomd drop-ins belong to the
+# x86_64 boot and memory stack and are left out of the aarch64 package (see
+# package()). makepkg only honours the arch-suffixed arrays below on
+# arch-specific packages.
+arch=('x86_64' 'aarch64')
 url='https://github.com/basecamp/omarchy'
 license=('MIT')
 provides=('omarchy-settings')
@@ -44,15 +49,10 @@ makedepends=(
 # scriptlet WILL clobber user edits on each upgrade (documented limitation).
 backup=(
   'etc/fastfetch/config.jsonc'
-  'etc/mkinitcpio.conf.d/omarchy_hooks.conf'
-  'etc/mkinitcpio.conf.d/thunderbolt_module.conf'
-  'etc/limine-entry-tool.d/omarchy-defaults.conf'
-  'etc/limine-entry-tool.d/omarchy-uki.conf'
   'etc/docker/daemon.json'
   'etc/gnupg/dirmngr.conf'
   'etc/sysctl.d/99-omarchy-sysctl.conf'
   'etc/sysctl.d/90-omarchy-file-watchers.conf'
-  'etc/modprobe.d/omarchy-usb-autosuspend.conf'
   'etc/systemd/logind.conf.d/10-ignore-power-button.conf'
   'etc/systemd/logind.conf.d/20-inhibit-delay.conf'
   'etc/systemd/resolved.conf.d/10-disable-multicast.conf'
@@ -63,18 +63,31 @@ backup=(
   'etc/systemd/system/plocate-updatedb.service.d/ac-only.conf'
   'etc/systemd/system.conf.d/20-omarchy-nofile.conf'
   'etc/systemd/user.conf.d/20-omarchy-nofile.conf'
-  'etc/systemd/oomd.conf.d/10-omarchy.conf'
-  'etc/systemd/zram-generator.conf'
   'etc/sddm.conf.d/10-theme.conf'
   'etc/sddm.conf.d/10-wayland.conf'
   'etc/udev/rules.d/99-omarchy-power-profile.rules'
   'etc/udev/rules.d/99-omarchy-wifi-powersave.rules'
 )
+# backup has no arch-suffixed form, so the x86_64-only drop-ins join it here.
+# Each of these paths is removed from the aarch64 package in package().
+if [[ $CARCH == x86_64 ]]; then
+  backup+=(
+    'etc/mkinitcpio.conf.d/omarchy_hooks.conf'
+    'etc/mkinitcpio.conf.d/thunderbolt_module.conf'
+    'etc/limine-entry-tool.d/omarchy-defaults.conf'
+    'etc/limine-entry-tool.d/omarchy-uki.conf'
+    'etc/modprobe.d/omarchy-usb-autosuspend.conf'
+    'etc/systemd/oomd.conf.d/10-omarchy.conf'
+    'etc/systemd/zram-generator.conf'
+  )
+fi
 
 optdepends=(
   'omarchy-dev: Full Omarchy desktop (quattro branch tip)'
   'inxi: System information for omarchy-debug'
   'fastfetch: System information for omarchy-upload-log'
+)
+optdepends_x86_64=(
   'limine: Bootloader the shipped /etc/mkinitcpio.conf.d/ and /etc/limine-entry-tool.d/ drop-ins are for'
   'limine-mkinitcpio-hook: Picks up the shipped /etc/mkinitcpio.conf.d/omarchy_hooks.conf'
   'limine-snapper-sync: Boot-entry sync for snapper snapshots'
@@ -147,6 +160,14 @@ package() {
   install -d "$pkgdir/usr/share/omarchy/config"
   cp -a config/. "$pkgdir/usr/share/omarchy/config/"
 
+  # The Limine/Snapper notifier has nothing to notify about without the x86_64
+  # boot stack; drop it from both seeds so aarch64 users don't autostart a
+  # helper whose backing tool is not installed.
+  if [[ $CARCH == aarch64 ]]; then
+    rm -f "$pkgdir/etc/skel/.config/autostart/limine-snapper-notify.desktop" \
+      "$pkgdir/usr/share/omarchy/config/autostart/limine-snapper-notify.desktop"
+  fi
+
   # Package-owned defaults with real system/XDG locations. User config remains
   # higher priority: ~/.config/uwsm/default, ~/.config/uwsm/env.d,
   # ~/.config/environment.d, ~/.config/fontconfig, ~/.config/xdg-terminals.list,
@@ -174,9 +195,13 @@ package() {
   install -Dm644 default/systemd/user/omarchy-crash-watch.service "$pkgdir/usr/lib/systemd/user/omarchy-crash-watch.service"
   # Marks app.slice (and only app.slice) as a systemd-oomd kill candidate, so
   # memory pressure costs one app scope instead of the compositor session.
-  # Thresholds live in etc/systemd/oomd.conf.d/10-omarchy.conf.
-  install -Dm644 default/systemd/user/app.slice.d/10-oomd.conf "$pkgdir/usr/lib/systemd/user/app.slice.d/10-oomd.conf"
-  install -Dm644 default/systemd/zram-generator.conf.d/90-omarchy.conf "$pkgdir/usr/lib/systemd/zram-generator.conf.d/90-omarchy.conf"
+  # Thresholds live in etc/systemd/oomd.conf.d/10-omarchy.conf. Both this and
+  # the zram vendor drop-in belong to the x86_64 memory stack: the aarch64
+  # install neither enables systemd-oomd nor configures zram swap.
+  if [[ $CARCH == x86_64 ]]; then
+    install -Dm644 default/systemd/user/app.slice.d/10-oomd.conf "$pkgdir/usr/lib/systemd/user/app.slice.d/10-oomd.conf"
+    install -Dm644 default/systemd/zram-generator.conf.d/90-omarchy.conf "$pkgdir/usr/lib/systemd/zram-generator.conf.d/90-omarchy.conf"
+  fi
 
   # Same for applications/** — used by omarchy-refresh-applications,
   # omarchy-install-gaming-*, etc. to copy .desktop files into ~/.local/share.
@@ -190,6 +215,25 @@ package() {
   # stage separately below).
   install -d "$pkgdir/etc"
   cp -a etc/. "$pkgdir/etc/"
+  if [[ $CARCH == aarch64 ]]; then
+    # The x86_64 boot stack's drop-ins must not ship on aarch64: mkinitcpio
+    # reads every file under /etc/mkinitcpio.conf.d/, so omarchy_hooks.conf
+    # would inject the Limine hooks into the Asahi kernel's initramfs, and the
+    # Limine entry-tool config has no consumer without Limine.
+    rm -rf "$pkgdir/etc/limine-entry-tool.d" "$pkgdir/etc/mkinitcpio.conf.d"
+    # Memory stack: no zram device or zswap on the aarch64 install, and
+    # systemd-oomd is not enabled there, so the vm.* reclaim tuning written
+    # for zram would be wrong for it. Keep only the network tuning.
+    rm -rf "$pkgdir/etc/systemd/oomd.conf.d"
+    rm -f "$pkgdir/etc/systemd/zram-generator.conf" "$pkgdir/etc/tmpfiles.d/omarchy-zswap.conf"
+    cat >"$pkgdir/etc/sysctl.d/99-omarchy-sysctl.conf" <<'EOF'
+# Solve common flakiness with SSH (MTU discovery on flaky links).
+net.ipv4.tcp_mtu_probing=1
+EOF
+    # USB autosuspend is left at the kernel default on Apple Silicon.
+    rm -f "$pkgdir/etc/modprobe.d/omarchy-usb-autosuspend.conf"
+    rmdir "$pkgdir/etc/modprobe.d" "$pkgdir/etc/tmpfiles.d" 2>/dev/null || true
+  fi
   # sudoers.d files must be mode 0440 or sudo will refuse them, and the
   # directory must be 0750 to match the Arch sudo package's filesystem
   # convention (otherwise pacman warns about dir-mode drift on every install).
@@ -280,6 +324,10 @@ EOF
   # live root config.
   install -d "$pkgdir/usr/share/omarchy/default"
   cp -a default/. "$pkgdir/usr/share/omarchy/default/"
+  # The Limine template is read by the x86_64 ISO orchestrator only.
+  if [[ $CARCH == aarch64 ]]; then
+    rm -rf "$pkgdir/usr/share/omarchy/default/limine"
+  fi
 
   # Snapper config template used by the install-time `snapper create-config`.
   install -Dm644 default/snapper/root \

--- a/pkgbuilds/omarchy-settings-dev/omarchy-settings-dev.install
+++ b/pkgbuilds/omarchy-settings-dev/omarchy-settings-dev.install
@@ -1,5 +1,30 @@
+_apple_silicon() {
+  [[ $(uname -m) == aarch64 ]] && grep -aq 'apple,' /proc/device-tree/compatible 2>/dev/null
+}
+
 _etc_overrides_apply() {
   echo "Applying Omarchy etc-overrides..."
+
+  # The hardened CUPS authorization applies on every platform. It waits for the
+  # file the cups package owns: an ISO bootstrap without cups installed is left
+  # alone and picks it up once cups lands.
+  if [[ -f /etc/cups/cups-files.conf && -f /usr/share/omarchy/etc-overrides/cups-cups-files.conf ]]; then
+    systemd-sysusers /etc/sysusers.d/omarchy-cups-browsed.conf
+    install -m 0640 -o root -g cups /usr/share/omarchy/etc-overrides/cups-cups-files.conf /etc/cups/cups-files.conf
+  fi
+
+  # Apple Silicon installs run on Arch Linux ARM's base with the Asahi
+  # packages, and keep that system identity: /etc/os-release stays the
+  # symlink to the distribution's /usr/lib/os-release, and the PAM, NSS,
+  # plymouth and skel overrides below are not applied there.
+  if _apple_silicon; then
+    echo "Preserving Arch Linux ARM system configuration on Apple Silicon..."
+    if [[ -f /usr/lib/os-release ]]; then
+      rm -f /etc/os-release
+      ln -s ../usr/lib/os-release /etc/os-release
+    fi
+    return 0
+  fi
 
   # Ensure parent dirs exist. cups-browsed may not be installed yet during ISO
   # bootstrap; do not create /etc/cups/cups-browsed.conf before the package is
@@ -20,10 +45,6 @@ _etc_overrides_apply() {
   if [[ -f /etc/cups/cups-browsed.conf ]]; then
     install -d /etc/cups
     cp -f /usr/share/omarchy/etc-overrides/cups-cups-browsed.conf /etc/cups/cups-browsed.conf
-  fi
-  if [[ -f /etc/cups/cups-files.conf && -f /usr/share/omarchy/etc-overrides/cups-cups-files.conf ]]; then
-    systemd-sysusers /etc/sysusers.d/omarchy-cups-browsed.conf
-    install -m 0640 -o root -g cups /usr/share/omarchy/etc-overrides/cups-cups-files.conf /etc/cups/cups-files.conf
   fi
   cp -f /usr/share/omarchy/etc-overrides/plymouth-plymouthd.conf /etc/plymouth/plymouthd.conf
   cp -f /usr/share/omarchy/etc-overrides/dot.bashrc              /etc/skel/.bashrc

--- a/pkgbuilds/omarchy-settings/PKGBUILD
+++ b/pkgbuilds/omarchy-settings/PKGBUILD
@@ -15,7 +15,12 @@ _commit='346e69e1cec6c4e8924531874af6ba010a1bc99e'
 pkgver=4.0.2
 pkgrel=1
 pkgdesc='Omarchy user defaults, /etc/skel content, fonts, plymouth theme, and support helpers'
-arch=('any')
+# Arch-specific because the shipped /etc tree is not the same on every
+# architecture: the Limine, mkinitcpio, zram and oomd drop-ins belong to the
+# x86_64 boot and memory stack and are left out of the aarch64 package (see
+# package()). makepkg only honours the arch-suffixed arrays below on
+# arch-specific packages.
+arch=('x86_64' 'aarch64')
 url='https://github.com/basecamp/omarchy'
 license=('MIT')
 conflicts=('omarchy-settings-dev')
@@ -53,15 +58,10 @@ makedepends=(
 # scriptlet WILL clobber user edits on each upgrade (documented limitation).
 backup=(
   'etc/fastfetch/config.jsonc'
-  'etc/mkinitcpio.conf.d/omarchy_hooks.conf'
-  'etc/mkinitcpio.conf.d/thunderbolt_module.conf'
-  'etc/limine-entry-tool.d/omarchy-defaults.conf'
-  'etc/limine-entry-tool.d/omarchy-uki.conf'
   'etc/docker/daemon.json'
   'etc/gnupg/dirmngr.conf'
   'etc/sysctl.d/99-omarchy-sysctl.conf'
   'etc/sysctl.d/90-omarchy-file-watchers.conf'
-  'etc/modprobe.d/omarchy-usb-autosuspend.conf'
   'etc/systemd/logind.conf.d/10-ignore-power-button.conf'
   'etc/systemd/logind.conf.d/20-inhibit-delay.conf'
   'etc/systemd/resolved.conf.d/10-disable-multicast.conf'
@@ -72,18 +72,31 @@ backup=(
   'etc/systemd/system/plocate-updatedb.service.d/ac-only.conf'
   'etc/systemd/system.conf.d/20-omarchy-nofile.conf'
   'etc/systemd/user.conf.d/20-omarchy-nofile.conf'
-  'etc/systemd/oomd.conf.d/10-omarchy.conf'
-  'etc/systemd/zram-generator.conf'
   'etc/sddm.conf.d/10-theme.conf'
   'etc/sddm.conf.d/10-wayland.conf'
   'etc/udev/rules.d/99-omarchy-power-profile.rules'
   'etc/udev/rules.d/99-omarchy-wifi-powersave.rules'
 )
+# backup has no arch-suffixed form, so the x86_64-only drop-ins join it here.
+# Each of these paths is removed from the aarch64 package in package().
+if [[ $CARCH == x86_64 ]]; then
+  backup+=(
+    'etc/mkinitcpio.conf.d/omarchy_hooks.conf'
+    'etc/mkinitcpio.conf.d/thunderbolt_module.conf'
+    'etc/limine-entry-tool.d/omarchy-defaults.conf'
+    'etc/limine-entry-tool.d/omarchy-uki.conf'
+    'etc/modprobe.d/omarchy-usb-autosuspend.conf'
+    'etc/systemd/oomd.conf.d/10-omarchy.conf'
+    'etc/systemd/zram-generator.conf'
+  )
+fi
 
 optdepends=(
   'omarchy: Full Omarchy desktop'
   'inxi: System information for omarchy-debug'
   'fastfetch: System information for omarchy-upload-log'
+)
+optdepends_x86_64=(
   'limine: Bootloader the shipped /etc/mkinitcpio.conf.d/ and /etc/limine-entry-tool.d/ drop-ins are for'
   'limine-mkinitcpio-hook: Picks up the shipped /etc/mkinitcpio.conf.d/omarchy_hooks.conf'
   'limine-snapper-sync: Boot-entry sync for snapper snapshots'
@@ -142,6 +155,14 @@ package() {
   install -d "$pkgdir/usr/share/omarchy/config"
   cp -a config/. "$pkgdir/usr/share/omarchy/config/"
 
+  # The Limine/Snapper notifier has nothing to notify about without the x86_64
+  # boot stack; drop it from both seeds so aarch64 users don't autostart a
+  # helper whose backing tool is not installed.
+  if [[ $CARCH == aarch64 ]]; then
+    rm -f "$pkgdir/etc/skel/.config/autostart/limine-snapper-notify.desktop" \
+      "$pkgdir/usr/share/omarchy/config/autostart/limine-snapper-notify.desktop"
+  fi
+
   # Package-owned defaults with real system/XDG locations. User config remains
   # higher priority: ~/.config/uwsm/default, ~/.config/uwsm/env.d,
   # ~/.config/environment.d, ~/.config/fontconfig, ~/.config/xdg-terminals.list,
@@ -169,9 +190,13 @@ package() {
   install -Dm644 default/systemd/user/omarchy-crash-watch.service "$pkgdir/usr/lib/systemd/user/omarchy-crash-watch.service"
   # Marks app.slice (and only app.slice) as a systemd-oomd kill candidate, so
   # memory pressure costs one app scope instead of the compositor session.
-  # Thresholds live in etc/systemd/oomd.conf.d/10-omarchy.conf.
-  install -Dm644 default/systemd/user/app.slice.d/10-oomd.conf "$pkgdir/usr/lib/systemd/user/app.slice.d/10-oomd.conf"
-  install -Dm644 default/systemd/zram-generator.conf.d/90-omarchy.conf "$pkgdir/usr/lib/systemd/zram-generator.conf.d/90-omarchy.conf"
+  # Thresholds live in etc/systemd/oomd.conf.d/10-omarchy.conf. Both this and
+  # the zram vendor drop-in belong to the x86_64 memory stack: the aarch64
+  # install neither enables systemd-oomd nor configures zram swap.
+  if [[ $CARCH == x86_64 ]]; then
+    install -Dm644 default/systemd/user/app.slice.d/10-oomd.conf "$pkgdir/usr/lib/systemd/user/app.slice.d/10-oomd.conf"
+    install -Dm644 default/systemd/zram-generator.conf.d/90-omarchy.conf "$pkgdir/usr/lib/systemd/zram-generator.conf.d/90-omarchy.conf"
+  fi
 
   # Same for applications/** — used by omarchy-refresh-applications,
   # omarchy-install-gaming-*, etc. to copy .desktop files into ~/.local/share.
@@ -185,6 +210,25 @@ package() {
   # stage separately below).
   install -d "$pkgdir/etc"
   cp -a etc/. "$pkgdir/etc/"
+  if [[ $CARCH == aarch64 ]]; then
+    # The x86_64 boot stack's drop-ins must not ship on aarch64: mkinitcpio
+    # reads every file under /etc/mkinitcpio.conf.d/, so omarchy_hooks.conf
+    # would inject the Limine hooks into the Asahi kernel's initramfs, and the
+    # Limine entry-tool config has no consumer without Limine.
+    rm -rf "$pkgdir/etc/limine-entry-tool.d" "$pkgdir/etc/mkinitcpio.conf.d"
+    # Memory stack: no zram device or zswap on the aarch64 install, and
+    # systemd-oomd is not enabled there, so the vm.* reclaim tuning written
+    # for zram would be wrong for it. Keep only the network tuning.
+    rm -rf "$pkgdir/etc/systemd/oomd.conf.d"
+    rm -f "$pkgdir/etc/systemd/zram-generator.conf" "$pkgdir/etc/tmpfiles.d/omarchy-zswap.conf"
+    cat >"$pkgdir/etc/sysctl.d/99-omarchy-sysctl.conf" <<'EOF'
+# Solve common flakiness with SSH (MTU discovery on flaky links).
+net.ipv4.tcp_mtu_probing=1
+EOF
+    # USB autosuspend is left at the kernel default on Apple Silicon.
+    rm -f "$pkgdir/etc/modprobe.d/omarchy-usb-autosuspend.conf"
+    rmdir "$pkgdir/etc/modprobe.d" "$pkgdir/etc/tmpfiles.d" 2>/dev/null || true
+  fi
   # sudoers.d files must be mode 0440 or sudo will refuse them, and the
   # directory must be 0750 to match the Arch sudo package's filesystem
   # convention (otherwise pacman warns about dir-mode drift on every install).
@@ -275,6 +319,10 @@ EOF
   # live root config.
   install -d "$pkgdir/usr/share/omarchy/default"
   cp -a default/. "$pkgdir/usr/share/omarchy/default/"
+  # The Limine template is read by the x86_64 ISO orchestrator only.
+  if [[ $CARCH == aarch64 ]]; then
+    rm -rf "$pkgdir/usr/share/omarchy/default/limine"
+  fi
 
   # Snapper config template used by the install-time `snapper create-config`.
   install -Dm644 default/snapper/root \

--- a/pkgbuilds/omarchy-settings/omarchy-settings.install
+++ b/pkgbuilds/omarchy-settings/omarchy-settings.install
@@ -1,5 +1,30 @@
+_apple_silicon() {
+  [[ $(uname -m) == aarch64 ]] && grep -aq 'apple,' /proc/device-tree/compatible 2>/dev/null
+}
+
 _etc_overrides_apply() {
   echo "Applying Omarchy etc-overrides..."
+
+  # The hardened CUPS authorization applies on every platform. It waits for the
+  # file the cups package owns: an ISO bootstrap without cups installed is left
+  # alone and picks it up once cups lands.
+  if [[ -f /etc/cups/cups-files.conf && -f /usr/share/omarchy/etc-overrides/cups-cups-files.conf ]]; then
+    systemd-sysusers /etc/sysusers.d/omarchy-cups-browsed.conf
+    install -m 0640 -o root -g cups /usr/share/omarchy/etc-overrides/cups-cups-files.conf /etc/cups/cups-files.conf
+  fi
+
+  # Apple Silicon installs run on Arch Linux ARM's base with the Asahi
+  # packages, and keep that system identity: /etc/os-release stays the
+  # symlink to the distribution's /usr/lib/os-release, and the PAM, NSS,
+  # plymouth and skel overrides below are not applied there.
+  if _apple_silicon; then
+    echo "Preserving Arch Linux ARM system configuration on Apple Silicon..."
+    if [[ -f /usr/lib/os-release ]]; then
+      rm -f /etc/os-release
+      ln -s ../usr/lib/os-release /etc/os-release
+    fi
+    return 0
+  fi
 
   # Ensure parent dirs exist. cups-browsed may not be installed yet during ISO
   # bootstrap; do not create /etc/cups/cups-browsed.conf before the package is
@@ -20,10 +45,6 @@ _etc_overrides_apply() {
   if [[ -f /etc/cups/cups-browsed.conf ]]; then
     install -d /etc/cups
     cp -f /usr/share/omarchy/etc-overrides/cups-cups-browsed.conf /etc/cups/cups-browsed.conf
-  fi
-  if [[ -f /etc/cups/cups-files.conf && -f /usr/share/omarchy/etc-overrides/cups-cups-files.conf ]]; then
-    systemd-sysusers /etc/sysusers.d/omarchy-cups-browsed.conf
-    install -m 0640 -o root -g cups /usr/share/omarchy/etc-overrides/cups-cups-files.conf /etc/cups/cups-files.conf
   fi
   cp -f /usr/share/omarchy/etc-overrides/plymouth-plymouthd.conf /etc/plymouth/plymouthd.conf
   cp -f /usr/share/omarchy/etc-overrides/dot.bashrc              /etc/skel/.bashrc

--- a/pkgbuilds/omarchy/PKGBUILD
+++ b/pkgbuilds/omarchy/PKGBUILD
@@ -15,7 +15,10 @@ _commit='346e69e1cec6c4e8924531874af6ba010a1bc99e'
 pkgver=4.0.2
 pkgrel=1
 pkgdesc='Beautiful, modern, and opinionated Arch Linux by DHH'
-arch=('any')
+# The payload is architecture-independent, but the dependency set is not: the
+# boot stack differs per architecture (see depends_x86_64 / depends_aarch64),
+# and makepkg only honours arch-suffixed arrays on arch-specific packages.
+arch=('x86_64' 'aarch64')
 url='https://github.com/basecamp/omarchy'
 license=('MIT')
 conflicts=('omarchy-dev')
@@ -30,18 +33,6 @@ depends=(
   # dependency can only be satisfied by the real omarchy-settings built
   # from the same _commit, and forces the pair to upgrade together.
   "omarchy-settings=${pkgver}"
-
-  # Bootloader stack. Lives here rather than on omarchy-settings because
-  # omarchy-settings is also installed into the live ISO env (for plymouth
-  # / /etc/skel seeding), where the limine-mkinitcpio-hook would fail with
-  # 'Cannot detect an ESP path' inside the chroot. The omarchy-settings
-  # config drop-ins under /etc/mkinitcpio.conf.d/, /etc/limine-entry-tool.d/,
-  # and /etc/snapper/config-templates/ only do anything when these are
-  # installed alongside.
-  'limine'
-  'limine-mkinitcpio-hook'
-  'limine-snapper-sync'
-  'snapper'
 
   # Wayland / Hyprland core
   'hyprland'
@@ -67,6 +58,29 @@ depends=(
 
   # System font (UI assumes it)
   'ttf-jetbrains-mono-nerd-basic'
+)
+
+# Bootloader stack. Lives here rather than on omarchy-settings because
+# omarchy-settings is also installed into the live ISO env (for plymouth
+# / /etc/skel seeding), where the limine-mkinitcpio-hook would fail with
+# 'Cannot detect an ESP path' inside the chroot. The omarchy-settings
+# config drop-ins under /etc/mkinitcpio.conf.d/, /etc/limine-entry-tool.d/,
+# and /etc/snapper/config-templates/ only do anything when these are
+# installed alongside.
+depends_x86_64=(
+  'limine'
+  'limine-mkinitcpio-hook'
+  'limine-snapper-sync'
+  'snapper'
+)
+
+# Apple Silicon boots through m1n1 + GRUB from the Asahi packages and keeps
+# Arch Linux ARM's kernel and boot layout, so the Limine/Snapper stack does not
+# apply. Wi-Fi on the Broadcom parts only scans reliably through the iwd
+# backend, which install/hardware/network.sh selects on Apple Silicon.
+depends_aarch64=(
+  'iwd'
+  'networkmanager'
 )
 
 makedepends=(

--- a/pkgbuilds/retroarch-joypad-autoconfig-git/PKGBUILD
+++ b/pkgbuilds/retroarch-joypad-autoconfig-git/PKGBUILD
@@ -1,7 +1,10 @@
 # Maintainer: Alexandre Bouvier <contact@amb.tf>
 _pkgname=retroarch-joypad-autoconfig
+# Pinned so every architecture packages the same tree and a rebuild of the
+# same pkgver reproduces the same contents; bump both together.
+_commit=033151045d378b64e712a92592467800d7924227
 pkgname=$_pkgname-git
-pkgver=1.22.0.r24.g739cee1
+pkgver=1.22.0.r96.g0331510
 pkgrel=1
 pkgdesc="RetroArch joypad autoconfig files"
 arch=('any')
@@ -12,7 +15,7 @@ makedepends=('git')
 optdepends=('retroarch')
 provides=("$_pkgname")
 conflicts=("$_pkgname")
-source=("$_pkgname::git+$url.git")
+source=("$_pkgname::git+$url.git#commit=$_commit")
 b2sums=('SKIP')
 
 pkgver() {


### PR DESCRIPTION
## Summary

Build the `omarchy` / `omarchy-settings` pair (and the `-dev` pair) for aarch64 alongside x86_64, and pin `retroarch-joypad-autoconfig-git` to a commit.

This is the first of a small series bringing the Apple Silicon (Asahi) work from `maralcbr/omarchy-pkgs` upstream. It contains only recipe changes; the aarch64 release plumbing (built on the existing x86_64 build host under QEMU, on its own timer) follows in a separate PR so each can be reviewed on its own.

### Why the pair becomes arch-specific

The Omarchy payload is architecture-independent, but the package is not:

- The dependency set differs. On x86_64 `omarchy` pulls the Limine + mkinitcpio hook + Snapper stack. On Apple Silicon the system boots through m1n1 + GRUB from the Asahi packages on Arch Linux ARM's kernel, so that stack does not apply, and Wi-Fi on the Broadcom parts needs the iwd backend.
- The shipped `/etc` tree differs. mkinitcpio reads every file under `/etc/mkinitcpio.conf.d/`, so shipping `omarchy_hooks.conf` on aarch64 injects the Limine hooks into the Asahi kernel's initramfs. The Limine entry-tool config, the zram/zswap/oomd drop-ins and the zram-tuned `vm.*` sysctls belong to the x86_64 boot and memory stack.

makepkg only honours `depends_x86_64`, `depends_aarch64` and `optdepends_x86_64` on arch-specific packages, so `arch=('any')` becomes `arch=('x86_64' 'aarch64')`. The x86_64 package is byte-for-byte what it was apart from the filename suffix (`-any` becomes `-x86_64`). `backup=()` has no arch-suffixed form, so the x86_64-only entries are appended under `[[ $CARCH == x86_64 ]]` and each of those paths is removed from the aarch64 package in `package()`.

### What the aarch64 package leaves out

- `etc/limine-entry-tool.d/`, `etc/mkinitcpio.conf.d/`, `/usr/share/omarchy/default/limine/`
- `etc/systemd/oomd.conf.d/`, `etc/systemd/zram-generator.conf`, `etc/tmpfiles.d/omarchy-zswap.conf`, the user `app.slice.d/10-oomd.conf` and the zram vendor drop-in
- `etc/modprobe.d/omarchy-usb-autosuspend.conf`
- the `limine-snapper-notify` autostart entry
- `etc/sysctl.d/99-omarchy-sysctl.conf` keeps only the TCP MTU probing line

### The install scriptlet on Apple Silicon

`omarchy-settings.install` now applies the hardened `cups-files.conf` on every platform, then on Apple Silicon (aarch64 with `apple,` in the device-tree compatible string) keeps the Arch Linux ARM system identity: `/etc/os-release` stays a symlink to `/usr/lib/os-release` and the PAM, NSS, plymouth and skel overrides are not applied. This is the behaviour of the shipped Apple Silicon builds. If you would rather narrow it to just `os-release`, that is a one-line change and I am happy to make it.

### `retroarch-joypad-autoconfig-git`

The recipe fetched the branch tip, so a rebuild on another architecture could package a different tree than the one already published. It is now pinned to a commit, with `pkgver` set to what that commit describes (1.22.0.r96.g0331510, as an aarch64 build of it reports). The old `pkgver` had drifted 72 commits behind the tip it was building.

## Testing

- `makepkg --printsrcinfo` for all five recipes under `CARCH=aarch64` and `CARCH=x86_64` in an Arch Linux ARM container: the arch-suffixed depends and backup entries land only under x86_64.
- Real `makepkg` of `omarchy-settings` and `omarchy` for both `CARCH` values in the same container; the aarch64 package contains none of the paths listed above, the x86_64 package contains all of them, and `.PKGINFO` carries the split depends.
- `bin/omarchy-pkgs self-test` and `bin/omarchy-release self-test` pass.
- On a MacBook Pro M1 Pro (`apple,j314s`) running Omarchy on Asahi: `pacman -U --print` of both aarch64 packages against the live install resolves with no missing dependencies (iwd and NetworkManager already present, no Limine or Snapper requested). A full `pacman -U` of both packages plus their dependencies (1.36 GiB from Arch Linux ARM, the Asahi repo and an Omarchy aarch64 repo) in a privileged Arch Linux ARM container on the same machine, so the scriptlet sees the real device tree: it takes the Apple Silicon branch, `/etc/os-release` stays the distribution symlink, the PAM/NSS overrides are untouched, `depends_aarch64` pulls iwd + networkmanager, and no Limine or Snapper package is installed.
- The same recipe changes have shipped in every Apple Silicon release from the fork since July, including the 4.0.2 build installed and accepted on that M1 Pro on 2 September.

## Follow-ups (separate PRs)

- Builder flags for CI and resumed builds (`OMARCHY_SKIP_BUILDER_IMAGE`, `OMARCHY_KEEP_BUILD_WORKSPACE`, `OMARCHY_DEFER_RUNTIME_DEPS`).
- aarch64 as a first-class architecture in the release pipeline (arch-aware `check-versions`, `auto-release`, a separate aarch64 timer, `clean-repo`, `omarchy-release`, and a keyring bootstrap for a not-yet-published aarch64 tree). Built on the same host as x86_64 via the QEMU path `bin/build` already has; expect roughly 5-10x the x86_64 wall time. This will carry #171 and #223 with their authors' commits.
- The Limine Gradle pin needed to build the Limine stack on Arch Linux ARM is already in #222.
