### PR TITLE
Ship the SSH agent relay units for Herdr panes

### DIFF
--- a/pkgbuilds/omarchy-settings-dev/PKGBUILD
+++ b/pkgbuilds/omarchy-settings-dev/PKGBUILD
@@ -172,6 +172,8 @@ package() {
   install -Dm644 default/systemd/user/omarchy-tailscale-receive.service "$pkgdir/usr/lib/systemd/user/omarchy-tailscale-receive.service"
   install -Dm644 default/systemd/user/omarchy-fcitx5.service "$pkgdir/usr/lib/systemd/user/omarchy-fcitx5.service"
   install -Dm644 default/systemd/user/omarchy-crash-watch.service "$pkgdir/usr/lib/systemd/user/omarchy-crash-watch.service"
+  install -Dm644 default/systemd/user/omarchy-ssh-agent-proxy.socket "$pkgdir/usr/lib/systemd/user/omarchy-ssh-agent-proxy.socket"
+  install -Dm644 default/systemd/user/omarchy-ssh-agent-proxy@.service "$pkgdir/usr/lib/systemd/user/omarchy-ssh-agent-proxy@.service"
   # Marks app.slice (and only app.slice) as a systemd-oomd kill candidate, so
   # memory pressure costs one app scope instead of the compositor session.
   # Thresholds live in etc/systemd/oomd.conf.d/10-omarchy.conf.

--- a/pkgbuilds/omarchy-settings/PKGBUILD
+++ b/pkgbuilds/omarchy-settings/PKGBUILD
@@ -167,6 +167,8 @@ package() {
   install -Dm644 default/systemd/user/omarchy-tailscale-receive.service "$pkgdir/usr/lib/systemd/user/omarchy-tailscale-receive.service"
   install -Dm644 default/systemd/user/omarchy-fcitx5.service "$pkgdir/usr/lib/systemd/user/omarchy-fcitx5.service"
   install -Dm644 default/systemd/user/omarchy-crash-watch.service "$pkgdir/usr/lib/systemd/user/omarchy-crash-watch.service"
+  install -Dm644 default/systemd/user/omarchy-ssh-agent-proxy.socket "$pkgdir/usr/lib/systemd/user/omarchy-ssh-agent-proxy.socket"
+  install -Dm644 default/systemd/user/omarchy-ssh-agent-proxy@.service "$pkgdir/usr/lib/systemd/user/omarchy-ssh-agent-proxy@.service"
   # Marks app.slice (and only app.slice) as a systemd-oomd kill candidate, so
   # memory pressure costs one app scope instead of the compositor session.
   # Thresholds live in etc/systemd/oomd.conf.d/10-omarchy.conf.


### PR DESCRIPTION
# Ship the SSH agent relay units for Herdr panes

Companion to omacom/omarchy#9946: that change adds `default/systemd/user/omarchy-ssh-agent-proxy.socket` and `omarchy-ssh-agent-proxy@.service`, and a migration that enables the socket. Install both next to the other user units in `omarchy-settings` and `omarchy-settings-dev`, and ship them in the same release as the migration, so the enable has something to act on (see the follow-up that was needed for `omarchy-tailscale-receive.service` in #6375).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HH9yzRubMppKo8PAPHn1cu
