### PR TITLE
Add OpenClaw to the fast ring, following the npm registry

### DIFF
--- a/pkgbuilds/openclaw/.omarchy/package.json
+++ b/pkgbuilds/openclaw/.omarchy/package.json
@@ -1,0 +1,11 @@
+{
+  "source": "local",
+  "release_ring": "fast",
+  "min_release_age": "24h",
+  "upstream": {
+    "npm": "openclaw",
+    "sources": {
+      "any": ["{npm_tarball}"]
+    }
+  }
+}

--- a/pkgbuilds/openclaw/PKGBUILD
+++ b/pkgbuilds/openclaw/PKGBUILD
@@ -1,0 +1,72 @@
+# Based on the AUR openclaw package:
+# Maintainer: Ralph Torres <mail at ralphptorr dot es>
+# Contributor: Evert Vorster <evorster@gmail.com>
+# Contributor: Emir-Eins <emir-eins@outlook.com>
+# Contributor: Wuxxin <wuxxin@gmail.com>
+# Followed here straight from the npm registry (see .omarchy/package.json), since
+# upstream's release cadence outruns the AUR.
+
+pkgname=openclaw
+pkgver=2026.9.1
+pkgrel=1
+pkgdesc='Multi-channel AI gateway with extensible messaging integrations'
+arch=(x86_64 aarch64)
+url=https://github.com/openclaw/openclaw
+license=(MIT)
+
+depends=('nodejs>=22')
+makedepends=(npm)
+optdepends=(
+    '1password-cli: 1password skill'
+    'curl: weather, openai-whisper-api skills'
+    'ffmpeg: video-frames skill'
+    'github-cli: github, gh-issues skills'
+    'jq: session-logs, trello skills'
+    'python-openai-whisper: openai-whisper skill'
+    'ripgrep: session-logs skill'
+    'tmux: tmux skill'
+    'uv: nano-pdf skill'
+    'go: for installing skill tools not packaged for Arch'
+)
+source=($pkgname-$pkgver.tgz::https://registry.npmjs.org/$pkgname/-/$pkgname-$pkgver.tgz)
+sha256sums=('1bfcac877d53f1e41b69d15c24e081895b2f07d6ff2ffdfe0bf8a7336ab00e59')
+options=(!debug !strip)
+install=$pkgname.install
+noextract=($pkgname-$pkgver.tgz)
+
+package() {
+    export SHARP_IGNORE_GLOBAL_LIBVIPS=1
+    # npm 12 blocks install-time lifecycle scripts unless the package is
+    # allow-listed, and for a local tarball the allow-list key is the tarball's
+    # own file: spec, not the package name (arborist matches node.resolved).
+    # Upstream's postinstall prunes stale dist files and clears the
+    # .openclaw-lifecycle-pending marker the tarball ships with; without it,
+    # every openclaw invocation tries to finish that lifecycle itself and dies
+    # with EACCES on the root-owned install.
+    # That postinstall also migrates legacy state under whatever home it sees
+    # (pruning plugin-runtime-deps in ~/.openclaw and friends), so it gets a
+    # scratch home: a maintainer's own OpenClaw is not the build's to touch.
+    mkdir -p "$srcdir"/home
+    env -u OPENCLAW_HOME -u OPENCLAW_STATE_DIR -u OPENCLAW_CONFIG_PATH HOME="$srcdir"/home \
+        npm install --silent --global --cache "$srcdir"/npm-cache \
+        --allow-scripts="file:$srcdir/$pkgname-$pkgver.tgz" \
+        --prefix "$pkgdir"/usr "$srcdir"/$pkgname-$pkgver.tgz
+    if [[ -e "$pkgdir"/usr/lib/node_modules/$pkgname/.openclaw-lifecycle-pending ]]; then
+        error "openclaw's postinstall did not run; the package would fail on first use"
+        return 1
+    fi
+
+    cat > $pkgname <<'EOF'
+#!/bin/sh
+export SHARP_IGNORE_GLOBAL_LIBVIPS=1
+exec node /usr/lib/node_modules/openclaw/openclaw.mjs "$@"
+EOF
+    install -Dm755 -t "$pkgdir"/usr/bin $pkgname
+
+    cd "$pkgdir"/usr/lib/node_modules/$pkgname
+    install -Dm644 -t "$pkgdir"/usr/share/licenses/$pkgname LICENSE
+    install -Dm644 -t "$pkgdir"/usr/share/doc/$pkgname README.md CHANGELOG.md
+    for f in docs/*
+    do ln -s /usr/lib/node_modules/$pkgname/"$f" "$pkgdir"/usr/share/doc/$pkgname/
+    done
+}

--- a/pkgbuilds/openclaw/openclaw.install
+++ b/pkgbuilds/openclaw/openclaw.install
@@ -1,0 +1,17 @@
+post_install() {
+    printf "%s\n" \
+        "==> Install gateway service: openclaw gateway install --force" \
+        "==> Perform onboarding once: openclaw onboard"
+}
+
+post_upgrade() {
+    # The gateway runs as a systemd user unit (openclaw-gateway.service in
+    # ~/.config/systemd/user), which a root pacman hook has no session bus
+    # to reach, so it cannot be restarted from here and keeps running the
+    # old code until the user restarts it.
+    printf "%s\n" \
+        "==> Restart the gateway to apply updates:" \
+        "    openclaw gateway restart" \
+        "==> Run doctor to migrate configs, check gateway health, etc.:" \
+        "    openclaw doctor"
+}


### PR DESCRIPTION
Adds `openclaw` (the OpenClaw agent platform: CLI, gateway service, and Control UI) as a local package on the fast ring, tracking npm's `latest` dist-tag through the declarative npm provider with the usual 24h quarantine.

## Why local rather than AUR

OpenClaw ships date-based releases every few days and the AUR package trails them by a week or more, so the PKGBUILD lives here (based on the AUR one) and the tarball comes straight from the npm registry with a pinned checksum. The pin is 2026.9.1, taken inside the quarantine window on purpose via `BYPASS_MIN_RELEASE_AGE`; unattended syncs still honour the 24h floor.

## Things worth knowing

- **npm 12 lifecycle scripts.** The builder's npm blocks install-time scripts unless the package is allow-listed, and for a local tarball the key that matches is the tarball's own `file:` spec, not the package name. Without it OpenClaw's postinstall never runs, its `.openclaw-lifecycle-pending` marker ships, and every `openclaw` invocation fails with `EACCES` inside `/usr/lib/node_modules`. `package()` passes `--allow-scripts` and fails the build if the marker survives.
- **No systemctl in `.install`.** The gateway is a systemd *user* unit, which a root pacman hook cannot reach, so `post_upgrade` prints the restart/doctor guidance instead of attempting it (same shape as voxtype-bin).
- Not vendored: `npm install` at package time pulls ~330 transitive deps, as the AUR package does.

## Verified

Built with `bin/build --package openclaw`, installed on an Omarchy machine, then exercised `openclaw gateway install/start/uninstall`, `openclaw dashboard --json`, the Control UI, and the TUI. `bin/sync-upstream self-test` passes.

Companion: the Omarchy-side Install > AI / default-agent wiring is omacom/omarchy#10246.
