### PR TITLE
Report Omarchy to Steam instead of Arch Linux

### DIFF
--- a/pkgbuilds/omarchy-settings-dev/PKGBUILD
+++ b/pkgbuilds/omarchy-settings-dev/PKGBUILD
@@ -37,11 +37,11 @@ makedepends=(
 
 # backup=() is pacman's hook for protecting user edits to package-owned files
 # on upgrade. Only the paths the package actually installs into /etc qualify.
-# The etc-overrides set (faillock.conf, nsswitch.conf, cups-browsed.conf,
+# The etc-overrides set (os-release, lsb-release, faillock.conf, nsswitch.conf, cups-browsed.conf,
 # cups-files.conf, plymouthd.conf, /etc/skel/.bashrc) ships at
 # /usr/share/omarchy/etc-overrides/
-# and is cp -f'd by post_install — those paths are unowned by pacman and the
-# scriptlet WILL clobber user edits on each upgrade (documented limitation).
+# and is cp -f'd by post_install — the scriptlet WILL clobber user edits on
+# each upgrade (documented limitation).
 backup=(
   'etc/fastfetch/config.jsonc'
   'etc/mkinitcpio.conf.d/omarchy_hooks.conf'
@@ -217,6 +217,11 @@ DOCUMENTATION_URL="https://learn.omacom.io/2/the-omarchy-manual"
 SUPPORT_URL="https://discord.gg/tXFUdasqhY"
 BUG_REPORT_URL="https://github.com/basecamp/omarchy/issues"
 LOGO=omarchy
+EOF
+  cat >"$pkgdir/usr/share/omarchy/etc-overrides/lsb-release" <<EOF
+DISTRIB_ID="Omarchy"
+DISTRIB_RELEASE="rolling"
+DISTRIB_DESCRIPTION="Omarchy"
 EOF
   for path in "${_etc_override_paths[@]}"; do
     case "$path" in

--- a/pkgbuilds/omarchy-settings-dev/omarchy-settings-dev.install
+++ b/pkgbuilds/omarchy-settings-dev/omarchy-settings-dev.install
@@ -7,7 +7,7 @@ _etc_overrides_apply() {
   install -d /etc/plymouth /etc/security /etc/skel
 
   # NOTE: these cp -f's are intentionally destructive on every install/upgrade.
-  # Users who customize /etc/os-release, /etc/plymouth/plymouthd.conf (theme
+  # Users who customize /etc/os-release, /etc/lsb-release, /etc/plymouth/plymouthd.conf (theme
   # switch), /etc/cups/cups-browsed.conf, /etc/cups/cups-files.conf, /etc/nsswitch.conf,
   # /etc/security/faillock.conf, or /etc/skel/.bashrc WILL have their changes
   # reset to Omarchy defaults each time omarchy-settings-dev is upgraded. This is
@@ -15,6 +15,7 @@ _etc_overrides_apply() {
   # of pacman backup=().
   rm -f /etc/os-release
   cp -f /usr/share/omarchy/etc-overrides/os-release              /etc/os-release
+  cp -f /usr/share/omarchy/etc-overrides/lsb-release             /etc/lsb-release
   cp -f /usr/share/omarchy/etc-overrides/security-faillock.conf  /etc/security/faillock.conf
   cp -f /usr/share/omarchy/etc-overrides/nsswitch.conf           /etc/nsswitch.conf
   if [[ -f /etc/cups/cups-browsed.conf ]]; then
@@ -27,7 +28,7 @@ _etc_overrides_apply() {
   fi
   cp -f /usr/share/omarchy/etc-overrides/plymouth-plymouthd.conf /etc/plymouth/plymouthd.conf
   cp -f /usr/share/omarchy/etc-overrides/dot.bashrc              /etc/skel/.bashrc
-  chmod 0644 /etc/os-release /etc/security/faillock.conf /etc/nsswitch.conf \
+  chmod 0644 /etc/os-release /etc/lsb-release /etc/security/faillock.conf /etc/nsswitch.conf \
              /etc/plymouth/plymouthd.conf /etc/skel/.bashrc
   if [[ -f /etc/cups/cups-browsed.conf ]]; then
     chmod 0644 /etc/cups/cups-browsed.conf

--- a/pkgbuilds/omarchy-settings/PKGBUILD
+++ b/pkgbuilds/omarchy-settings/PKGBUILD
@@ -46,11 +46,11 @@ makedepends=(
 
 # backup=() is pacman's hook for protecting user edits to package-owned files
 # on upgrade. Only the paths the package actually installs into /etc qualify.
-# The etc-overrides set (faillock.conf, nsswitch.conf, cups-browsed.conf,
+# The etc-overrides set (os-release, lsb-release, faillock.conf, nsswitch.conf, cups-browsed.conf,
 # cups-files.conf, plymouthd.conf, /etc/skel/.bashrc) ships at
 # /usr/share/omarchy/etc-overrides/
-# and is cp -f'd by post_install — those paths are unowned by pacman and the
-# scriptlet WILL clobber user edits on each upgrade (documented limitation).
+# and is cp -f'd by post_install — the scriptlet WILL clobber user edits on
+# each upgrade (documented limitation).
 backup=(
   'etc/fastfetch/config.jsonc'
   'etc/mkinitcpio.conf.d/omarchy_hooks.conf'
@@ -212,6 +212,11 @@ DOCUMENTATION_URL="https://learn.omacom.io/2/the-omarchy-manual"
 SUPPORT_URL="https://discord.gg/tXFUdasqhY"
 BUG_REPORT_URL="https://github.com/basecamp/omarchy/issues"
 LOGO=omarchy
+EOF
+  cat >"$pkgdir/usr/share/omarchy/etc-overrides/lsb-release" <<EOF
+DISTRIB_ID="Omarchy"
+DISTRIB_RELEASE="rolling"
+DISTRIB_DESCRIPTION="Omarchy"
 EOF
   for path in "${_etc_override_paths[@]}"; do
     case "$path" in

--- a/pkgbuilds/omarchy-settings/omarchy-settings.install
+++ b/pkgbuilds/omarchy-settings/omarchy-settings.install
@@ -7,7 +7,7 @@ _etc_overrides_apply() {
   install -d /etc/plymouth /etc/security /etc/skel
 
   # NOTE: these cp -f's are intentionally destructive on every install/upgrade.
-  # Users who customize /etc/os-release, /etc/plymouth/plymouthd.conf (theme
+  # Users who customize /etc/os-release, /etc/lsb-release, /etc/plymouth/plymouthd.conf (theme
   # switch), /etc/cups/cups-browsed.conf, /etc/cups/cups-files.conf, /etc/nsswitch.conf,
   # /etc/security/faillock.conf, or /etc/skel/.bashrc WILL have their changes
   # reset to Omarchy defaults each time omarchy-settings is upgraded. This is
@@ -15,6 +15,7 @@ _etc_overrides_apply() {
   # of pacman backup=().
   rm -f /etc/os-release
   cp -f /usr/share/omarchy/etc-overrides/os-release              /etc/os-release
+  cp -f /usr/share/omarchy/etc-overrides/lsb-release             /etc/lsb-release
   cp -f /usr/share/omarchy/etc-overrides/security-faillock.conf  /etc/security/faillock.conf
   cp -f /usr/share/omarchy/etc-overrides/nsswitch.conf           /etc/nsswitch.conf
   if [[ -f /etc/cups/cups-browsed.conf ]]; then
@@ -27,7 +28,7 @@ _etc_overrides_apply() {
   fi
   cp -f /usr/share/omarchy/etc-overrides/plymouth-plymouthd.conf /etc/plymouth/plymouthd.conf
   cp -f /usr/share/omarchy/etc-overrides/dot.bashrc              /etc/skel/.bashrc
-  chmod 0644 /etc/os-release /etc/security/faillock.conf /etc/nsswitch.conf \
+  chmod 0644 /etc/os-release /etc/lsb-release /etc/security/faillock.conf /etc/nsswitch.conf \
              /etc/plymouth/plymouthd.conf /etc/skel/.bashrc
   if [[ -f /etc/cups/cups-browsed.conf ]]; then
     chmod 0644 /etc/cups/cups-browsed.conf


### PR DESCRIPTION
## Summary

- ship an Omarchy-specific `/etc/lsb-release` override
- apply it from both stable and development `omarchy-settings` packages
- keep the release value as `rolling` so reporting is not split across Omarchy patch versions

## Why

Omarchy already identifies itself correctly in `/etc/os-release`:

```text
ID=omarchy
ID_LIKE=arch
NAME="Omarchy"
```

However, Arch's `steam` package depends on `lsb-release`, whose `/etc/lsb-release` currently says:

```text
DISTRIB_ID="Arch"
DISTRIB_RELEASE="rolling"
DISTRIB_DESCRIPTION="Arch Linux"
```

Steam's launcher checks `/etc/lsb-release` before `/etc/os-release`. On a stock Omarchy 4.0.2 installation this is visible in `~/.local/share/Steam/logs/console-linux.txt`:

```text
Running Steam on arch rolling 64-bit
```

Steam's public hardware survey does not currently list Omarchy as a distinct Linux version. Although the public table only exposes entries above its reporting cutoff, the client-side value shows that native Steam installations submit/use the Arch identity at this detection point.

With this override, the same Steam detection path resolves to:

```text
omarchy rolling 64-bit
```

## Verification

- `bash -n` passes for both PKGBUILDs and install scripts
- all repository self-tests pass:
  - `./bin/sync-upstream self-test`
  - `./bin/omarchy-pkgs self-test`
  - `./bin/omarchy-release self-test`
- `omarchy-settings` builds successfully with `makepkg`
- inspected the built archive to verify the new override and install-script copy are present
