### PR TITLE
Add Strata file manager to fast ring

### DIFF
--- a/pkgbuilds/strata/.omarchy/package.json
+++ b/pkgbuilds/strata/.omarchy/package.json
@@ -1,0 +1,4 @@
+{
+  "source": "local",
+  "release_ring": "fast"
+}

--- a/pkgbuilds/strata/PKGBUILD
+++ b/pkgbuilds/strata/PKGBUILD
@@ -1,0 +1,82 @@
+pkgname=strata
+pkgver=0.8.0
+pkgrel=1
+pkgdesc='Fast, keyboard-first file manager for modern Linux desktops'
+arch=('x86_64' 'aarch64')
+url='https://github.com/lgse/strata'
+license=('GPL-3.0-or-later')
+
+depends=(
+  'bash'
+  'bubblewrap'
+  'cairo'
+  'ffmpeg'
+  'ffmpegthumbnailer'
+  'fontconfig'
+  'gcc-libs'
+  'gdk-pixbuf2'
+  'glib2'
+  'glibc'
+  'graphene'
+  'gst-libav'
+  'gst-plugins-good'
+  'gtk4'
+  'gtksourceview5'
+  'hicolor-icon-theme'
+  'pango'
+  'poppler-glib'
+  'util-linux'
+  'xdg-terminal-exec'
+)
+makedepends=('cargo' 'glib2-devel' 'pkgconf')
+optdepends=(
+  'gvfs-smb: browse SMB network shares'
+  'imagemagick: additional camera RAW preview support'
+  'libraw: additional camera RAW preview support'
+)
+conflicts=('strata-git')
+options=('!debug' '!lto')
+
+_commit='61b4b0bc74a5b8ca262c7c080e9fea57bba65ff5'
+source=("$pkgname-$pkgver.tar.gz::$url/archive/refs/tags/v$pkgver.tar.gz")
+sha256sums=('8a6179ad5673afd8036ff6640c1740f6fa676516a05346c180d67ef98c4a56f7')
+
+prepare() {
+  cd "$pkgname-$pkgver"
+
+  cargo fetch --locked --target "$CARCH-unknown-linux-gnu"
+}
+
+build() {
+  cd "$pkgname-$pkgver"
+
+  export CARGO_TARGET_DIR=target
+  export STRATA_BUILD_COMMIT="$_commit"
+  export STRATA_RELEASE_TAG="v$pkgver"
+  export STRATA_BUILD_KIND=stable
+  cargo build --frozen --release
+}
+
+check() {
+  cd "$pkgname-$pkgver"
+
+  export CARGO_TARGET_DIR=target
+  export STRATA_BUILD_COMMIT="$_commit"
+  export STRATA_RELEASE_TAG="v$pkgver"
+  export STRATA_BUILD_KIND=stable
+  cargo test --frozen --release --all-targets --all-features
+}
+
+package() {
+  cd "$pkgname-$pkgver"
+
+  install -Dm755 target/release/strata "$pkgdir/usr/bin/strata"
+  install -Dm644 data/io.github.lgse.Strata.desktop \
+    "$pkgdir/usr/share/applications/io.github.lgse.Strata.desktop"
+  install -Dm644 data/icons/scalable/apps/io.github.lgse.Strata.svg \
+    "$pkgdir/usr/share/icons/hicolor/scalable/apps/io.github.lgse.Strata.svg"
+  install -Dm644 LICENSE "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+  install -Dm644 THIRD_PARTY_LICENSES.md \
+    "$pkgdir/usr/share/licenses/$pkgname/THIRD_PARTY_LICENSES.md"
+  install -Dm644 README.md "$pkgdir/usr/share/doc/$pkgname/README.md"
+}


### PR DESCRIPTION
## Summary

- add Strata v0.8.0 as a locally maintained package
- pin the audited upstream release source and SHA-256
- enable deployment on the fast release ring
- support x86_64 and aarch64

## Security review

- audited upstream commit `61b4b0bc74a5b8ca262c7c080e9fea57bba65ff5`
- verified the GitHub tag source matches the audited git archive
- RustSec audit: 0 vulnerabilities across 233 locked crates
- `cargo deny check`: advisories, bans, licenses, and sources all passed
- Gitleaks: no secrets across the full repository history
- reviewed archive extraction, file operations, updater, preview sandboxing, external commands, and release workflow
- upstream test suite: all 375 tests passed

One documented low-privilege TOCTOU caveat remains for recursive operations in hostile shared writable directories: https://github.com/lgse/strata/issues/8. This is non-blocking for typical single-user Omarchy desktop use.

## Package validation

- clean `makepkg` build from an empty Cargo cache
- release-mode package tests passed
- packaged binary smoke test passed
- ELF is PIE, full RELRO/BIND_NOW, non-executable stack, stripped, and has no RPATH/RUNPATH
- repository dry runs include the package for x86_64 and aarch64