### PR TITLE
Install the libinput quirks file shipped by omarchy

### DIFF
--- a/pkgbuilds/omarchy-settings-dev/PKGBUILD
+++ b/pkgbuilds/omarchy-settings-dev/PKGBUILD
@@ -177,6 +177,7 @@ package() {
   install -Dm644 default/fontconfig/conf.avail/50-omarchy.conf "$pkgdir/usr/share/fontconfig/conf.avail/50-omarchy.conf"
   install -d "$pkgdir/etc/fonts/conf.d"
   ln -sfn /usr/share/fontconfig/conf.avail/50-omarchy.conf "$pkgdir/etc/fonts/conf.d/50-omarchy.conf"
+  install -Dm644 default/libinput/50-omarchy.quirks "$pkgdir/usr/share/libinput/50-omarchy.quirks"
   install -Dm644 default/xdg-terminal-exec/hyprland-xdg-terminals.list "$pkgdir/usr/share/xdg-terminal-exec/hyprland-xdg-terminals.list"
   install -Dm644 default/applications/mimeapps.list "$pkgdir/usr/share/applications/mimeapps.list"
   install -Dm644 default/systemd/user/bt-agent.service "$pkgdir/usr/lib/systemd/user/bt-agent.service"

--- a/pkgbuilds/omarchy-settings/PKGBUILD
+++ b/pkgbuilds/omarchy-settings/PKGBUILD
@@ -172,6 +172,7 @@ package() {
   install -Dm644 default/fontconfig/conf.avail/50-omarchy.conf "$pkgdir/usr/share/fontconfig/conf.avail/50-omarchy.conf"
   install -d "$pkgdir/etc/fonts/conf.d"
   ln -sfn /usr/share/fontconfig/conf.avail/50-omarchy.conf "$pkgdir/etc/fonts/conf.d/50-omarchy.conf"
+  install -Dm644 default/libinput/50-omarchy.quirks "$pkgdir/usr/share/libinput/50-omarchy.quirks"
   install -Dm644 default/xdg-terminal-exec/hyprland-xdg-terminals.list "$pkgdir/usr/share/xdg-terminal-exec/hyprland-xdg-terminals.list"
   install -Dm644 default/applications/mimeapps.list "$pkgdir/usr/share/applications/mimeapps.list"
   install -Dm644 default/systemd/user/bt-agent.service "$pkgdir/usr/lib/systemd/user/bt-agent.service"


### PR DESCRIPTION
## What

Installs `default/libinput/50-omarchy.quirks` to `/usr/share/libinput/50-omarchy.quirks`.

Companion to **omacom/omarchy#9850**, which adds the file. That PR is inert without this one: `cp -a default/.` already ships the source under `/usr/share/omarchy/default/libinput/`, but libinput reads quirks from `/usr/share/libinput/`, not from Omarchy's tree, so without this line the quirk never applies.

## Why

Shokz USB headset dongles (`3511:2B1E/2EF2/2F06`) emit phantom `KEY_POWER` events because their HID report descriptor declares the vendor control channel as a Consumer "Power" usage. On Omarchy that opens the system menu by itself; the quirk drops the event code for those devices only. Full detail in the omarchy PR and in [libinput#1333](https://gitlab.freedesktop.org/libinput/libinput/-/issues/1333).

## Notes

One line in each of `omarchy-settings` and `omarchy-settings-dev`, placed with the other package-owned defaults next to the fontconfig install, mirroring how every such file is installed in both PKGBUILDs.

No `pkgver`/`pkgrel` change, following 6daa7c9 ("Stage CUPS authorization as settings override", #237), where a contributor added installs to both PKGBUILDs without touching the version fields.
