### PR TITLE
feat(omafiles): add keyboard-driven file explorer

### DIFF
--- a/pkgbuilds/omafiles/.omarchy/package.json
+++ b/pkgbuilds/omafiles/.omarchy/package.json
@@ -1,0 +1,3 @@
+{
+  "source": "local"
+}

--- a/pkgbuilds/omafiles/PKGBUILD
+++ b/pkgbuilds/omafiles/PKGBUILD
@@ -24,7 +24,7 @@ makedepends=(
   'qt6-declarative'
 )
 source=("$pkgname-$pkgver.tar.gz::https://github.com/This-Is-NPC/omafiles/archive/refs/tags/v$pkgver.tar.gz")
-sha256sums=('SKIP')
+sha256sums=('047f2edc18c78b0566bbfcdcb2a58155245306814ce34f07ed424ef4d16d4a36')
 
 build() {
   cd "$srcdir/$pkgname-$pkgver"

--- a/pkgbuilds/omafiles/PKGBUILD
+++ b/pkgbuilds/omafiles/PKGBUILD
@@ -1,0 +1,45 @@
+# Maintainer: This_Is_NPC <gabrielfollone27@gmail.com>
+
+pkgname=omafiles
+pkgver=0.1.0
+pkgrel=1
+pkgdesc='Tag files and list them by tag, from a command line and a Qt Quick window'
+arch=('x86_64' 'aarch64')
+url='https://github.com/This-Is-NPC/omafiles'
+license=('MIT')
+install='omafiles.install'
+options=('!debug')
+depends=(
+  'hicolor-icon-theme'
+  'qt6-base'
+  'qt6-declarative'
+  'xdg-desktop-portal'
+  'xdg-utils'
+  'glib2'
+)
+makedepends=(
+  'gcc'
+  'make'
+  'qt6-base'
+  'qt6-declarative'
+)
+source=("$pkgname-$pkgver.tar.gz::https://github.com/This-Is-NPC/omafiles/archive/refs/tags/v$pkgver.tar.gz")
+sha256sums=('SKIP')
+
+build() {
+  cd "$srcdir/$pkgname-$pkgver"
+  mkdir -p build
+  cd build
+  qmake6 "../omafiles.pro"
+  make -j"$(nproc)"
+}
+
+package() {
+  cd "$srcdir/$pkgname-$pkgver"
+
+  install -Dm755 build/bin/omafiles "$pkgdir/usr/bin/omafiles"
+  install -Dm755 build/bin/omafiles-studio "$pkgdir/usr/bin/omafiles-studio"
+  install -Dm644 LICENSE "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+  install -Dm644 pkgbuild/omafiles.svg "$pkgdir/usr/share/icons/hicolor/scalable/apps/omafiles.svg"
+  install -Dm644 pkgbuild/omafiles.desktop "$pkgdir/usr/share/applications/omafiles.desktop"
+}

--- a/pkgbuilds/omafiles/omafiles.install
+++ b/pkgbuilds/omafiles/omafiles.install
@@ -1,0 +1,12 @@
+post_install() {
+  command -v update-desktop-database >/dev/null 2>&1 && update-desktop-database -q
+  command -v gtk-update-icon-cache >/dev/null 2>&1 && gtk-update-icon-cache -q -t -f usr/share/icons/hicolor
+}
+
+post_upgrade() {
+  post_install
+}
+
+post_remove() {
+  post_install
+}


### PR DESCRIPTION
Adds `omafiles`, a keyboard-driven file explorer with a command line and a Qt
Quick window working over one index. Tags are the organizing layer, and nothing
is moved, renamed or wrapped to carry them.

Source: [This-Is-NPC/omafiles](https://github.com/This-Is-NPC/omafiles) · [v0.1.0](https://github.com/This-Is-NPC/omafiles/releases/tag/v0.1.0)

<img alt="The studio" src="https://raw.githubusercontent.com/This-Is-NPC/omafiles/v0.1.0/docs/img/studio.png" />
<img alt="The graph view" src="https://raw.githubusercontent.com/This-Is-NPC/omafiles/v0.1.0/docs/img/graph.png" />
<img alt="The key sheet" src="https://raw.githubusercontent.com/This-Is-NPC/omafiles/v0.1.0/docs/img/keys.png" />

### Package

C++17 and Qt Quick built out of tree with `qmake6` and `make`, in the same shape
as `pkgbuilds/omawrite`. `.omarchy/package.json` is `{"source": "local"}`. The
source is the GitHub tag tarball with a pinned sha256; nothing is fetched during
`build()`.

Installs `omafiles` and `omafiles-studio`, the desktop entry, the hicolor SVG
icon and the MIT licence, with the same desktop-database and icon-cache
scriptlet omawrite uses.

Runtime dependencies are `qt6-base` and `qt6-declarative` for the window,
`xdg-desktop-portal`, `xdg-utils` for `omafiles open`, `glib2` for
`omafiles trash`, and `hicolor-icon-theme`.

### Verification

- Source archive SHA-256 `047f2edc18c78b0566bbfcdcb2a58155245306814ce34f07ed424ef4d16d4a36` matches the tarball GitHub generates for `v0.1.0`.
- Every path `package()` installs is present in that tarball: `omafiles.pro`, `LICENSE`, `pkgbuild/omafiles.svg`, `pkgbuild/omafiles.desktop`.
- `cli.pro` and `studio.pro` point `DESTDIR` at `../../bin`, which lands as `build/bin` for the out-of-tree build `build()` does — the paths `package()` reads.
- Upstream suite at the tag: 65 passed, 0 failed, 1 skipped (the documentation-shot writer, which needs `OMAFILES_DOCS=1`).

Not covered: no `makepkg` or `bin/repo build` run yet, and only x86_64 has been
built and used — `aarch64` is declared but untested.
