### PR TITLE
Install the T1 ALS auto-brightness user unit

### DIFF
--- a/pkgbuilds/omarchy-settings-dev/PKGBUILD
+++ b/pkgbuilds/omarchy-settings-dev/PKGBUILD
@@ -170,6 +170,7 @@ package() {
   install -Dm644 default/systemd/user/omarchy-tailscale-receive.service "$pkgdir/usr/lib/systemd/user/omarchy-tailscale-receive.service"
   install -Dm644 default/systemd/user/omarchy-fcitx5.service "$pkgdir/usr/lib/systemd/user/omarchy-fcitx5.service"
   install -Dm644 default/systemd/user/omarchy-crash-watch.service "$pkgdir/usr/lib/systemd/user/omarchy-crash-watch.service"
+  install -Dm644 default/systemd/user/omarchy-als-brightness.service "$pkgdir/usr/lib/systemd/user/omarchy-als-brightness.service"
   # Marks app.slice (and only app.slice) as a systemd-oomd kill candidate, so
   # memory pressure costs one app scope instead of the compositor session.
   # Thresholds live in etc/systemd/oomd.conf.d/10-omarchy.conf.

--- a/pkgbuilds/omarchy-settings/PKGBUILD
+++ b/pkgbuilds/omarchy-settings/PKGBUILD
@@ -165,6 +165,7 @@ package() {
   install -Dm644 default/systemd/user/omarchy-tailscale-receive.service "$pkgdir/usr/lib/systemd/user/omarchy-tailscale-receive.service"
   install -Dm644 default/systemd/user/omarchy-fcitx5.service "$pkgdir/usr/lib/systemd/user/omarchy-fcitx5.service"
   install -Dm644 default/systemd/user/omarchy-crash-watch.service "$pkgdir/usr/lib/systemd/user/omarchy-crash-watch.service"
+  install -Dm644 default/systemd/user/omarchy-als-brightness.service "$pkgdir/usr/lib/systemd/user/omarchy-als-brightness.service"
   # Marks app.slice (and only app.slice) as a systemd-oomd kill candidate, so
   # memory pressure costs one app scope instead of the compositor session.
   # Thresholds live in etc/systemd/oomd.conf.d/10-omarchy.conf.


### PR DESCRIPTION
Pairs with [omacom/omarchy#10331](https://github.com/omacom/omarchy/pull/10331). That PR adds `omarchy-als-brightness.service`; this installs it in both `omarchy-settings` and `omarchy-settings-dev`.

Without this, first-run enable and the T1 migration have nothing to point at under `/usr/lib/systemd/user/`. The unit's own `ExecCondition` / IIO glob keep it inert off T1 hardware.

Related: omacom/omarchy#10331
Related: omacom/omarchy-pkgs#193
