### PR TITLE
Add safe upstream release sync for Strata

### DIFF
--- a/pkgbuilds/strata/.omarchy/package.json
+++ b/pkgbuilds/strata/.omarchy/package.json
@@ -1,4 +1,5 @@
 {
   "source": "local",
-  "release_ring": "fast"
+  "release_ring": "fast",
+  "min_release_age": "24h"
 }

--- a/pkgbuilds/strata/.omarchy/upstream.sh
+++ b/pkgbuilds/strata/.omarchy/upstream.sh
@@ -1,0 +1,106 @@
+#!/bin/bash
+# Strata publishes annotated tags and GitHub source archives, but no checksum
+# manifest. Download the small archive only when a newer stable release exists,
+# then verify that its embedded commit matches the release tag before hashing it.
+set -euo pipefail
+
+REPO='lgse/strata'
+API_URL="https://api.github.com/repos/$REPO"
+
+current=$(awk -F= '/^pkgver=/ { print $2; exit }' PKGBUILD)
+releases=$(curl -fsSL "$API_URL/releases?per_page=100")
+now=$(date +%s)
+min_age=${MIN_RELEASE_AGE_SECONDS:-0}
+
+candidates=0
+best_version=''
+best_tag=''
+best_published_at=''
+
+while IFS=$'\t' read -r tag published_at; do
+  if [[ ! $tag =~ ^v([0-9]+\.[0-9]+\.[0-9]+)$ ]]; then
+    printf '%s has an unusable stable release tag: %s\n' "$REPO" "${tag:-<empty>}" >&2
+    exit 1
+  fi
+  version=${BASH_REMATCH[1]}
+
+  if [[ -z $published_at ]] || ! published_epoch=$(date --date="$published_at" +%s 2>/dev/null); then
+    printf '%s release %s has an invalid publication time\n' "$REPO" "$tag" >&2
+    exit 1
+  fi
+  candidates=$((candidates + 1))
+
+  if ((now - published_epoch < min_age)) && [[ ${BYPASS_MIN_RELEASE_AGE:-} != 1 ]]; then
+    continue
+  fi
+
+  if [[ -z $best_version ]] || (( $(vercmp "$version" "$best_version") > 0 )); then
+    best_version=$version
+    best_tag=$tag
+    best_published_at=$published_at
+  fi
+done < <(jq -r '.[] | select((.draft or .prerelease) | not) | [.tag_name // "", .published_at // ""] | @tsv' <<<"$releases")
+
+if ((candidates == 0)); then
+  printf 'No stable releases found for %s\n' "$REPO" >&2
+  exit 1
+fi
+
+if [[ -z $best_version ]] || (( $(vercmp "$best_version" "$current") <= 0 )); then
+  echo '{}'
+  exit 0
+fi
+
+tag_ref=$(curl -fsSL "$API_URL/git/ref/tags/$best_tag")
+tag_type=$(jq -r '.object.type // empty' <<<"$tag_ref")
+tag_object=$(jq -r '.object.sha // empty' <<<"$tag_ref")
+if [[ ! $tag_object =~ ^[0-9a-f]{40}$ ]]; then
+  printf 'Release %s has an invalid tag object\n' "$best_tag" >&2
+  exit 1
+fi
+
+case "$tag_type" in
+  commit)
+    expected_commit=$tag_object
+    ;;
+  tag)
+    tag_data=$(curl -fsSL "$API_URL/git/tags/$tag_object")
+    if [[ $(jq -r '.object.type // empty' <<<"$tag_data") != commit ]]; then
+      printf 'Release %s does not resolve to a commit\n' "$best_tag" >&2
+      exit 1
+    fi
+    expected_commit=$(jq -r '.object.sha // empty' <<<"$tag_data")
+    ;;
+  *)
+    printf 'Release %s has unsupported tag object type %s\n' "$best_tag" "${tag_type:-<empty>}" >&2
+    exit 1
+    ;;
+esac
+
+if [[ ! $expected_commit =~ ^[0-9a-f]{40}$ ]]; then
+  printf 'Release %s resolves to an invalid commit\n' "$best_tag" >&2
+  exit 1
+fi
+
+tarball=$(mktemp)
+trap 'rm -f "$tarball"' EXIT
+curl -fsSL -o "$tarball" "https://github.com/$REPO/archive/refs/tags/$best_tag.tar.gz"
+
+expected_root="strata-$best_version"
+served_roots=$(tar -tzf "$tarball" | cut -d/ -f1 | sort -u)
+if [[ $served_roots != "$expected_root" ]]; then
+  printf 'Release %s contains root %s, expected %s\n' "$best_tag" "$served_roots" "$expected_root" >&2
+  exit 1
+fi
+
+if ! archive_commit=$(git get-tar-commit-id < <(gzip -dc "$tarball")) ||
+  [[ $archive_commit != "$expected_commit" ]]; then
+  printf 'Release %s archive commit does not match its tag\n' "$best_tag" >&2
+  exit 1
+fi
+
+jq -n \
+  --arg pkgver "$best_version" \
+  --arg published_at "$best_published_at" \
+  --arg source "$(sha256sum "$tarball" | cut -d' ' -f1)" \
+  '{pkgver: $pkgver, published_at: $published_at, sha256sums: {any: [$source]}}'

--- a/pkgbuilds/strata/PKGBUILD
+++ b/pkgbuilds/strata/PKGBUILD
@@ -1,6 +1,6 @@
 pkgname=strata
 pkgver=0.8.0
-pkgrel=1
+pkgrel=2
 pkgdesc='Fast, keyboard-first file manager for modern Linux desktops'
 arch=('x86_64' 'aarch64')
 url='https://github.com/lgse/strata'
@@ -28,7 +28,7 @@ depends=(
   'util-linux'
   'xdg-terminal-exec'
 )
-makedepends=('cargo' 'glib2-devel' 'pkgconf')
+makedepends=('cargo' 'git' 'glib2-devel' 'pkgconf')
 optdepends=(
   'gvfs-smb: browse SMB network shares'
   'imagemagick: additional camera RAW preview support'
@@ -37,12 +37,19 @@ optdepends=(
 conflicts=('strata-git')
 options=('!debug' '!lto')
 
-_commit='61b4b0bc74a5b8ca262c7c080e9fea57bba65ff5'
 source=("$pkgname-$pkgver.tar.gz::$url/archive/refs/tags/v$pkgver.tar.gz")
 sha256sums=('8a6179ad5673afd8036ff6640c1740f6fa676516a05346c180d67ef98c4a56f7')
 
 prepare() {
   cd "$pkgname-$pkgver"
+
+  local commit
+  if ! commit=$(git get-tar-commit-id < <(gzip -dc "$srcdir/$pkgname-$pkgver.tar.gz")) ||
+    [[ ! $commit =~ ^[0-9a-f]{40}$ ]]; then
+    printf 'Could not recover the release commit from the source archive\n' >&2
+    return 1
+  fi
+  printf '%s\n' "$commit" >.build-commit
 
   cargo fetch --locked --target "$CARCH-unknown-linux-gnu"
 }
@@ -51,7 +58,8 @@ build() {
   cd "$pkgname-$pkgver"
 
   export CARGO_TARGET_DIR=target
-  export STRATA_BUILD_COMMIT="$_commit"
+  export STRATA_BUILD_COMMIT
+  STRATA_BUILD_COMMIT=$(<.build-commit)
   export STRATA_RELEASE_TAG="v$pkgver"
   export STRATA_BUILD_KIND=stable
   cargo build --frozen --release
@@ -61,7 +69,8 @@ check() {
   cd "$pkgname-$pkgver"
 
   export CARGO_TARGET_DIR=target
-  export STRATA_BUILD_COMMIT="$_commit"
+  export STRATA_BUILD_COMMIT
+  STRATA_BUILD_COMMIT=$(<.build-commit)
   export STRATA_RELEASE_TAG="v$pkgver"
   export STRATA_BUILD_KIND=stable
   cargo test --frozen --release --all-targets --all-features


### PR DESCRIPTION
## What this does

Adds safe upstream-release syncing for Strata without leaving its embedded build commit stuck on the original v0.8.0 SHA.

- follows strict stable `vX.Y.Z` GitHub releases
- holds new releases for 24 hours
- verifies the archive root and checks its embedded Git commit against the release tag
- hashes the source archive before updating the PKGBUILD
- derives `STRATA_BUILD_COMMIT` from the pinned archive during the build

The recipe moves from `0.8.0-1` to `0.8.0-2` because the build inputs changed. A future version bump will reset `pkgrel` to 1 normally.

## Current release

[v0.8.1](https://github.com/lgse/strata/releases/tag/v0.8.1) is the newest release, but it is still inside the 24-hour quarantine. This PR deliberately does not bypass that window. Once it clears, the scheduled sync will open the normal version-bump PR.

I tested both paths: scheduled mode leaves v0.8.1 alone today, while an explicit bypass updates a disposable checkout to v0.8.1 with the independently reproduced SHA-256 and exact tag commit.

## Validation

- current v0.8.0 source verification passed and derives commit `61b4b0bc74a5b8ca262c7c080e9fea57bba65ff5`
- simulated sync produced v0.8.1, `pkgrel=1`, and source SHA-256 `dca3b6af063f5d49257d27b61be1fa2dfffb1d9998c295382e564ce8e995de71`
- full v0.8.1 package build passed all 384 tests and embedded commit `a2ebf1b820acacbd9b55ffe0e0f204175a613104`
- v0.8.1 adds no dependency changes; reviewed its update-install delta and found no blocking issue
- Gitleaks found no secrets in the three v0.8.1 commits
- sync and repository self-tests passed
- edge/RC/stable dry-runs passed on x86_64 and aarch64
