### PR TITLE
Add Cytracon Omarchy apps: catsync, cctv-lite, syscare, tilix-cytracon

### DIFF
--- a/pkgbuilds/catsync/.omarchy/package.json
+++ b/pkgbuilds/catsync/.omarchy/package.json
@@ -1,0 +1,12 @@
+{
+  "source": "local",
+  "upstream": {
+    "git_tags": "https://github.com/cytracon/catsync.git",
+    "tag_pattern": "v{pkgver}",
+    "sources": {
+      "any": [
+        "https://github.com/cytracon/catsync/archive/refs/tags/{tag}.tar.gz"
+      ]
+    }
+  }
+}

--- a/pkgbuilds/catsync/PKGBUILD
+++ b/pkgbuilds/catsync/PKGBUILD
@@ -1,0 +1,70 @@
+# Maintainer: Bernard Bachmann <bb@cytracon.com>
+
+pkgname=catsync
+pkgver=0.5.0
+pkgrel=1
+pkgdesc='Google Drive sync daemon and tray for Omarchy'
+arch=('any')
+url='https://github.com/cytracon/catsync'
+license=('MIT')
+install='catsync.install'
+depends=(
+  'python'
+  'python-gobject'
+  'gtk3'
+  'libayatana-appindicator'
+)
+optdepends=(
+  'xdg-utils: open Drive links from the tray'
+)
+source=("$pkgname-$pkgver.tar.gz::https://github.com/cytracon/catsync/archive/refs/tags/v$pkgver.tar.gz")
+sha256sums=('f43eb7a03e32ac3c43b8bb4c34189240956429ec485e87440757ebbe058abada')
+
+package() {
+  cd "$srcdir/$pkgname-$pkgver"
+
+  install -d "$pkgdir/usr/lib/$pkgname"
+  cp -a catsyncd "$pkgdir/usr/lib/$pkgname/"
+  find "$pkgdir/usr/lib/$pkgname" -type d -name '__pycache__' -exec rm -rf {} +
+  find "$pkgdir/usr/lib/$pkgname" -type f -name '*.pyc' -delete
+
+  install -Dm755 /dev/stdin "$pkgdir/usr/bin/catsyncd" <<'EOF'
+#!/usr/bin/env bash
+export PYTHONPATH="/usr/lib/catsync${PYTHONPATH:+:$PYTHONPATH}"
+exec python3 -m catsyncd "$@"
+EOF
+  install -Dm755 /dev/stdin "$pkgdir/usr/bin/catsync-tray" <<'EOF'
+#!/usr/bin/env bash
+export PYTHONPATH="/usr/lib/catsync${PYTHONPATH:+:$PYTHONPATH}"
+exec python3 -m catsyncd.tray "$@"
+EOF
+  install -Dm755 /dev/stdin "$pkgdir/usr/bin/catsync" <<'EOF'
+#!/usr/bin/env bash
+cmd="${1:-start}"
+case "$cmd" in
+  start|tray) exec /usr/bin/catsync-tray ;;
+  settings) exec /usr/bin/catsync-tray --settings ;;
+  setup) exec /usr/bin/catsync-tray --setup ;;
+  *) exec /usr/bin/catsyncd "$@" ;;
+esac
+EOF
+
+  install -Dm644 data/catsync.desktop "$pkgdir/usr/share/applications/catsync.desktop"
+  install -Dm644 data/catsync-settings.desktop "$pkgdir/usr/share/applications/catsync-settings.desktop"
+  install -Dm644 data/catsync-helper.desktop "$pkgdir/usr/share/applications/catsync-helper.desktop"
+
+  install -Dm644 data/icons/catsync.svg "$pkgdir/usr/share/icons/hicolor/scalable/apps/catsync.svg"
+  install -Dm644 data/icons/catsyncd-tray.svg "$pkgdir/usr/share/icons/hicolor/scalable/apps/catsyncd-tray.svg"
+  install -Dm644 data/icons/catsyncd-tray-busy.svg "$pkgdir/usr/share/icons/hicolor/scalable/apps/catsyncd-tray-busy.svg"
+  install -Dm644 data/icons/catsyncd-tray-stopped.svg "$pkgdir/usr/share/icons/hicolor/scalable/apps/catsyncd-tray-stopped.svg"
+
+  sed 's|ExecStart=%h/.local/bin/catsyncd daemon|ExecStart=/usr/bin/catsyncd daemon|' \
+    data/systemd/catsyncd.service \
+    | install -Dm644 /dev/stdin "$pkgdir/usr/lib/systemd/user/catsyncd.service"
+  sed 's|ExecStart=%h/.local/bin/catsync-tray|ExecStart=/usr/bin/catsync-tray|' \
+    data/systemd/catsync-tray.service \
+    | install -Dm644 /dev/stdin "$pkgdir/usr/lib/systemd/user/catsync-tray.service"
+
+  install -Dm644 LICENSE "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+  install -Dm644 data/config.json.example "$pkgdir/usr/share/doc/$pkgname/config.json.example"
+}

--- a/pkgbuilds/catsync/catsync.install
+++ b/pkgbuilds/catsync/catsync.install
@@ -1,0 +1,14 @@
+post_install() {
+  command -v update-desktop-database >/dev/null 2>&1 && update-desktop-database -q
+  command -v gtk-update-icon-cache >/dev/null 2>&1 && gtk-update-icon-cache -q -t -f usr/share/icons/hicolor
+  echo 'Enable the user daemon after Google auth: systemctl --user enable --now catsyncd.service'
+}
+
+post_upgrade() {
+  post_install
+}
+
+post_remove() {
+  command -v update-desktop-database >/dev/null 2>&1 && update-desktop-database -q
+  command -v gtk-update-icon-cache >/dev/null 2>&1 && gtk-update-icon-cache -q -t -f usr/share/icons/hicolor
+}

--- a/pkgbuilds/cctv-lite/.omarchy/package.json
+++ b/pkgbuilds/cctv-lite/.omarchy/package.json
@@ -1,0 +1,12 @@
+{
+  "source": "local",
+  "upstream": {
+    "git_tags": "https://github.com/cytracon/cctv-lite.git",
+    "tag_pattern": "v{pkgver}",
+    "sources": {
+      "any": [
+        "https://github.com/cytracon/cctv-lite/archive/refs/tags/{tag}.tar.gz"
+      ]
+    }
+  }
+}

--- a/pkgbuilds/cctv-lite/PKGBUILD
+++ b/pkgbuilds/cctv-lite/PKGBUILD
@@ -1,0 +1,50 @@
+# Maintainer: Bernard Bachmann <bb@cytracon.com>
+
+pkgname=cctv-lite
+pkgver=0.2.0
+pkgrel=1
+pkgdesc='Live multi-camera RTSP viewer for Omarchy'
+arch=('any')
+url='https://github.com/cytracon/cctv-lite'
+license=('MIT')
+install='cctv-lite.install'
+depends=(
+  'python'
+  'python-gobject'
+  'python-yaml'
+  'gtk4'
+  'libadwaita'
+  'gstreamer'
+  'gst-plugins-base'
+  'gst-plugins-good'
+  'gst-plugins-bad'
+  'gst-libav'
+  'gst-plugin-gtk4'
+)
+source=("$pkgname-$pkgver.tar.gz::https://github.com/cytracon/cctv-lite/archive/refs/tags/v$pkgver.tar.gz")
+sha256sums=('c58c457de5e84ce24edfb6ded088817769a30fd1c92c55b0b26c56453df59e8d')
+
+package() {
+  cd "$srcdir/$pkgname-$pkgver"
+
+  install -d "$pkgdir/usr/lib/$pkgname"
+  cp -a cctv_lite "$pkgdir/usr/lib/$pkgname/"
+  find "$pkgdir/usr/lib/$pkgname" -type d -name '__pycache__' -exec rm -rf {} +
+  find "$pkgdir/usr/lib/$pkgname" -type f -name '*.pyc' -delete
+
+  install -Dm755 /dev/stdin "$pkgdir/usr/bin/cctv-lite" <<'EOF'
+#!/usr/bin/env bash
+export PYTHONPATH="/usr/lib/cctv-lite${PYTHONPATH:+:$PYTHONPATH}"
+exec python3 -m cctv_lite "$@"
+EOF
+
+  install -Dm644 data/com.bbachmann.cctv-lite.desktop \
+    "$pkgdir/usr/share/applications/com.bbachmann.cctv-lite.desktop"
+  install -Dm644 data/icons/cctv-lite.svg \
+    "$pkgdir/usr/share/icons/hicolor/scalable/apps/com.bbachmann.cctv-lite.svg"
+  install -Dm644 data/icons/cctv-lite.svg \
+    "$pkgdir/usr/share/icons/hicolor/scalable/apps/cctv-lite.svg"
+
+  install -Dm644 LICENSE "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+  install -Dm644 data/config.yaml.example "$pkgdir/usr/share/doc/$pkgname/config.yaml.example"
+}

--- a/pkgbuilds/cctv-lite/cctv-lite.install
+++ b/pkgbuilds/cctv-lite/cctv-lite.install
@@ -1,0 +1,12 @@
+post_install() {
+  command -v update-desktop-database >/dev/null 2>&1 && update-desktop-database -q
+  command -v gtk-update-icon-cache >/dev/null 2>&1 && gtk-update-icon-cache -q -t -f usr/share/icons/hicolor
+}
+
+post_upgrade() {
+  post_install
+}
+
+post_remove() {
+  post_install
+}

--- a/pkgbuilds/syscare/.omarchy/package.json
+++ b/pkgbuilds/syscare/.omarchy/package.json
@@ -1,0 +1,12 @@
+{
+  "source": "local",
+  "upstream": {
+    "git_tags": "https://github.com/cytracon/syscare.git",
+    "tag_pattern": "v{pkgver}",
+    "sources": {
+      "any": [
+        "https://github.com/cytracon/syscare/archive/refs/tags/{tag}.tar.gz"
+      ]
+    }
+  }
+}

--- a/pkgbuilds/syscare/PKGBUILD
+++ b/pkgbuilds/syscare/PKGBUILD
@@ -1,0 +1,55 @@
+# Maintainer: Bernard Bachmann <bb@cytracon.com>
+
+pkgname=syscare
+pkgver=0.3.1
+pkgrel=1
+pkgdesc='System optimizer for Omarchy: clean caches, updates, processes, security'
+arch=('any')
+url='https://github.com/cytracon/syscare'
+license=('MIT')
+install='syscare.install'
+depends=(
+  'python'
+  'python-gobject'
+  'python-psutil'
+  'gtk4'
+  'libadwaita'
+  'pacman-contrib'
+  'polkit'
+)
+source=("$pkgname-$pkgver.tar.gz::https://github.com/cytracon/syscare/archive/refs/tags/v$pkgver.tar.gz")
+sha256sums=('482a3eaa561b6671e726a8207f782d30e8435d9990fe217f64bc9f78121ca4ae')
+
+package() {
+  cd "$srcdir/$pkgname-$pkgver"
+
+  install -d "$pkgdir/usr/lib/$pkgname"
+  cp -a syscare "$pkgdir/usr/lib/$pkgname/"
+  find "$pkgdir/usr/lib/$pkgname" -type d -name '__pycache__' -exec rm -rf {} +
+  find "$pkgdir/usr/lib/$pkgname" -type f -name '*.pyc' -delete
+
+  install -Dm755 /dev/stdin "$pkgdir/usr/bin/syscare" <<'EOF'
+#!/usr/bin/env bash
+export PYTHONPATH="/usr/lib/syscare${PYTHONPATH:+:$PYTHONPATH}"
+exec python3 -m syscare "$@"
+EOF
+
+  install -Dm644 data/com.bbachmann.syscare.desktop \
+    "$pkgdir/usr/share/applications/com.bbachmann.syscare.desktop"
+  install -Dm644 data/icons/syscare.svg \
+    "$pkgdir/usr/share/icons/hicolor/scalable/apps/com.bbachmann.syscare.svg"
+  install -Dm644 data/icons/syscare.svg \
+    "$pkgdir/usr/share/icons/hicolor/scalable/apps/syscare.svg"
+
+  if [[ -d data/icons/png ]]; then
+    for size in 16 22 24 32 48 64 128 256 512; do
+      src="data/icons/png/${size}x${size}/com.bbachmann.syscare.png"
+      if [[ -f "$src" ]]; then
+        install -Dm644 "$src" \
+          "$pkgdir/usr/share/icons/hicolor/${size}x${size}/apps/com.bbachmann.syscare.png"
+      fi
+    done
+  fi
+
+  install -Dm644 LICENSE "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+}

--- a/pkgbuilds/syscare/syscare.install
+++ b/pkgbuilds/syscare/syscare.install
@@ -1,0 +1,12 @@
+post_install() {
+  command -v update-desktop-database >/dev/null 2>&1 && update-desktop-database -q
+  command -v gtk-update-icon-cache >/dev/null 2>&1 && gtk-update-icon-cache -q -t -f usr/share/icons/hicolor
+}
+
+post_upgrade() {
+  post_install
+}
+
+post_remove() {
+  post_install
+}

--- a/pkgbuilds/tilix-cytracon/.omarchy/package.json
+++ b/pkgbuilds/tilix-cytracon/.omarchy/package.json
@@ -1,0 +1,3 @@
+{
+  "source": "local"
+}

--- a/pkgbuilds/tilix-cytracon/PKGBUILD
+++ b/pkgbuilds/tilix-cytracon/PKGBUILD
@@ -1,0 +1,62 @@
+# Maintainer: Bernard Bachmann <bb@cytracon.com>
+
+pkgname=tilix-cytracon
+_srcname=tilix
+_tag=v1.9.8-cytracon.12
+pkgver=1.9.8.cytracon.12
+pkgrel=1
+pkgdesc='Cytracon Tilix: tiling terminal for Omarchy with split panes, bookmarks, and AI CLIs'
+arch=('x86_64' 'aarch64')
+url='https://github.com/cytracon/tilix'
+license=('MPL-2.0')
+depends=(
+  'libx11'
+  'gtkd'
+  'vte3'
+  'dconf'
+  'gsettings-desktop-schemas'
+  'liblphobos'
+  'libunwind'
+)
+makedepends=(
+  'ldc'
+  'po4a'
+  'meson'
+  'appstream'
+  'dub'
+)
+optdepends=(
+  'python-nautilus: Open Tilix Here in Nautilus'
+  'libsecret: password manager'
+)
+provides=('tilix')
+conflicts=('tilix')
+source=("$_srcname-$pkgver.tar.gz::https://github.com/cytracon/tilix/archive/refs/tags/$_tag.tar.gz")
+sha256sums=('bc03b57ffe2d80730b41135b7f558e0af1d5d0be74f600950bf6a213402b0e5d')
+
+prepare() {
+  mv "$srcdir/$_srcname-${_tag#v}" "$srcdir/$_srcname-$pkgver"
+}
+
+build() {
+  export DC=ldc
+  local srcdir_build="$srcdir/$_srcname-$pkgver"
+  if [[ -f "$srcdir_build/meson.build" ]]; then
+    arch-meson "$srcdir_build" build
+    meson compile -C build
+  else
+    cd "$srcdir_build"
+    dub build --compiler=ldc2 --build=release
+  fi
+}
+
+package() {
+  local srcdir_build="$srcdir/$_srcname-$pkgver"
+  if [[ -d "$srcdir/build" ]]; then
+    meson install -C build --destdir "$pkgdir"
+  else
+    cd "$srcdir_build"
+    PREFIX="$pkgdir/usr" ./install.sh "$pkgdir/usr"
+  fi
+  install -Dm644 "$srcdir_build/LICENSE" "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+}


### PR DESCRIPTION
## What

Add four local packages for Cytracon apps already used on Omarchy via `omarchy install …` (user-local `~/.local`). These PKGBUILDs install system-wide so they can appear in the official Omarchy package repository and therefore on omarchyapps.com.

| Package | Version | Upstream | What it is |
|---|---|---|---|
| `catsync` | 0.5.0 | https://github.com/cytracon/catsync | Google Drive sync daemon + tray. MIT. |
| `cctv-lite` | 0.2.0 | https://github.com/cytracon/cctv-lite | Live RTSP camera grid. MIT. |
| `syscare` | 0.3.1 | https://github.com/cytracon/syscare | System optimizer (caches, updates, processes, security). MIT. |
| `tilix-cytracon` | 1.9.8.cytracon.12 | https://github.com/cytracon/tilix | Cytracon Tilix fork (tiling terminal, bookmarks, AI CLIs). MPL-2.0. `provides/conflicts: tilix`. |

Matching bar plugins are already listed in the plugin marketplace (`io.github.cytracon.*`).

## Source / updates

- Python apps: `source: local` with `git_tags` `v{pkgver}` from the GitHub repos.
- Tilix: `source: local` only. Upstream tags are `v1.9.8-cytracon.N`, which cannot be used as an Arch `pkgver` (hyphen). Mapped to `1.9.8.cytracon.12`.
- Tagged GitHub releases exist for each version in this PR.

## Packaging notes

- Python apps are `arch=('any')`. Payload under `/usr/lib/<name>/`, launchers in `/usr/bin`. User config stays in `~/.config/` and is not overwritten.
- Catsync ships user systemd units with `ExecStart=/usr/bin/catsyncd daemon` (not `~/.local`).
- Catsync needs Google OAuth on the machine (`~/.config/catsyncd/`). No secrets in the package.
- CCTV Lite stores camera URLs in `~/.config/cctv-lite/` (not packaged).
- Tilix is a compiled D/GTK app. PKGBUILD prefers `meson`+`ldc` (Arch extra style) and falls back to `dub` if meson is not used.

## Tested

- `package()` smoke-tested for catsync, cctv-lite, and syscare: wrappers, desktop files, icons, licenses, systemd unit paths, and `python3 -m` imports.
- Tilix was **not** compiled in this checkout (ldc/meson build belongs on the package builder).
- aarch64 for Tilix is declared but not built here.

I am the upstream maintainer (`cytracon`). Happy to split into four PRs if you prefer.