### PR TITLE
Update Hermes Desktop to 2026.8.31

### DIFF
--- a/pkgbuilds/hermes-desktop/PKGBUILD
+++ b/pkgbuilds/hermes-desktop/PKGBUILD
@@ -18,8 +18,8 @@
 # finds none. /usr/bin/hermes-desktop heads that off. See hermes-desktop.sh.
 
 pkgname=hermes-desktop
-pkgver=2026.8.18
-pkgrel=2
+pkgver=2026.8.31
+pkgrel=1
 pkgdesc='Native desktop shell for Hermes Agent'
 arch=('x86_64')
 url='https://github.com/NousResearch/hermes-agent'
@@ -74,14 +74,14 @@ options=('!strip' '!debug')
 # before falling back to `git rev-parse`. That fallback is wrong here: makepkg
 # builds inside this repository, so git ascends out of srcdir and stamps the
 # app with an omarchy-pkgs commit that means nothing upstream.
-_commit=e624e9fde561e1add9388384012b295fde669ade
+_commit=29112bef099274229cadff79cdff7bf7b99c4b77
 
 _srcdir="hermes-agent-${pkgver}"
 source=("${pkgname}-${pkgver}.tar.gz::${url}/archive/refs/tags/v${pkgver}.tar.gz"
         'hermes-desktop.sh'
         'hermes-desktop.desktop'
         'hermes-desktop.png')
-sha256sums=('1e3d39d3638ec15fa9d31af262568a953e9272090deb1c50c44cd401175f5b80'
+sha256sums=('78fb3ff707ec1d17044b875ecac8bef28aa39d44242824f6871ca40afe7bf217'
             'f5833b969ce451aadee9f08d92db55cce3c7c9213175080590bf37444854d676'
             '3ef685bfcf366776b025d26c37d32854d8d4aa2023b2bd07c8e08b001ef1e8c4'
             'd60d164e24fdcf6532133b8ea43c77a201e4b9e9dbc396187b58d51d8590ef52')


### PR DESCRIPTION
## Summary

- update Hermes Desktop from `2026.8.18` to the latest stable `2026.8.31` release
- bind the package build stamp to the release tag's exact commit
- refresh the source archive hash while preserving Omarchy-owned launch and runtime behavior

This is intentionally separate from the architecture work in #240.

## Verification

- source archive and all local assets verified
- clean x86_64 Arch package build passed
- packaged launch, desktop, icon, and license paths verified
- packaged install stamp identifies commit `29112bef099274229cadff79cdff7bf7b99c4b77` and tag `v2026.8.31`
- repository self-tests passed
- edge and stable build dry runs passed

The upstream annotated tag is unsigned, matching the authority shape already used by this package; the recipe binds both the tag target and source SHA-256.