### PR TITLE
omakade: update to 1.6.1 with full runtime deps and aarch64

### DIFF
--- a/pkgbuilds/omakade/.omarchy/package.json
+++ b/pkgbuilds/omakade/.omarchy/package.json
@@ -2,7 +2,7 @@
   "source": "local",
   "release_ring": "fast",
   "upstream": {
-    "github": "tsouth89/omakade",
+    "github": "btsouth/omakade",
     "checksums": "SHA256SUMS",
     "assets": {
       "any": "omakade-{pkgver}.tar.gz"

--- a/pkgbuilds/omakade/PKGBUILD
+++ b/pkgbuilds/omakade/PKGBUILD
@@ -1,14 +1,14 @@
 pkgname=omakade
 pkgver=1.6.1
-pkgrel=1
+pkgrel=2
 pkgdesc='A beautiful, local-first game library for Omarchy'
-arch=('x86_64')
-url='https://tsouth89.github.io/omakade/'
+arch=('x86_64' 'aarch64')
+url='https://btsouth.github.io/omakade/'
 license=('GPL-3.0-or-later')
-depends=('glib2' 'libsecret' 'qt6-base' 'qt6-declarative' 'qt6-wayland' 'sdl3')
+depends=('glib2' 'hicolor-icon-theme' 'libsecret' 'libzip' 'qt6-base' 'qt6-declarative' 'qt6-imageformats' 'qt6-svg' 'qt6-wayland' 'sdl3')
 makedepends=('cmake' 'ninja' 'pkgconf')
 options=('!debug')
-source=("$pkgname-$pkgver.tar.gz::https://github.com/tsouth89/omakade/releases/download/v$pkgver/$pkgname-$pkgver.tar.gz")
+source=("$pkgname-$pkgver.tar.gz::https://github.com/btsouth/omakade/releases/download/v$pkgver/$pkgname-$pkgver.tar.gz")
 sha256sums=('7de0575fb6a7c16f7e8f88e15b6fa15e8486e924e92d07bf6029c0d94a0887e5')
 
 build() {


### PR DESCRIPTION
Bumps omakade to 1.6.1 and fixes the packaging that the automated sync in #313 would carry forward unchanged.

- depends adds libzip, qt6-svg, qt6-imageformats, and hicolor-icon-theme. libzip is a hard build requirement since 1.5, so the 1.6.0 bump in #313 will not build as is. The other three were verified in #272.
- arch adds aarch64. Upstream ships and tests ARM64 packages since 1.6.0.
- source, url, and the upstream sync target move from tsouth89 to btsouth after the account rename. GitHub redirects the old name, but the redirect should not be relied on.

Built locally with makepkg against the 1.6.1 tarball (checksum verified against the release SHA256SUMS) and smoke tested the packaged binary.

Supersedes #272 and the omakade hunk of #313.