### PR TITLE
perplexity: fix /lib filesystem conflict breaking every install of 26.9.1

### DIFF
--- a/pkgbuilds/perplexity/PKGBUILD
+++ b/pkgbuilds/perplexity/PKGBUILD
@@ -6,7 +6,7 @@
 
 pkgname=perplexity
 pkgver=26.9.1+build61614
-pkgrel=1
+pkgrel=2
 pkgdesc="Official Perplexity desktop app"
 arch=('x86_64' 'aarch64')
 url="https://www.perplexity.ai"
@@ -56,6 +56,8 @@ depends=(
 optdepends=(
   'apparmor: confine the app with the bundled user-namespace profile'
   'libappindicator-gtk3: tray icon support'
+  'docker: containerized local GPU runtime for on-device models'
+  'nvidia-container-toolkit: containerized local GPU runtime for on-device models'
 )
 
 makedepends=('libarchive')
@@ -90,6 +92,23 @@ package() {
 
   bsdtar -xOf "${deb}" data.tar.xz |
     bsdtar --no-same-owner -xf - -C "${pkgdir}"
+
+  # 26.9.1 started shipping a systemd unit under /lib, and owning /lib -- a
+  # symlink owned by the filesystem package -- makes pacman refuse the whole
+  # transaction. The unit is also a no-op here:
+  # its setup script apt-installs Docker and the NVIDIA Container Toolkit and
+  # exits on any distro but Ubuntu (install those yourself; see optdepends).
+  # Delete it, but only it: anything else arriving outside the trees this
+  # PKGBUILD expects stops the build rather than shipping the next conflict.
+  local unexpected
+  unexpected=$(cd "${pkgdir}" && find . \( -type f -o -type l \) | grep -vE \
+    '^\./(opt|usr)/|^\./lib/systemd/system/perplexity-local-runtime-setup\.service$' || true)
+  if [[ -n "${unexpected}" ]]; then
+    echo "Unexpected files outside opt/ and usr/ in the upstream deb:" >&2
+    echo "${unexpected}" >&2
+    return 1
+  fi
+  rm -rf "${pkgdir}/lib"
 
   # pacman never runs the deb's postinst, so the /usr/bin entry it would have
   # symlinked is a launcher here instead, and the menu entry goes through it so

--- a/pkgbuilds/perplexity/PKGBUILD
+++ b/pkgbuilds/perplexity/PKGBUILD
@@ -95,20 +95,26 @@ package() {
 
   # 26.9.1 started shipping a systemd unit under /lib, and owning /lib -- a
   # symlink owned by the filesystem package -- makes pacman refuse the whole
-  # transaction. The unit is also a no-op here:
-  # its setup script apt-installs Docker and the NVIDIA Container Toolkit and
-  # exits on any distro but Ubuntu (install those yourself; see optdepends).
-  # Delete it, but only it: anything else arriving outside the trees this
-  # PKGBUILD expects stops the build rather than shipping the next conflict.
+  # transaction. The unit is also a no-op here: its setup script apt-installs
+  # Docker and the NVIDIA Container Toolkit and exits on any distro but Ubuntu
+  # (install those yourself; see optdepends). Delete it, and its parents once
+  # emptied; then anything else left outside opt/ and usr/ -- whatever its
+  # type, an empty bin/ or lib64/ included, since those are filesystem-owned
+  # symlinks too -- stops the build rather than shipping the next conflict.
+  (
+    cd "${pkgdir}"
+    rm -f lib/systemd/system/perplexity-local-runtime-setup.service
+    rmdir -p lib/systemd/system 2>/dev/null || true
+  )
+
   local unexpected
-  unexpected=$(cd "${pkgdir}" && find . \( -type f -o -type l \) | grep -vE \
-    '^\./(opt|usr)/|^\./lib/systemd/system/perplexity-local-runtime-setup\.service$' || true)
+  unexpected=$(cd "${pkgdir}" && find . -mindepth 1 \
+    -path ./opt -prune -o -path ./usr -prune -o -print)
   if [[ -n "${unexpected}" ]]; then
-    echo "Unexpected files outside opt/ and usr/ in the upstream deb:" >&2
+    echo "Unexpected entries outside opt/ and usr/ in the upstream deb:" >&2
     echo "${unexpected}" >&2
     return 1
   fi
-  rm -rf "${pkgdir}/lib"
 
   # pacman never runs the deb's postinst, so the /usr/bin entry it would have
   # symlinked is a launcher here instead, and the menu entry goes through it so


### PR DESCRIPTION
The 26.9.1 auto-bump ships a package no machine can install:

```
error: failed to commit transaction (conflicting files)
perplexity: /lib exists in filesystem (owned by filesystem)
```

Upstream's 26.9.1 deb added `lib/systemd/system/perplexity-local-runtime-setup.service`, and the PKGBUILD's wholesale `data.tar` extraction made the package own `/lib` — a `filesystem`-owned symlink on Arch — so pacman refuses the whole transaction, fresh install or upgrade.

## Fix (pkgrel=2)

- **Drop the unit, don't relocate it.** It's Debian-only by upstream's own design: it apt-installs Docker + the NVIDIA Container Toolkit and its script exits on any distro but Ubuntu (`Automated setup requires Ubuntu`). Users who want the containerized local GPU runtime get `docker` and `nvidia-container-toolkit` as new optdepends instead. The inert setup script stays in `/opt/Perplexity/resources` untouched.
- **Fail closed on the next surprise.** `package()` now allowlists what leaves the deb (`opt/`, `usr/`, plus that one known unit path, which it deletes); any other stray top-level file stops the build instead of shipping another filesystem conflict.

## Verification (clean `archlinux:latest` container)

1. The published `26.9.1+build61614-1` from the edge mirror reproduces the `/lib` conflict.
2. `-2` installs fresh: OK.
3. The field scenario — `26.8.4+build50522-1` installed, upgrade to `-2`: OK.
4. Post-install: launcher present, no `/lib` entries in the package, unit absent.

Built via `bin/build --package perplexity`.