### PR TITLE
Fix missing Git in upstream sync container

### DIFF
--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -39,7 +39,7 @@ jobs:
             archlinux:base-devel bash -lc '
               set -euo pipefail
 
-              pacman -Syu --noconfirm jq
+              pacman -Syu --noconfirm git jq
 
               groupadd -g "$HOST_GID" runner
               useradd -m -u "$HOST_UID" -g "$HOST_GID" runner

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
             -w /workspace \
             archlinux:base-devel bash -lc '
               set -euo pipefail
-              pacman -Syu --noconfirm jq
+              pacman -Syu --noconfirm git jq
               ./bin/sync-upstream self-test
               ./bin/sync-rebuilds --self-test
               ./bin/omarchy-pkgs self-test


### PR DESCRIPTION
The scheduled upstream sync runs in `archlinux:base-devel`, which does not include Git. The `git_tags` provider and Strata's archive/tag verification both invoke `git`, so the job found valid updates but ultimately exited with five failures before it could open the generated sync PR.

Install `git` alongside `jq` in the production sync container and the matching CI container. No package updates are included here; the next successful upstream sync will rediscover them and open its normal automated PR.

Validation:
- Reproduced that a fresh `archlinux:base-devel` image has no `git`.
- Ran all four CI self-test suites in that image after installing `git jq`; all passed.
- Ran the five previously failing packages against live upstreams in a disposable package tree: 1 updated, 4 skipped, 0 failed.
- Ran the complete upstream sync against live upstreams in a disposable package tree: 3 updated, 21 skipped, 0 failed.