### PR TITLE
Add omareel, a screen recorder and editor for Omarchy

### DIFF
--- a/pkgbuilds/omareel/.omarchy/package.json
+++ b/pkgbuilds/omareel/.omarchy/package.json
@@ -1,0 +1,6 @@
+{
+  "source": "local",
+  "rebuild_on": [
+    "hyprland"
+  ]
+}

--- a/pkgbuilds/omareel/PKGBUILD
+++ b/pkgbuilds/omareel/PKGBUILD
@@ -34,7 +34,7 @@ makedepends=(
 optdepends=('gifsicle: optimize exported GIF files')
 conflicts=('omarecord')
 source=("$pkgname-$pkgver.tar.gz::$url/archive/refs/tags/v$pkgver.tar.gz")
-sha256sums=('SKIP')
+sha256sums=('330d8e2805135af33bf35378e2e961094fc375075d38120c8270bd42fe04ce5b')
 
 build() {
   cd "$srcdir/$pkgname-$pkgver"

--- a/pkgbuilds/omareel/PKGBUILD
+++ b/pkgbuilds/omareel/PKGBUILD
@@ -1,0 +1,61 @@
+# Maintainer: Ryan <ryan@heyoodle.com>
+
+pkgname=omareel
+pkgver=0.1.0
+pkgrel=1
+pkgdesc='Screen recorder and editor for Omarchy with a synthetic cursor, auto zooms, and a camera bubble'
+arch=('x86_64' 'aarch64')
+url='https://github.com/omacom/omareel'
+license=('MIT')
+install='omareel.install'
+options=('!debug')
+depends=(
+  'ffmpeg'
+  'gpu-screen-recorder'
+  'hicolor-icon-theme'
+  'hyprland'
+  'layer-shell-qt'
+  'libevdev'
+  'libjpeg-turbo'
+  'qt6-base'
+  'qt6-declarative'
+  'qt6-multimedia'
+  'qt6-svg'
+  'slurp'
+  'xdg-desktop-portal'
+)
+makedepends=(
+  'cmake'
+  'ninja'
+  'pkgconf'
+  'qt6-shadertools'
+  'wayland'
+)
+optdepends=('gifsicle: optimize exported GIF files')
+conflicts=('omarecord')
+source=("$pkgname-$pkgver.tar.gz::$url/archive/refs/tags/v$pkgver.tar.gz")
+sha256sums=('SKIP')
+
+build() {
+  cd "$srcdir/$pkgname-$pkgver"
+  ./bin/build
+}
+
+package() {
+  cd "$srcdir/$pkgname-$pkgver"
+  install -Dm755 build/omareel "$pkgdir/usr/bin/omareel"
+  ln -s omareel "$pkgdir/usr/bin/omarecord"
+  # The capture-exclusion plugin is bound to the Hyprland commit it was built
+  # against; rebuild_on hyprland keeps this package in step with the compositor.
+  install -Dm755 build/plugin/omareel-capture-exclude.so "$pkgdir/usr/lib/omareel/omareel-capture-exclude.so"
+  install -Dm644 build/plugin/omareel-capture-exclude.so.hash "$pkgdir/usr/lib/omareel/omareel-capture-exclude.so.hash"
+  install -Dm644 LICENSE "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+  install -Dm644 LICENSES/lucide.txt "$pkgdir/usr/share/licenses/$pkgname/lucide.txt"
+  install -Dm644 pkg/omareel.svg "$pkgdir/usr/share/icons/hicolor/scalable/apps/omareel.svg"
+  local size
+  for size in 16 32 48 64 128 256 512; do
+    install -Dm644 "pkg/icons/omareel-$size.png" \
+      "$pkgdir/usr/share/icons/hicolor/${size}x${size}/apps/omareel.png"
+  done
+  install -Dm644 pkg/omareel.desktop "$pkgdir/usr/share/applications/omareel.desktop"
+}

--- a/pkgbuilds/omareel/omareel.install
+++ b/pkgbuilds/omareel/omareel.install
@@ -1,0 +1,13 @@
+post_install() {
+  command -v update-desktop-database >/dev/null 2>&1 && update-desktop-database -q
+  command -v gtk-update-icon-cache >/dev/null 2>&1 && gtk-update-icon-cache -q -t -f usr/share/icons/hicolor
+  return 0
+}
+
+post_upgrade() {
+  post_install
+}
+
+post_remove() {
+  post_install
+}


### PR DESCRIPTION
Adds `omareel` as a local-source package built from the tagged GitHub release at https://github.com/omacom/omareel.

Omareel records the screen without the system cursor, records input separately, and renders a synthetic cursor, click effects, automatic zooms, framing on Omarchy wallpapers, and a camera bubble in a non-destructive editor that exports MP4 or GIF.

Packaging notes:

- `arch=('x86_64' 'aarch64')`; both build with `./bin/build` (CMake + Ninja, Qt 6, C++17) and the tagged release workflow upstream builds and tests both.
- The package ships a small Hyprland plugin (`/usr/lib/omareel/omareel-capture-exclude.so`) that keeps the recording bar and camera self-view out of captured video. It compiles against the `hyprland` headers and only loads on the exact Hyprland commit it was built for, so the metadata declares `"rebuild_on": ["hyprland"]` to have `sync-rebuilds` bump `pkgrel` whenever Hyprland moves. When the plugin cannot load, the app falls back to keeping overlays off the recorded screen.
- `sha256sums=('SKIP')` follows the other local packages that build from GitHub tag archives.
- `conflicts=('omarecord')` retires the pre-release name.