### PR TITLE
Add oma-preview: native PDF reader/editor with visible agent review

### DIFF
--- a/pkgbuilds/oma-preview/.omarchy/package.json
+++ b/pkgbuilds/oma-preview/.omarchy/package.json
@@ -1,0 +1,3 @@
+{
+  "source": "local"
+}

--- a/pkgbuilds/oma-preview/PKGBUILD
+++ b/pkgbuilds/oma-preview/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Lukas Innig (derluke on GitHub)
 pkgname=oma-preview
-pkgver=0.8.1
+pkgver=0.8.2
 pkgrel=1
 pkgdesc='A small Omarchy-native PDF reader and editor with visible agent review'
 arch=('x86_64' 'aarch64')
@@ -10,7 +10,7 @@ options=('!debug')
 depends=('quickshell' 'qt6-declarative' 'qt6-webengine' 'qpdf' 'poppler' 'librsvg' 'gcc-libs' 'glibc')
 makedepends=('cargo')
 source=("$pkgname-$pkgver.tar.gz::$url/archive/refs/tags/v$pkgver.tar.gz")
-sha256sums=('9e56d0d6de45e0cb3984e10328aee929c40e4d9b1780235ed850117fa783f541')
+sha256sums=('7a457d76550500caa19028cf6cb698812c7d41f4167205e60417369af4ceb7ce')
 
 prepare() {
     cd "oma-preview-$pkgver"

--- a/pkgbuilds/oma-preview/PKGBUILD
+++ b/pkgbuilds/oma-preview/PKGBUILD
@@ -1,0 +1,43 @@
+# Maintainer: Lukas Innig (derluke on GitHub)
+pkgname=oma-preview
+pkgver=0.8.1
+pkgrel=1
+pkgdesc='A small Omarchy-native PDF reader and editor with visible agent review'
+arch=('x86_64' 'aarch64')
+url='https://github.com/derluke/oma-preview'
+license=('MIT')
+options=('!debug')
+depends=('quickshell' 'qt6-declarative' 'qt6-webengine' 'qpdf' 'poppler' 'librsvg' 'gcc-libs' 'glibc')
+makedepends=('cargo')
+source=("$pkgname-$pkgver.tar.gz::$url/archive/refs/tags/v$pkgver.tar.gz")
+sha256sums=('9e56d0d6de45e0cb3984e10328aee929c40e4d9b1780235ed850117fa783f541')
+
+prepare() {
+    cd "oma-preview-$pkgver"
+    # Packaged builds must not embed a developer checkout as a UI fallback.
+    sed -i 's#PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("ui")#PathBuf::from("/usr/share/oma-preview/ui")#' src/main.rs
+    cargo fetch --locked
+}
+
+build() {
+    cd "oma-preview-$pkgver"
+    cargo build --frozen --release
+}
+
+check() {
+    cd "oma-preview-$pkgver"
+    cargo test --frozen
+}
+
+package() {
+    cd "oma-preview-$pkgver"
+    install -Dm755 target/release/oma-preview "$pkgdir/usr/bin/oma-preview"
+    install -d "$pkgdir/usr/share/oma-preview/ui"
+    install -m644 ui/*.qml ui/qmldir "$pkgdir/usr/share/oma-preview/ui/"
+    install -Dm644 data/org.omarchy.oma-preview.desktop "$pkgdir/usr/share/applications/org.omarchy.oma-preview.desktop"
+    install -Dm644 assets/org.omarchy.oma-preview.svg "$pkgdir/usr/share/icons/hicolor/scalable/apps/org.omarchy.oma-preview.svg"
+    install -Dm644 LICENSE "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+    install -Dm644 README.md "$pkgdir/usr/share/doc/$pkgname/README.md"
+    install -Dm644 skills/oma-preview/SKILL.md "$pkgdir/usr/share/oma-preview/skills/oma-preview/SKILL.md"
+    install -Dm644 skills/oma-preview/agents/openai.yaml "$pkgdir/usr/share/oma-preview/skills/oma-preview/agents/openai.yaml"
+}

--- a/pkgbuilds/oma-preview/PKGBUILD
+++ b/pkgbuilds/oma-preview/PKGBUILD
@@ -1,16 +1,16 @@
 # Maintainer: Lukas Innig (derluke on GitHub)
 pkgname=oma-preview
-pkgver=0.8.2
+pkgver=0.9.0
 pkgrel=1
 pkgdesc='A small Omarchy-native PDF reader and editor with visible agent review'
 arch=('x86_64' 'aarch64')
 url='https://github.com/derluke/oma-preview'
 license=('MIT')
 options=('!debug')
-depends=('quickshell' 'qt6-declarative' 'qt6-webengine' 'qpdf' 'poppler' 'librsvg' 'gcc-libs' 'glibc')
-makedepends=('cargo')
+depends=('quickshell' 'qt6-base>=6.11' 'qt6-declarative' 'qt6-webengine' 'wayland' 'qpdf' 'poppler' 'librsvg' 'gcc-libs' 'glibc')
+makedepends=('cargo' 'cmake' 'wayland-protocols' 'pkgconf')
 source=("$pkgname-$pkgver.tar.gz::$url/archive/refs/tags/v$pkgver.tar.gz")
-sha256sums=('7a457d76550500caa19028cf6cb698812c7d41f4167205e60417369af4ceb7ce')
+sha256sums=('d2a18a7c568677861ace057a8fe8fce57f7ab2dc8363eef3e193115d75852cdc')
 
 prepare() {
     cd "oma-preview-$pkgver"
@@ -22,6 +22,7 @@ prepare() {
 build() {
     cd "oma-preview-$pkgver"
     cargo build --frozen --release
+    if [[ -f native/build.sh ]]; then bash native/build.sh; fi
 }
 
 check() {
@@ -34,6 +35,14 @@ package() {
     install -Dm755 target/release/oma-preview "$pkgdir/usr/bin/oma-preview"
     install -d "$pkgdir/usr/share/oma-preview/ui"
     install -m644 ui/*.qml ui/qmldir "$pkgdir/usr/share/oma-preview/ui/"
+    # Older published tags predate the pool; new pool builds require its asset.
+    if [[ -f ui/PdfDocumentPool.qml ]]; then
+        install -m644 ui/idle.pdf "$pkgdir/usr/share/oma-preview/ui/"
+    fi
+    if [[ -f native/build.sh ]]; then
+        install -d "$pkgdir/usr/share/oma-preview/ui/native"
+        install -m644 ui/native/* "$pkgdir/usr/share/oma-preview/ui/native/"
+    fi
     install -Dm644 data/org.omarchy.oma-preview.desktop "$pkgdir/usr/share/applications/org.omarchy.oma-preview.desktop"
     install -Dm644 assets/org.omarchy.oma-preview.svg "$pkgdir/usr/share/icons/hicolor/scalable/apps/org.omarchy.oma-preview.svg"
     install -Dm644 LICENSE "$pkgdir/usr/share/licenses/$pkgname/LICENSE"

--- a/pkgbuilds/oma-preview/PKGBUILD
+++ b/pkgbuilds/oma-preview/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Lukas Innig (derluke on GitHub)
 pkgname=oma-preview
-pkgver=0.9.1
+pkgver=0.10.0
 pkgrel=1
 pkgdesc='A small Omarchy-native PDF reader and editor with visible agent review'
 arch=('x86_64' 'aarch64')
@@ -10,7 +10,7 @@ options=('!debug')
 depends=('quickshell' 'qt6-base>=6.11' 'qt6-declarative' 'qt6-webengine' 'wayland' 'qpdf' 'poppler' 'librsvg' 'gcc-libs' 'glibc')
 makedepends=('cargo' 'cmake' 'wayland-protocols' 'pkgconf')
 source=("$pkgname-$pkgver.tar.gz::$url/archive/refs/tags/v$pkgver.tar.gz")
-sha256sums=('dbce359e08413067305fd0815a56cd39c70103845d60111380fcc6735cea2c1a')
+sha256sums=('6c5bf0e8af5c140ea29930d344b6987433154b17e808aa48b1d33398da0039cc')
 
 prepare() {
     cd "oma-preview-$pkgver"

--- a/pkgbuilds/oma-preview/PKGBUILD
+++ b/pkgbuilds/oma-preview/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Lukas Innig (derluke on GitHub)
 pkgname=oma-preview
-pkgver=0.9.0
+pkgver=0.9.1
 pkgrel=1
 pkgdesc='A small Omarchy-native PDF reader and editor with visible agent review'
 arch=('x86_64' 'aarch64')
@@ -10,7 +10,7 @@ options=('!debug')
 depends=('quickshell' 'qt6-base>=6.11' 'qt6-declarative' 'qt6-webengine' 'wayland' 'qpdf' 'poppler' 'librsvg' 'gcc-libs' 'glibc')
 makedepends=('cargo' 'cmake' 'wayland-protocols' 'pkgconf')
 source=("$pkgname-$pkgver.tar.gz::$url/archive/refs/tags/v$pkgver.tar.gz")
-sha256sums=('d2a18a7c568677861ace057a8fe8fce57f7ab2dc8363eef3e193115d75852cdc')
+sha256sums=('dbce359e08413067305fd0815a56cd39c70103845d60111380fcc6735cea2c1a')
 
 prepare() {
     cd "oma-preview-$pkgver"


### PR DESCRIPTION
## Summary

Add `oma-preview` 0.10.0, a Rust/Quickshell PDF reader and editor built for Omarchy. I maintain the [upstream project](https://github.com/derluke/oma-preview).

Continuous reading, highlighted search, bookmarks, text overlays on non-fillable PDFs, reusable handwritten signatures and page assembly. Private drafts preserve edits and up to 100 undo/redo changes across reopening. The JSON CLI lets agents propose visible changes in the running window; users can correct them before exporting a separate PDF.

0.10.0 adds edge-revealed controls and scrollbars, sharper scrolling, retained-frame single-page reading, faster mouse-wheel page turns, Ctrl+wheel zoom, and confirmed draft clearing. Restored-draft notices stay below the drawer and dismiss automatically. Existing mouse-wheel precision and trackpad momentum remain covered by regression tests.

## Packaging

- Local-source PKGBUILD, pinned `v0.10.0` tag and SHA-256; no AUR account required.
- Normal edge-first policy, no fast-ring override or automatic upstream sync.
- Installs the binary, QML UI, native hold-gesture module, desktop file, icon, license and optional agent skill under `/usr`.
- Qt 6.11+ runtime; CMake, pkgconf and wayland-protocols build dependencies.
- Native hold gestures use Qt’s existing Wayland connection; no raw device permissions or compositor configuration changes.
- Does not change default applications or write into home directories. Existing Folio private-storage paths are retained for compatibility.

## Validation

- x86-64 `makepkg` build from the published tag, including source checksum verification and 13 Rust/CLI tests.
- Local isolated UI checks cover native wheel/trackpad input, search, draft clearing and failure recovery, annotations, reader lifecycle, page identity, controls and a 2,048-page synthetic fixture.
- Retained-frame checks on a 12-slide presentation captured no blank transition frames at 1× or 2×; the source remained unchanged.
- All 29 isolated UI checks pass against the extracted x86-64 release package.
- [Clean Arch build and full suite passed](https://github.com/derluke/oma-preview/actions/runs/34166544815).
- [Fresh installation of the public package passed](https://github.com/derluke/oma-preview/actions/runs/34166869162), including installed-file integrity/version and all 29 installed-UI regressions.
- [Release checks and methodology](https://github.com/derluke/oma-preview/blob/main/tests/RESULTS.md).
- ARM64 source builds are declared but remain untested; maintainer build validation is needed. Automated captures are not physical-input or low-end-hardware benchmarks.

This does not request changing the default PDF app. I can maintain package updates through follow-up PRs.

## Screenshots and demo

Freshly captured from the actual 0.10.0 app: reading, edge controls, Find, bookmarking, typing, resizing, correction, undo, three palettes, export and clearing a draft.

![Oma Preview 0.10.0 in use](https://github.com/derluke/oma-preview/releases/download/v0.10.0/oma-preview-0.10-demo.gif)

[Full-resolution 32-second MP4](https://github.com/derluke/oma-preview/releases/download/v0.10.0/oma-preview-0.10-demo.mp4) · [Try the sample PDF](https://github.com/derluke/oma-preview/releases/download/v0.10.0/A.slower.weekend.pdf) · [Release and package](https://github.com/derluke/oma-preview/releases/tag/v0.10.0)

Fictional content, scripted in-window actions, edited timing and an illustrated pointer. Captured in an isolated offscreen instance without desktop input or desktop theme changes.

<details>
<summary>Reading, editing and themes</summary>

![Reading in Tokyo Night](https://github.com/derluke/oma-preview/releases/download/v0.10.0/01-reading-tokyo-night.png)

![Edge-revealed controls](https://github.com/derluke/oma-preview/releases/download/v0.10.0/09-edge-controls.png)

![Text selection and contextual controls](https://github.com/derluke/oma-preview/releases/download/v0.10.0/07-editing-controls.png)

![The same edited document in Catppuccin Latte](https://github.com/derluke/oma-preview/releases/download/v0.10.0/05-editing-latte.png)

![The same edited document in Gruvbox](https://github.com/derluke/oma-preview/releases/download/v0.10.0/06-editing-gruvbox.png)

</details>
