### PR TITLE
Add omanote, a notes app built on omawrite, to the fast ring

### DIFF
--- a/pkgbuilds/omanote/.omarchy/package.json
+++ b/pkgbuilds/omanote/.omarchy/package.json
@@ -1,0 +1,11 @@
+{
+  "source": "local",
+  "release_ring": "fast",
+  "upstream": {
+    "git_tags": "https://github.com/ratandeepbansal/omanote.git",
+    "tag_pattern": "v{pkgver}",
+    "sources": {
+      "any": ["https://github.com/ratandeepbansal/omanote/archive/refs/tags/{tag}.tar.gz"]
+    }
+  }
+}

--- a/pkgbuilds/omanote/PKGBUILD
+++ b/pkgbuilds/omanote/PKGBUILD
@@ -1,9 +1,9 @@
 # Maintainer: Ratandeep Bansal <ratandeepbansal@gmail.com>
 
 pkgname=omanote
-pkgver=0.1.0
+pkgver=0.2.2
 pkgrel=1
-pkgdesc='Markdown notes app with a collapsible notes sidebar, built on Omawrite'
+pkgdesc='Markdown notes app with a collapsible notes sidebar, built on Omawrite, with folders, tags, and quick capture'
 arch=('x86_64' 'aarch64')
 url='https://github.com/ratandeepbansal/omanote'
 license=('MIT' 'OFL-1.1')
@@ -15,6 +15,11 @@ depends=(
   'qt6-declarative'
   'xdg-desktop-portal'
 )
+optdepends=(
+  'walker: pick a note by title with omanote-pick'
+  'fuzzel: pick a note by title with omanote-pick'
+  'wofi: pick a note by title with omanote-pick'
+)
 makedepends=(
   'gcc'
   'make'
@@ -22,7 +27,7 @@ makedepends=(
   'qt6-declarative'
 )
 source=("$pkgname-$pkgver.tar.gz::https://github.com/ratandeepbansal/omanote/archive/refs/tags/v$pkgver.tar.gz")
-sha256sums=('2ec8e6479f8566ae6ac23645f1323cf5f840d94fbe8092d1500781d03b6fda80')
+sha256sums=('87578a9ef6804d831b29a10d844acecda73242564a64bfde81fd2eb06cf8afbe')
 
 build() {
   cd "$srcdir/$pkgname-$pkgver"
@@ -33,6 +38,7 @@ package() {
   cd "$srcdir/$pkgname-$pkgver"
 
   install -Dm755 build/omanote "$pkgdir/usr/bin/omanote"
+  install -Dm755 bin/omanote-pick "$pkgdir/usr/bin/omanote-pick"
   install -Dm644 LICENSE "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
   install -Dm644 fonts/OFL.txt "$pkgdir/usr/share/licenses/$pkgname/OFL.txt"
   install -Dm644 pkgbuild/omanote.svg "$pkgdir/usr/share/icons/hicolor/scalable/apps/omanote.svg"

--- a/pkgbuilds/omanote/PKGBUILD
+++ b/pkgbuilds/omanote/PKGBUILD
@@ -1,0 +1,40 @@
+# Maintainer: Ratandeep Bansal <ratandeepbansal@gmail.com>
+
+pkgname=omanote
+pkgver=0.1.0
+pkgrel=1
+pkgdesc='Markdown notes app with a collapsible notes sidebar, built on Omawrite'
+arch=('x86_64' 'aarch64')
+url='https://github.com/ratandeepbansal/omanote'
+license=('MIT' 'OFL-1.1')
+install='omanote.install'
+options=('!debug')
+depends=(
+  'hicolor-icon-theme'
+  'qt6-base'
+  'qt6-declarative'
+  'xdg-desktop-portal'
+)
+makedepends=(
+  'gcc'
+  'make'
+  'qt6-base'
+  'qt6-declarative'
+)
+source=("$pkgname-$pkgver.tar.gz::https://github.com/ratandeepbansal/omanote/archive/refs/tags/v$pkgver.tar.gz")
+sha256sums=('2ec8e6479f8566ae6ac23645f1323cf5f840d94fbe8092d1500781d03b6fda80')
+
+build() {
+  cd "$srcdir/$pkgname-$pkgver"
+  ./bin/build
+}
+
+package() {
+  cd "$srcdir/$pkgname-$pkgver"
+
+  install -Dm755 build/omanote "$pkgdir/usr/bin/omanote"
+  install -Dm644 LICENSE "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+  install -Dm644 fonts/OFL.txt "$pkgdir/usr/share/licenses/$pkgname/OFL.txt"
+  install -Dm644 pkgbuild/omanote.svg "$pkgdir/usr/share/icons/hicolor/scalable/apps/omanote.svg"
+  install -Dm644 pkgbuild/omanote.desktop "$pkgdir/usr/share/applications/omanote.desktop"
+}

--- a/pkgbuilds/omanote/omanote.install
+++ b/pkgbuilds/omanote/omanote.install
@@ -1,0 +1,12 @@
+post_install() {
+  gtk-update-icon-cache -q -t -f usr/share/icons/hicolor >/dev/null 2>&1 || true
+  update-desktop-database -q >/dev/null 2>&1 || true
+}
+
+post_upgrade() {
+  post_install
+}
+
+post_remove() {
+  post_install
+}


### PR DESCRIPTION
Adds **omanote** — Omawrite with a collapsible notes sidebar, in the spirit of Apple Notes. Notes are plain Markdown files in `~/Documents/notes`; they autosave, and the sidebar gives search, pin, and delete-to-trash. Collapsed, it is Omawrite again. It follows the Omarchy theme and text size through the same code Omawrite uses.

- Source: https://github.com/ratandeepbansal/omanote (MIT, plus OFL-1.1 for the bundled iA Writer Mono font, as in omawrite)
- Releases: https://github.com/ratandeepbansal/omanote/releases

Omawrite is a great place to type and I wanted local multi-note storage on top of it, so this is a fork rather than a patch. It installs beside omawrite with its own binary, config, and data paths, so both keep working.

**Update:** now at 0.2.2. Since the PR was opened, omanote gained folders (subdirectories), `#tags`, sort modes, checklists, `[[wiki links]]`, image paste, a Markdown preview, spreadsheet-to-table paste, PDF/HTML export, and CLI commands (`omanote --new`, `--daily`, `--search`) that reach the running window, which makes it easy to bind in Hyprland. It also ships `omanote-pick`, a walker/fuzzel/wofi picker for opening notes by title.

### Packaging

Modelled on `pkgbuilds/omawrite`: same deps, same build (`./bin/build`, qmake + make), same install layout, `options=('!debug')`, `arch=('x86_64' 'aarch64')`. Installs `/usr/bin/omanote` and `/usr/bin/omanote-pick`; the launchers are `optdepends`.

`.omarchy/package.json` is `{"source": "local", "release_ring": "fast"}` with a `git_tags` upstream on `v{pkgver}` tags, hashing the GitHub tag tarball, so the sync can pick up new releases without a checksum manifest.

### Checks

- `makepkg -f` builds from the v0.2.2 tag tarball; `sha256sums` matches the archive
- The project's test suite (25 tests, unit + offscreen QML) passes via `./bin/test`
- Package contains both binaries, desktop entry, scalable icon, and both licenses

Happy to adjust anything about the packaging or the ring.
