### PR TITLE
Bump libfprint-git for Synaptics fingerprint reader 06cb:010b

### DIFF
--- a/pkgbuilds/libfprint-git/PKGBUILD
+++ b/pkgbuilds/libfprint-git/PKGBUILD
@@ -1,22 +1,17 @@
 # Maintainer: Mikko Nyman <mikko@nyman.xyz>
 # Based on the Arch libfprint package by Jan Alexander Steffens (heftig).
 #
-# Carried the focaltech_moc driver and the FocalTech FT9349 device ID
-# (USB 2808:a97a, ASUS ExpertBook Ultra B9406CAA) while mainline libfprint
-# releases (1.94.x) lacked them. libfprint 1.94.100 ships both, so Omarchy
-# has moved back to stock libfprint and no longer installs this package.
-#
-# Kept around pinned to the last known good commit as an escape hatch;
-# the fallback patch stays for the conditional in prepare().
+# Pinned to upstream support for the Synaptics fingerprint reader USB
+# 06cb:010b, missing from stock libfprint 1.94.100. Also retains the
+# FocalTech MOC support carried by the previous pin.
+# The setup wizard still installs stock libfprint; this is an opt-in package.
 
 pkgname=libfprint-git
-pkgver=1.94.10.r12.gd79f157
-pkgrel=1.1
-# The repo already carries an untested 1.94.10.r220.g695663f build that sorts
-# above the pinned pkgver; the epoch makes the pinned build win the version
-# comparison and gives it a fresh filename that can be promoted.
+pkgver=1.94.100.r10.g6f9479c
+pkgrel=1
+# Retain the epoch used to supersede the previously published untested build.
 epoch=1
-pkgdesc="Library for fingerprint readers (libfprint master with FocalTech MOC updates)"
+pkgdesc="Library for fingerprint readers (pinned upstream with Synaptics 06cb:010b support)"
 url="https://fprint.freedesktop.org/"
 arch=(x86_64)
 license=(LGPL-2.1-or-later)
@@ -47,7 +42,7 @@ provides=(libfprint libfprint-2.so)
 conflicts=(libfprint)
 groups=(fprint)
 source=(
-  "git+https://gitlab.freedesktop.org/libfprint/libfprint.git#commit=d79f157282085738ea8ffbe8c2ae96fb8b3ad831"
+  "git+https://gitlab.freedesktop.org/libfprint/libfprint.git#commit=6f9479c3d55f847c1b3769f28ceb99227f9858cf"
   "focaltech_moc-add-pid-0xA97A.patch"
 )
 b2sums=(
@@ -79,9 +74,6 @@ build() {
   )
   arch-meson libfprint build "${meson_options[@]}"
   meson compile -C build
-  # Regenerate autosuspend.hwdb from the patched id_table[] so the
-  # udev-hwdb test in check() doesn't fail on the new PID 0xA97A.
-  ninja -C build sync-udev-hwdb
 }
 
 check() {

--- a/pkgbuilds/libfprint-git/PKGBUILD
+++ b/pkgbuilds/libfprint-git/PKGBUILD
@@ -1,17 +1,18 @@
 # Maintainer: Mikko Nyman <mikko@nyman.xyz>
 # Based on the Arch libfprint package by Jan Alexander Steffens (heftig).
 #
-# Pinned to upstream support for the Synaptics fingerprint reader USB
-# 06cb:010b, missing from stock libfprint 1.94.100. Also retains the
-# FocalTech MOC support carried by the previous pin.
-# The setup wizard still installs stock libfprint; this is an opt-in package.
+# Omarchy's fingerprint setup installs this in place of stock libfprint, so
+# readers upstream supports ahead of an Arch release reach users by bumping
+# the pin here. Pinned to the commit adding the Synaptics reader USB
+# 06cb:010b, missing from stock libfprint 1.94.100; the FocalTech MOC support
+# carried by the previous pin is retained.
 
 pkgname=libfprint-git
 pkgver=1.94.100.r10.g6f9479c
 pkgrel=1
 # Retain the epoch used to supersede the previously published untested build.
 epoch=1
-pkgdesc="Library for fingerprint readers (pinned upstream with Synaptics 06cb:010b support)"
+pkgdesc="Library for fingerprint readers (pinned upstream snapshot with FocalTech and Synaptics 06cb:010b support)"
 url="https://fprint.freedesktop.org/"
 arch=(x86_64)
 license=(LGPL-2.1-or-later)


### PR DESCRIPTION
The Synaptics fingerprint reader (`06cb:010b`) is visible on USB, but `libfprint 1.94.100` detects no devices. Bump the opt-in `libfprint-git` package to `1:1.94.100.r10.g6f9479c-1`, pinned to upstream commit [6f9479c3d55f847c1b3769f28ceb99227f9858cf](https://gitlab.freedesktop.org/libfprint/libfprint/-/commit/6f9479c3d55f847c1b3769f28ceb99227f9858cf), which adds this USB ID to the Synaptics driver and autosuspend database.

Retain the existing epoch and FocalTech support. Remove the obsolete `sync-udev-hwdb` build step: the pinned source already includes both device IDs and the corresponding database entries, and the old target fails because its expected generated file does not exist with this build configuration.

Validation with the Synaptics fingerprint reader (`06cb:010b`):
- Package built successfully with `makepkg`; all 131 upstream tests passed, including the hardware database check.
- The same C probe linked against stock libfprint detected 0 devices. Linked against the newly built library, it detected 1 Synaptics device and successfully opened and closed it. Neither probe enrolled or deleted prints; the installed driver was not replaced.
- Package version sorts above the previous epoch-bearing pin.
- All three repository self-test commands passed, along with `bash -n` and `git diff --check`.

Enrollment and authentication remain untested. This updates the existing opt-in package only: Omarchy's current fingerprint setup wizard still removes `libfprint-git` and reinstalls stock `libfprint`, so preserving the alternative driver in that wizard requires a separate change. Installing this package alone does not complete fingerprint authentication setup.
