### PR TITLE
Refuse to read package metadata as empty when it exists but cannot be opened

### DIFF
--- a/bin/check-versions
+++ b/bin/check-versions
@@ -189,13 +189,22 @@ check_mirror() {
 
   print_info "Checking $mirror packages for $ARCH..."
 
+  # Enumerate first and stop on failure: an unreadable metadata file must not
+  # produce a shorter list that the queue then treats as the truth.
+  local candidates
+  if ! candidates=$(packages_for_unscoped_build "$mirror" "$ARCH"); then
+    print_error "Could not enumerate $mirror packages for $ARCH — leaving its queue untouched"
+    exit 2
+  fi
+
   while IFS= read -r pkg; do
+    [[ -n "$pkg" ]] || continue
     local pkgdir="$PKGBUILDS_DIR/$pkg"
     if check_package "$pkg" "$pkgdir" "$mirror"; then
       needs_build=true
       packages+=("$pkg")
     fi
-  done < <(packages_for_unscoped_build "$mirror" "$ARCH")
+  done <<<"$candidates"
 
   echo ""
 

--- a/bin/sync-rebuilds
+++ b/bin/sync-rebuilds
@@ -781,6 +781,23 @@ cmd_self_test() {
   unset SELFTEST_ARCHES
   check "pkgrel untouched" 1 "$(pkgrel_of "$root/pkgbuilds/t-x86")"
 
+  echo "Metadata that exists but cannot be read aborts instead of reading as empty:"
+  root=$(selftest_root unreadable-metadata)
+  selftest_package "$root" t-locked 1 '{"source":"local","release_ring":"fast"}'
+  if [[ "$(id -u)" == 0 ]]; then
+    echo "  skip: running as root, every file is readable"
+  else
+    chmod 000 "$root/pkgbuilds/t-locked/.omarchy/package.json"
+    check "package_release_ring aborts with status 2" 2 "$( (package_release_ring "$root/pkgbuilds/t-locked" >/dev/null 2>&1); echo $? )"
+    check "package_builds_for_mirror aborts with status 2" 2 "$( (package_builds_for_mirror "$root/pkgbuilds/t-locked" rc >/dev/null 2>&1); echo $? )"
+    check "packages_for_unscoped_build aborts with status 2" 2 "$( (PKGBUILDS_DIR="$root/pkgbuilds" packages_for_unscoped_build rc >/dev/null 2>&1); echo $? )"
+    local guard_message
+    guard_message=$( (package_release_ring "$root/pkgbuilds/t-locked" 2>&1 1>/dev/null) || true )
+    check "message names the file" "true" "$( [[ "$guard_message" == *"cannot be read"* && "$guard_message" == *t-locked* ]] && echo true || echo false )"
+    chmod 644 "$root/pkgbuilds/t-locked/.omarchy/package.json"
+    check "readable again reads the ring" "fast" "$(package_release_ring "$root/pkgbuilds/t-locked")"
+  fi
+
   echo "A PKGBUILD that branches on CARCH at file scope still reads its version:"
   root=$(selftest_root carch-branch)
   mkdir -p "$root/pkgbuilds/t-carch/.omarchy"

--- a/build/build.sh
+++ b/build/build.sh
@@ -567,15 +567,24 @@ if [[ -n "$PACKAGES" ]]; then
     fi
   done
 else
-  # Build all packages that need updates from the relevant directories
+  # Build all packages that need updates from the relevant directories.
+  # Enumerate first and stop on failure: the version check queued this run
+  # from its own reading of the metadata, and a shorter list here (an
+  # unreadable file for the container user, say) would build nothing and
+  # report success — the queue then refills on the next tick, forever.
+  if ! CANDIDATE_PACKAGES=$(collect_packages); then
+    echo "==> ERROR: could not enumerate packages for $MIRROR ($ARCH); refusing to build a partial list"
+    exit 1
+  fi
   while IFS= read -r pkg; do
+    [[ -n "$pkg" ]] || continue
     if check_needs_build "$pkg"; then
       PACKAGES_TO_BUILD+=("$pkg")
     else
       echo "  + $pkg - already up to date"
       SKIPPED_PACKAGES="$SKIPPED_PACKAGES $pkg"
     fi
-  done < <(collect_packages)
+  done <<<"$CANDIDATE_PACKAGES"
 fi
 
 if [[ ${#PACKAGES_TO_BUILD[@]} -eq 0 ]]; then

--- a/helpers/package-metadata.sh
+++ b/helpers/package-metadata.sh
@@ -47,6 +47,26 @@ package_dir_for_name() {
   echo "$pkgdir"
 }
 
+# A metadata file that exists but cannot be opened is not "no metadata": it is
+# a broken checkout, and reading it as empty makes every decision that depends
+# on it silently wrong. The version check runs as root and the build container
+# as an unprivileged user, so a mode-0600 package.json is readable by one and
+# not the other — the two halves then disagree about a package forever, and
+# each release runs with nothing to publish while the queue refills.
+#
+# Every reader below goes through this: a file that is present but unreadable
+# aborts the calling script with a message naming the file and the fix.
+package_require_readable_metadata() {
+  local metadata="$1"
+
+  [[ -e "$metadata" ]] || return 0
+  [[ -r "$metadata" ]] && return 0
+
+  echo "ERROR: package metadata exists but cannot be read as $(id -un): $metadata" >&2
+  echo "       fix the file mode on the checkout (chmod 644) and rerun" >&2
+  exit 2
+}
+
 package_metadata_value() {
   local pkgdir="$1"
   local jq_filter="$2"
@@ -54,6 +74,7 @@ package_metadata_value() {
   local metadata
 
   metadata=$(metadata_file_for_dir "$pkgdir")
+  package_require_readable_metadata "$metadata"
   if [[ ! -f "$metadata" ]]; then
     echo "$default"
     return 0
@@ -67,6 +88,7 @@ package_sync_enabled() {
   local metadata source sync
 
   metadata=$(metadata_file_for_dir "$pkgdir")
+  package_require_readable_metadata "$metadata"
   [[ -f "$metadata" ]] || return 1
 
   source=$(jq -r '.source // ""' "$metadata")
@@ -83,6 +105,10 @@ package_release_ring() {
 
 package_is_fast_ring() {
   local pkgdir="$1"
+  # The ring is read inside a command substitution, where an abort would only
+  # end the subshell; check readability here so an unreadable file stops the
+  # caller rather than reading as "not fast".
+  package_require_readable_metadata "$(metadata_file_for_dir "$pkgdir")"
   [[ "$(package_release_ring "$pkgdir")" == "fast" ]]
 }
 
@@ -95,6 +121,7 @@ package_is_fast_ring() {
 package_min_release_age_seconds() {
   local pkgdir="$1" metadata raw
   metadata=$(metadata_file_for_dir "$pkgdir")
+  package_require_readable_metadata "$metadata"
   if [[ ! -f "$metadata" ]]; then
     echo 0
     return 0
@@ -128,6 +155,7 @@ package_build_skipped() {
   local metadata skip_build
 
   metadata=$(metadata_file_for_dir "$pkgdir")
+  package_require_readable_metadata "$metadata"
   [[ -f "$metadata" ]] || return 1
 
   skip_build=$(jq -r 'if has("skip_build") then .skip_build else false end' "$metadata")
@@ -136,7 +164,11 @@ package_build_skipped() {
 
 package_has_metadata() {
   local pkgdir="$1"
-  [[ -f "$(metadata_file_for_dir "$pkgdir")" ]]
+  local metadata
+
+  metadata=$(metadata_file_for_dir "$pkgdir")
+  package_require_readable_metadata "$metadata"
+  [[ -f "$metadata" ]]
 }
 
 package_has_pkgbuild() {
@@ -198,6 +230,7 @@ package_supports_arch() {
 package_has_channels() {
   local pkgdir="$1" metadata
   metadata=$(metadata_file_for_dir "$pkgdir")
+  package_require_readable_metadata "$metadata"
   [[ -f "$metadata" ]] || return 1
   jq -e 'has("channels")' "$metadata" >/dev/null
 }
@@ -205,6 +238,7 @@ package_has_channels() {
 package_channels() {
   local pkgdir="$1" metadata
   metadata=$(metadata_file_for_dir "$pkgdir")
+  package_require_readable_metadata "$metadata"
   [[ -f "$metadata" ]] || return 0
   jq -r '(.channels // [])[]' "$metadata"
 }
@@ -223,6 +257,7 @@ package_in_channel() {
 package_is_pinned() {
   local pkgdir="$1" metadata
   metadata=$(metadata_file_for_dir "$pkgdir")
+  package_require_readable_metadata "$metadata"
   [[ -f "$metadata" ]] || return 1
   [[ "$(jq -r 'if has("pinned") then .pinned else false end' "$metadata")" == "true" ]]
 }
@@ -275,19 +310,26 @@ package_moves_to_channel() {
 package_dirs() {
   [[ -d "$PKGBUILDS_DIR" ]] || return 0
 
-  find "$PKGBUILDS_DIR" -mindepth 1 -maxdepth 1 -type d -print | sort | while IFS= read -r pkgdir; do
+  # Read from a process substitution rather than piping into the loop, so the
+  # readability guard inside package_has_metadata aborts this function and
+  # not just a pipeline subshell.
+  local pkgdir
+  while IFS= read -r pkgdir; do
     package_has_pkgbuild "$pkgdir" || continue
     package_has_metadata "$pkgdir" || continue
     echo "$pkgdir"
-  done
+  done < <(find "$PKGBUILDS_DIR" -mindepth 1 -maxdepth 1 -type d -print | sort)
 }
 
 packages_for_aur_sync() {
-  package_dirs | while IFS= read -r pkgdir; do
+  local pkgdir dirs
+  dirs=$(package_dirs) || return $?
+  while IFS= read -r pkgdir; do
+    [[ -n "$pkgdir" ]] || continue
     if package_sync_enabled "$pkgdir"; then
       basename "$pkgdir"
     fi
-  done
+  done <<<"$dirs"
 }
 
 package_has_upstream_hook() {
@@ -298,6 +340,7 @@ package_has_upstream_hook() {
 package_has_upstream_provider() {
   local pkgdir="$1" metadata
   metadata=$(metadata_file_for_dir "$pkgdir")
+  package_require_readable_metadata "$metadata"
   [[ -f "$metadata" ]] || return 1
   # Any upstream key counts, valid or not: a malformed declaration must reach
   # bin/sync-upstream and fail loudly there, not vanish from discovery.
@@ -305,11 +348,14 @@ package_has_upstream_provider() {
 }
 
 packages_for_upstream_sync() {
-  package_dirs | while IFS= read -r pkgdir; do
+  local pkgdir dirs
+  dirs=$(package_dirs) || return $?
+  while IFS= read -r pkgdir; do
+    [[ -n "$pkgdir" ]] || continue
     if package_has_upstream_hook "$pkgdir" || package_has_upstream_provider "$pkgdir"; then
       basename "$pkgdir"
     fi
-  done
+  done <<<"$dirs"
 }
 
 # Packages that must be rebuilt when a dependency they link against changes,
@@ -321,6 +367,7 @@ package_rebuild_triggers() {
   local metadata
 
   metadata=$(metadata_file_for_dir "$pkgdir")
+  package_require_readable_metadata "$metadata"
   [[ -f "$metadata" ]] || return 0
 
   jq -r '(.rebuild_on // [])[]' "$metadata"
@@ -332,35 +379,49 @@ package_has_rebuild_triggers() {
 }
 
 packages_for_rebuild_sync() {
-  package_dirs | while IFS= read -r pkgdir; do
+  local pkgdir dirs
+  dirs=$(package_dirs) || return $?
+  while IFS= read -r pkgdir; do
+    [[ -n "$pkgdir" ]] || continue
     if package_has_rebuild_triggers "$pkgdir"; then
       basename "$pkgdir"
     fi
-  done
+  done <<<"$dirs"
 }
 
 packages_for_mirror() {
   local mirror="$1"
 
-  package_dirs | while IFS= read -r pkgdir; do
+  local pkgdir dirs
+  dirs=$(package_dirs) || return $?
+  while IFS= read -r pkgdir; do
+    [[ -n "$pkgdir" ]] || continue
     if package_builds_for_mirror "$pkgdir" "$mirror"; then
       basename "$pkgdir"
     fi
-  done
+  done <<<"$dirs"
 }
 
 packages_for_unscoped_build() {
   local mirror="$1"
   local arch="${2:-${ARCH:-x86_64}}"
 
-  package_dirs | while IFS= read -r pkgdir; do
+  local pkgdir dirs
+  # Enumerate into a variable and loop over that, not `package_dirs | while`
+  # or `done < <(package_dirs)`: both discard the producer's exit status, so
+  # the readability guard aborting inside package_dirs would leave the caller
+  # with a silently shorter list. This way the abort reaches the caller.
+  dirs=$(package_dirs) || return $?
+  while IFS= read -r pkgdir; do
+    [[ -n "$pkgdir" ]] || continue
     if package_builds_for_mirror "$pkgdir" "$mirror" &&
       ! package_build_skipped "$pkgdir" &&
       package_supports_arch "$pkgdir" "$arch"; then
       basename "$pkgdir"
     fi
-  done
+  done <<<"$dirs"
 }
+
 
 package_extract_vcs_hash_from_version() {
   local version="$1"
@@ -444,6 +505,7 @@ validate_package_metadata() {
   local metadata source sync skip_build aur ring pkgrel_type
 
   metadata=$(metadata_file_for_dir "$pkgdir")
+  package_require_readable_metadata "$metadata"
   [[ -f "$metadata" ]] || { echo "missing metadata: $metadata"; return 1; }
 
   jq empty "$metadata" >/dev/null || return 1


### PR DESCRIPTION
Follow-up to #320. rc and stable ran a release for `dropbox-cli` every five minutes tonight, built nothing, and requeued it on the next tick: 34 "nothing to publish" reports in two hours.

## Cause

On the release host, 42 `pkgbuilds/*/.omarchy/package.json` files were mode `0600 root:root` (all dated Aug 13; git tracks them as `100644`, a fresh clone gets `0644`, so this was local damage on the host). The two halves of the pipeline read that file as different users:

| Step | Runs as | `release_ring` seen | Decision |
|---|---|---|---|
| check-versions | root | `fast` | rc/stable are behind edge (2.1 vs 2): queue it |
| build container | uid 1000 | unreadable, so empty | not fast-ring: skip |

`package_metadata_value` saw the file exist, `jq` failed to open it, and the function returned its default. Nothing distinguished "unreadable" from "no ring". The release finished with nothing to publish, `auto-release` treated that as success and cleared the queue, and the next version check refilled it. 11 of the 42 files belonged to fast-ring packages, so the same loop would recur for any of them once edge moved ahead.

The host is repaired (`chmod 644`; both channels published dropbox-cli 2.1 on the next tick). This PR stops the tooling from ever hiding that class of failure again.

## Changes

- `package_require_readable_metadata` in `helpers/package-metadata.sh`: metadata that exists but cannot be read aborts with status 2 and a message naming the file and the fix. Every reader in the helper goes through it, including `package_is_fast_ring` at the call site, since its ring lookup runs inside a command substitution where an abort would only end the subshell.
- The package enumerators (`packages_for_unscoped_build`, `packages_for_mirror`, `packages_for_aur_sync`, `packages_for_upstream_sync`, `packages_for_rebuild_sync`) and `package_dirs` materialize their input into a variable instead of `producer | while`, so the abort propagates instead of yielding a silently shorter list.
- `check-versions` exits without touching any queue when enumeration fails; `build/build.sh` refuses to build a partial list. Both print the file that could not be read.
- `sync-rebuilds --self-test` covers the unreadable case: ring lookup, mirror decision, and enumeration all abort with status 2, the message names the file, and a readable file reads normally again. It skips itself when run as root, where every file is readable.

## Verification

- All four self-tests pass.
- Sandbox `check-versions` against today's edge database: readable metadata behaves as before; a `0000` `dropbox-cli` metadata file aborts with the message and writes no queue files.
- Sandbox `build/build.sh --dry-run` for rc: the unreadable file aborts with "refusing to build a partial list"; readable proceeds to `dropbox-cli`.