### PR TITLE
Add native calendar solver package

### DIFF
--- a/pkgbuilds/omarchy-calendar-solver/.omarchy/package.json
+++ b/pkgbuilds/omarchy-calendar-solver/.omarchy/package.json
@@ -1,0 +1,3 @@
+{
+  "source": "local"
+}

--- a/pkgbuilds/omarchy-calendar-solver/PKGBUILD
+++ b/pkgbuilds/omarchy-calendar-solver/PKGBUILD
@@ -1,0 +1,49 @@
+# Maintainer: blackopsrepl
+
+pkgname=omarchy-calendar-solver
+pkgver=0.1.1
+pkgrel=1
+pkgdesc="One-shot local scheduling adapter for Omarchy's native calendar planner"
+arch=('x86_64' 'aarch64')
+url="https://github.com/blackopsrepl/omarchy-calendar-solver"
+license=('MIT')
+depends=('gcc-libs' 'glibc')
+makedepends=('cargo')
+options=('!debug')
+
+# The source override is used by the Omarchy development and package build
+# workflows. Normal package builds use the immutable version tag.
+if [[ -n "${OMARCHY_CALENDAR_SOLVER_SRC:-}" ]]; then
+  source=()
+  sha256sums=()
+else
+  source=("$pkgname-$pkgver.tar.gz::$url/archive/refs/tags/v$pkgver.tar.gz")
+  sha256sums=('ba522a7996da05fc3e786577dfaa84569c84ea8d3b91d17805f8d9396df3b04c')
+fi
+
+prepare() {
+  if [[ -n "${OMARCHY_CALENDAR_SOLVER_SRC:-}" ]]; then
+    rm -rf "$srcdir/$pkgname-$pkgver"
+    mkdir -p "$srcdir/$pkgname-$pkgver"
+    cp -a "${OMARCHY_CALENDAR_SOLVER_SRC}/." "$srcdir/$pkgname-$pkgver/"
+  fi
+
+  cd "$srcdir/$pkgname-$pkgver"
+  cargo fetch --locked --target "$CARCH-unknown-linux-gnu"
+}
+
+build() {
+  cd "$srcdir/$pkgname-$pkgver"
+  export CARGO_TARGET_DIR=target
+  cargo build --frozen --release
+}
+
+package() {
+  cd "$srcdir/$pkgname-$pkgver"
+
+  install -Dm755 target/release/omarchy-calendar-solver "$pkgdir/usr/bin/omarchy-calendar-solver"
+  install -Dm644 LICENSE "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+  install -Dm644 LICENSES/SolverForge-Apache-2.0.txt "$pkgdir/usr/share/licenses/$pkgname/SolverForge-Apache-2.0.txt"
+  install -Dm644 NOTICE "$pkgdir/usr/share/licenses/$pkgname/NOTICE"
+  install -Dm644 README.md "$pkgdir/usr/share/doc/$pkgname/README.md"
+}


### PR DESCRIPTION
This adds the package for Omarchy’s native calendar planner solver.

It builds the tagged `v0.1.1` Rust adapter from a checksum-pinned source archive
and installs one executable at `/usr/bin/omarchy-calendar-solver`. The package
ships the adapter’s MIT license, SolverForge’s Apache 2.0 license, and NOTICE;
it does not add Cargo, a service, configuration, or a desktop entry to users’
systems.

The adapter is here:
https://github.com/blackopsrepl/omarchy-calendar-solver/tree/v0.1.1

The companion Omarchy change is here:
https://github.com/omacom/omarchy/pull/10215

Verification:

- `makepkg --printsrcinfo --nodeps`
- Clean `makepkg --nodeps --cleanbuild --clean` from the tagged archive
- The resulting package contains only the solver binary, documentation, and
  required license notices.
