### PR TITLE
chore(mise): bump to 2026.9.1

### DIFF
--- a/pkgbuilds/mise-bin/PKGBUILD
+++ b/pkgbuilds/mise-bin/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Jeff Dickey <releases@mise.jdx.dev>
 pkgname=mise-bin
-pkgver=2026.8.15
+pkgver=2026.9.1
 pkgrel=1
 pkgdesc="dev tools, env vars, task runner"
 arch=('x86_64' 'aarch64')
@@ -14,8 +14,8 @@ provides=('mise')
 conflicts=('mise')
 source_x86_64=("https://github.com/jdx/mise/releases/download/v${pkgver}/mise-v${pkgver}-linux-x64.tar.xz")
 source_aarch64=("https://github.com/jdx/mise/releases/download/v${pkgver}/mise-v${pkgver}-linux-arm64.tar.xz")
-sha256sums_x86_64=('0ed4ee8bcf229718bead0d0aa83de865803f3fe25cc6c71a41e3a8bd57c40a33')
-sha256sums_aarch64=('d5f9b7e6b36b5cf5aaab0dc4d7e29ee74224281b1a81a228bdc1cd1f3edf9d49')
+sha256sums_x86_64=('bbc21f8fe9b2aa09f74250be15f9bf32e87562e1039d858ad91d7944f057c8e2')
+sha256sums_aarch64=('7d0c28d44bd7e1c5444a7d867146afabe43592c728329bc0ed5ec59ca7106c48')
 
 package() {
     install -Dm755 "${srcdir}/mise/bin/mise" "${pkgdir}/usr/bin/mise"


### PR DESCRIPTION
## Summary

- update mise-bin from 2026.8.15 to 2026.9.1
- refresh the official x86_64 and aarch64 SHA-256 checksums

## Why

omacom/omarchy#9596 uses system lazy tools and `locked_scopes`, which require mise 2026.9.1. This update deliberately uses the documented `BYPASS_MIN_RELEASE_AGE=1` path because the release has not yet cleared this package's normal 24-hour quarantine.

## Testing

- `BYPASS_MIN_RELEASE_AGE=1 bin/sync-upstream mise-bin`
- `makepkg --verifysource --skippgpcheck`
- independently verified the aarch64 asset checksum
- built `mise-bin-2026.9.1-1-x86_64.pkg.tar.zst` successfully
- inspected the resulting package metadata with `pacman -Qip`

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*