### PR TITLE
Package freeze-safe Apple T1 Touch Bar driver

### DIFF
--- a/pkgbuilds/apple-ib-drv-dkms/99-ibridge.rules
+++ b/pkgbuilds/apple-ib-drv-dkms/99-ibridge.rules
@@ -1,0 +1,7 @@
+# Apple T1 iBridge (05ac:8600) on 2016/2017 Touch Bar MacBook Pros.
+# Configuration 1 exposes both the Touch Bar HID and FaceTime HD camera.
+ACTION=="add", SUBSYSTEM=="usb", ATTR{idVendor}=="05ac", ATTR{idProduct}=="8600", ATTR{bConfigurationValue}="1"
+
+# Changing the USB configuration can reset power/control after the initial add
+# event. Reapply on the resulting change/bind event after generic autosuspend.
+ACTION=="add|change|bind", SUBSYSTEM=="usb", ATTR{idVendor}=="05ac", ATTR{idProduct}=="8600", TEST=="power/control", ATTR{power/control}="on"

--- a/pkgbuilds/apple-ib-drv-dkms/PKGBUILD
+++ b/pkgbuilds/apple-ib-drv-dkms/PKGBUILD
@@ -1,0 +1,59 @@
+pkgname=apple-ib-drv-dkms
+pkgver=0.3.0
+pkgrel=1
+pkgdesc='Freeze-safe Apple T1 iBridge and Touch Bar DKMS driver'
+arch=('x86_64')
+url='https://github.com/AJ-dev-i60/t1-touchbar'
+license=('GPL-2.0-only' 'MIT')
+depends=('dkms')
+checkdepends=('LINUX-HEADERS')
+conflicts=('macbook12-spi-driver-dkms')
+source=("t1-touchbar-${pkgver}.tar.gz::${url}/archive/refs/tags/v${pkgver}.tar.gz"
+        '99-ibridge.rules')
+sha256sums=('4092c93e450578c7de61e5c0452fae59ea7e49a7902464eb981c645f15988af5'
+            '86f8f64485fb7d700bbf695e0902152f107867de1b94cba711257654dd319593')
+
+check() {
+  local kernels=(/usr/lib/modules/*/build)
+  if [[ ! -d ${kernels[0]} ]]; then
+    echo 'LINUX-HEADERS required to run check' >&2
+    return 0
+  fi
+
+  local kernel_build kernel_release
+  kernel_build=$(printf '%s\n' "${kernels[@]}" | sort -V | tail -n 1)
+  kernel_release=$(basename "$(dirname "$kernel_build")")
+  make -C "t1-touchbar-${pkgver}/apple-ib-drv" KERNELRELEASE="$kernel_release"
+}
+
+package() {
+  local source_dir="t1-touchbar-${pkgver}/apple-ib-drv"
+  local target_dir="$pkgdir/usr/src/apple-ib-drv-${pkgver}"
+
+  install -d -m 0755 "$target_dir"
+  install -m 0644 \
+    "$source_dir/Makefile" \
+    "$source_dir/apple-ibridge.c" \
+    "$source_dir/apple-ibridge.h" \
+    "$source_dir/apple-touchbar.c" \
+    "$source_dir/hid-ids.h" \
+    "$source_dir/dkms.conf" \
+    "$target_dir/"
+
+  sed -i \
+    -e "s/^PACKAGE_VERSION=.*/PACKAGE_VERSION=\"${pkgver}\"/" \
+    -e '/^CLEAN=/d' \
+    "$target_dir/dkms.conf"
+
+  install -Dm644 "$source_dir/packaging/apple-touchbar.modprobe.conf" \
+    "$pkgdir/usr/lib/modprobe.d/apple-touchbar.conf"
+  install -Dm644 "$source_dir/packaging/apple-touchbar.modules-load.conf" \
+    "$pkgdir/usr/lib/modules-load.d/apple-touchbar.conf"
+  install -Dm644 99-ibridge.rules \
+    "$pkgdir/usr/lib/udev/rules.d/99-ibridge.rules"
+
+  install -Dm644 "t1-touchbar-${pkgver}/LICENSE" \
+    "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+  install -Dm644 "$source_dir/LICENSE" \
+    "$pkgdir/usr/share/licenses/$pkgname/LICENSE.driver"
+}

--- a/pkgbuilds/apple-ib-drv-dkms/PKGBUILD
+++ b/pkgbuilds/apple-ib-drv-dkms/PKGBUILD
@@ -1,6 +1,6 @@
 pkgname=apple-ib-drv-dkms
 pkgver=0.3.0
-pkgrel=1
+pkgrel=4
 pkgdesc='Freeze-safe Apple T1 iBridge and Touch Bar DKMS driver'
 arch=('x86_64')
 url='https://github.com/AJ-dev-i60/t1-touchbar'
@@ -8,16 +8,27 @@ license=('GPL-2.0-only' 'MIT')
 depends=('dkms')
 checkdepends=('LINUX-HEADERS')
 conflicts=('macbook12-spi-driver-dkms')
+# Carry the hardware-tested resume/state fixes pending upstream PR #1:
+# https://github.com/AJ-dev-i60/t1-touchbar/pull/1
 source=("t1-touchbar-${pkgver}.tar.gz::${url}/archive/refs/tags/v${pkgver}.tar.gz"
-        '99-ibridge.rules')
+        '99-ibridge.rules'
+        'apple-touchbar-s2idle-resume.patch'
+        'apple-touchbar-t1-state.patch')
 sha256sums=('4092c93e450578c7de61e5c0452fae59ea7e49a7902464eb981c645f15988af5'
-            '86f8f64485fb7d700bbf695e0902152f107867de1b94cba711257654dd319593')
+            '86f8f64485fb7d700bbf695e0902152f107867de1b94cba711257654dd319593'
+            '900b340c337a395421c972ba9472ac67a2022df96e37173fd4b4587cffd0f465'
+            'f8c925477d4b237c1541a46c68fb5ed3f8a363bb3a1343399fa3b8d21605d90a')
+
+prepare() {
+  patch -d "t1-touchbar-${pkgver}" -Np1 <apple-touchbar-s2idle-resume.patch
+  patch -d "t1-touchbar-${pkgver}" -Np1 <apple-touchbar-t1-state.patch
+}
 
 check() {
   local kernels=(/usr/lib/modules/*/build)
   if [[ ! -d ${kernels[0]} ]]; then
     echo 'LINUX-HEADERS required to run check' >&2
-    return 0
+    return 1
   fi
 
   local kernel_build kernel_release

--- a/pkgbuilds/apple-ib-drv-dkms/apple-touchbar-s2idle-resume.patch
+++ b/pkgbuilds/apple-ib-drv-dkms/apple-touchbar-s2idle-resume.patch
@@ -1,0 +1,21 @@
+--- a/apple-ib-drv/apple-touchbar.c
++++ b/apple-ib-drv/apple-touchbar.c
+@@ -1405,8 +1405,8 @@ static int appletb_reset_resume(struct hid_device *hdev)
+ 	if (iface_info)
+ 		iface_info->suspended = false;
+ 
+-	if ((tb_dev->mode_iface.hdev && !tb_dev->mode_iface.suspended) &&
+-	    (tb_dev->disp_iface.hdev && !tb_dev->disp_iface.suspended)) {
++	if ((!tb_dev->mode_iface.hdev || !tb_dev->mode_iface.suspended) &&
++	    (!tb_dev->disp_iface.hdev || !tb_dev->disp_iface.suspended)) {
+ 		/*
+ 		 * Restore touch bar state. Note that autopm state is not
+ 		 * preserved, so need explicitly restore that here.
+@@ -1471,6 +1471,7 @@ static struct hid_driver appletb_hid_driver = {
+ 	.input_configured = appletb_input_configured,
+ #ifdef CONFIG_PM
+ 	.suspend = appletb_suspend,
++	.resume = appletb_reset_resume,
+ 	.reset_resume = appletb_reset_resume,
+ #endif
+ };

--- a/pkgbuilds/apple-ib-drv-dkms/apple-touchbar-t1-state.patch
+++ b/pkgbuilds/apple-ib-drv-dkms/apple-touchbar-t1-state.patch
@@ -1,0 +1,38 @@
+--- a/apple-ib-drv/apple-touchbar.c
++++ b/apple-ib-drv/apple-touchbar.c
+@@ -263,6 +263,19 @@
+ 
+ 			usleep_range(1000 << tries, 3000 << tries);
+ 		} while (++tries < 5);
++
++		/*
++		 * usb_control_msg() returns the number of bytes transferred on
++		 * success. The mode report is one byte, while the worker expects
++		 * its helper to return zero on success.
++		 */
++		if (rc == 1)
++			rc = 0;
++		else if (rc >= 0) {
++			hid_err(tb_dev->mode_iface.hdev,
++				"Short touch bar mode transfer (%d/1)\n", rc);
++			rc = -EIO;
++		}
+ 	} else {
+ 		rc = hid_hw_raw_request(tb_dev->mode_iface.hdev, report->id,
+ 					(__u8 *) buf, 2, report->type,
+@@ -764,8 +777,14 @@
+ 	 * we do want to wake up the screen if it's asleep, so generate a dummy
+ 	 * event in that case.
+ 	 */
++	/*
++	 * T1 has no independent display-control interface, and its display
++	 * helper is intentionally a no-op. Do not suppress a real key from
++	 * the logical display cache when the mode itself is active.
++	 */
+ 	if (tb_dev->cur_tb_mode == APPLETB_CMD_MODE_OFF ||
+-	    tb_dev->cur_tb_disp == APPLETB_CMD_DISP_OFF) {
++	    (!tb_dev->is_t1 &&
++	     tb_dev->cur_tb_disp == APPLETB_CMD_DISP_OFF)) {
+ 		send_dummy = true;
+ 		rc = 1;
+ 	/* translate special keys */


### PR DESCRIPTION
## Summary

Package the freeze-safe Apple T1 iBridge and firmware Touch Bar driver as `apple-ib-drv-dkms`.

- Uses the upstream `t1-touchbar` v0.3.0 release archive with a pinned SHA-256.
- Carries checksum-pinned resume and T1 mode-state patches from https://github.com/AJ-dev-i60/t1-touchbar/pull/1 while that upstream PR is pending; package release is now `0.3.0-4`.
- Ships DKMS source under `/usr/src/apple-ib-drv-0.3.0`.
- Ships package-owned modprobe, modules-load, and udev configuration.
- Conflicts with the obsolete `macbook12-spi-driver-dkms` package, whose duplicate iBridge modules do not build on Linux 7.
- Builds against the newest installed kernel headers during `check()`.

## Safety

The T1 ACPI `ASOC.SOCW(1)` call can hard-freeze affected MacBooks. The driver defaults to skipping it on MacBookPro13,x/14,x, and this package additionally pins:

```text
options apple_ibridge skip_acpi_power=1
```

The package does not perform a live USB unbind/rebind. Its udev rule keeps the iBridge in USB configuration 1, preserving both the firmware Touch Bar HID and FaceTime HD camera, and reapplies `power/control=on` after configuration-change and bind events.

## Validation

Hardware-tested on:

- MacBookPro13,3 (2016 15-inch, T1)
- `7.2.2-arch1-1-mbp133`

DKMS also built and installed successfully for `6.18.49-1-lts`, but that kernel was not boot-tested.

Validated results after package-backed reboot:

- DKMS status `installed` for the tested 7.2.2 kernel; build/install status also passed for the unbooted LTS kernel.
- `skip_acpi_power=1`; kernel log confirms `SOCW(1)` was not executed.
- Esc, volume, brightness, playback, and Fn/F1-F12 Touch Bar controls work.
- iBridge remains at USB configuration 1 with `power/control=on`.
- FaceTime HD camera captured 1280x720 MJPEG and worked in Zoom.
- Internal microphone captured stereo 48 kHz audio.
- Package build and source verification pass; built package SHA-256 was `3b967fa28b57f4b9633c02f78ff5860cb09fc411a0703516efcb89ba0735f1db`.

Companion Omarchy integration: https://github.com/omacom/omarchy/pull/10141 (draft). Hardware detection and package publication live in different repositories.

## Additional custom 7.2.3 validation — 2026-09-05

Live release: `7.2.3-arch1-2-mbp133`. At the September 5 audit, the installed package was `apple-ib-drv-dkms 0.3.0-1` with zero altered package files; the installed udev rule matches this PR. DKMS built/installed the modules for this custom kernel, and the on-host runtime verifier confirms iBridge and Touch Bar modules loaded with matching vermagic and `skip_acpi_power=1`.

Additional DKMS installations exist for stock `7.2.3-arch1-2` and `6.18.49-2-lts`; those are build/install-only results, not boot tests. The earlier `6.18.49-1-lts` result above is historical.

The owner subsequently confirmed working T1, audio playback, and audio recording/video tested in Zoom on the 7.2.3 setup. That closes the previously missing general functional confirmation; it does not assert a newly completed key-by-key or every-audio-mode test. The detailed 7.2.2 measurements above remain historical. Separate Radeon/display failures do not establish that this T1 package caused them.

## Resume fixes and package verification — 2026-09-07

Commit `9df28e3` carries the same two patches as the already-installed, host-tested `0.3.0-4` package:

- Register ordinary HID resume using the existing restoration helper; absent optional interfaces no longer prevent restoration.
- Normalize a successful one-byte T1 mode transfer to the worker's zero-success convention and stop stale independent display state from suppressing real T1 input.

Upstream source work and its retained hardware evidence are at https://github.com/AJ-dev-i60/t1-touchbar/pull/1. The host recorded T1 suspend/resume and real Escape input after the fix. Reset-resume evidence used a separate local USB quirk; this package does not add that quirk, power-cycle USB or claim to repair platform suspend.

Fresh package validation: all four source SHA-256 checks passed, both patches applied, `makepkg --force --cleanbuild --noconfirm` completed with its module check, and the packaged Touch Bar source was byte-identical to the installed tested source. Module compilation additionally passed for `7.2.3-arch1-2-mbp133` and `6.18.49-2-lts`; the package check compiled against stock `7.2.3-arch1-2`. Correct vermagic was checked. Stock and LTS remain build-only validation, not new boot tests. The focused Omarchy T1 integration suite also passed.

The build was resource-limited and isolated; no package reinstall or live module reload was performed. `check()` now fails instead of silently succeeding if no kernel headers are available. Built artifact SHA-256: `7f1810bff03d2873a2abd49bfb985c7fc40d990d6af5717abeb6026bd000270b`. Maintainer CI authorization and review remain outstanding.

## Custom 7.2.4 compatibility — 2026-09-15

Verified on the same MacBookPro13,3:

- Omarchy dev `4.0.0.r2128.gb679363-1`; Linux custom `7.2.4-arch1-2-mbp133` (not stock Linux).
- Existing `apple-ib-drv-dkms 0.3.0-4` is unchanged; package integrity reports 22 files and zero altered files.
- Kernel-upgrade hooks successfully rebuilt and installed both T1 modules for the new release. After an attended reboot, iBridge and Touch Bar were loaded with matching vermagic; `skip_acpi_power=1` and the log confirmed the ASOC.SOCW power-on call was skipped.
- The owner confirmed working Esc/volume keys, audio playback, microphone and camera after reboot. Audio uses the separate custom-kernel CS8409 patch; these results do not attribute the audio repair to this package.

**Suspend/resume was not tested on 7.2.4.** Earlier 7.2.3 resume/input-trace evidence remains historical. The separate local T1 reset-resume USB quirk was retained; it is still not supplied by this package. No new key-by-key, camera-format, microphone-format or long-term GPU stability claim is made. No package/source changes were needed.
