### PR TITLE
Update Flea to 0.1.4

### DIFF
--- a/pkgbuilds/flea/PKGBUILD
+++ b/pkgbuilds/flea/PKGBUILD
@@ -1,28 +1,37 @@
 # Maintainer: GM <gianmarcomorales@icloud.com>
 
 pkgname=flea
-pkgver=0.1.3
+pkgver=0.1.4
 pkgrel=1
 pkgdesc='Fast, keyboard-first file manager for Omarchy'
-arch=('x86_64')
+arch=('x86_64' 'aarch64')
 url='https://github.com/thisisgm/flea'
 license=('MIT')
 
 depends=(
   'bubblewrap'
+  'expect'
   'gcc-libs'
   'glib2'
   'glibc'
+  'gvfs'
+  'gvfs-dnssd'
+  'gvfs-nfs'
+  'gvfs-smb'
   'hicolor-icon-theme'
   'omarchy'
+  'python-gobject'
   'quickshell'
   'qt6-multimedia'
   'qt6-webengine'
   'shared-mime-info'
   'util-linux'
+  'wl-clipboard'
+  'xdg-terminal-exec'
   'xdg-utils'
 )
 makedepends=('cargo')
+checkdepends=('python')
 optdepends=(
   '7zip: 7z archive support'
   'dropbox-cli: Dropbox browsing and share links'
@@ -30,74 +39,16 @@ optdepends=(
   'imagemagick: image conversion'
   'libarchive: archive listing and extraction'
   'tailscale: Taildrop sharing'
-  'wl-clipboard: copy Dropbox share links to the clipboard'
 )
 conflicts=('flea-git')
 options=('!debug')
 
-_security_patches=(
-  '2bd7cc207c110ae3b3ea61a4d4e42336f1815111'
-  '27d19ca4a38ef4a0a920fb78441ce662a0101327'
-  '23290ce1917b0d7f0392dd09d04bf2a7504ec93a'
-  'b4b7ee47244b52457eec2874e21a8656d8ace647'
-)
 source=(
   "$pkgname-$pkgver.tar.gz::$url/archive/refs/tags/v$pkgver.tar.gz"
-  "security-2bd7cc2.patch::$url/commit/${_security_patches[0]}.patch"
-  "security-27d19ca.patch::$url/commit/${_security_patches[1]}.patch"
-  "security-23290ce.patch::$url/commit/${_security_patches[2]}.patch"
-  "security-b4b7ee4.patch::$url/commit/${_security_patches[3]}.patch"
 )
 sha256sums=(
-  '3599ab76253c444dea027f1ebe85b32612d9a174e60eb8aca33ee21d9e2d6973'
-  'c610a9f44294b67341940203943c9c567003b65cc436d6013cd36754379183d8'
-  'e457ef17e26f70057b1184eeb938fccc5906f48a7c77f1df573d55d13a845425'
-  'f8381456a3b5f39d341cc6610bf27beb8354892b17a1c8c6d7882db4e40824c3'
-  '46bdbe43f135a052c893b1987f8b0928736445616a84b0c65d2181ee74b21b25'
+  '02ccb77929058862072b17a60b9dd08733e395faebfd4cbabd6e5c4be5362b8f'
 )
-
-prepare() {
-  cd "$pkgname-$pkgver"
-
-  security_patch_present() {
-    case "$1" in
-      2bd7cc207c110ae3b3ea61a4d4e42336f1815111)
-        grep -Fq 'a.push("--".to_string());' src/backend/archive.rs &&
-          grep -Fq 'let input = std::fs::canonicalize(input)' src/backend/archiveops.rs &&
-          grep -Fq 'if op != "compress" && op != "extract"' \
-            src/backend/run.rs src/backend/archivereq.rs
-        ;;
-      27d19ca4a38ef4a0a920fb78441ce662a0101327)
-        grep -Fq 'the sandbox is unavailable: bwrap or prlimit is not on PATH' src/backend/archivework.rs &&
-          grep -Fq 'if !sandbox::available()' src/backend/mediaprobe.rs &&
-          grep -Fq 'if !sandbox::available()' src/backend/metareq.rs
-        ;;
-      23290ce1917b0d7f0392dd09d04bf2a7504ec93a)
-        grep -Fq 'copyToClipboard.command = ["wl-copy", url]' ui/ShareLink.qml
-        ;;
-      b4b7ee47244b52457eec2874e21a8656d8ace647)
-        grep -Fq '.custom_flags(O_NOFOLLOW)' src/backend/copyfile.rs
-        ;;
-      *)
-        return 1
-        ;;
-    esac
-  }
-
-  local commit patch_file
-  for commit in "${_security_patches[@]}"; do
-    patch_file="$srcdir/security-${commit:0:7}.patch"
-
-    if patch --batch --forward --dry-run -Np1 -i "$patch_file" >/dev/null 2>&1; then
-      patch --batch --forward -Np1 -i "$patch_file"
-    elif security_patch_present "$commit"; then
-      printf 'Security patch %s is already present upstream\n' "$commit"
-    else
-      printf 'Security patch %s no longer applies and is not present upstream\n' "$commit" >&2
-      return 1
-    fi
-  done
-}
 
 build() {
   cd "$pkgname-$pkgver"
@@ -150,6 +101,12 @@ package() {
   cd "$pkgname-$pkgver"
 
   install -Dm755 target/release/flea "$pkgdir/usr/bin/flea"
+  install -Dm755 tools/flea-gio-auth "$pkgdir/usr/lib/flea/flea-gio-auth"
+  install -Dm755 tools/flea-portal "$pkgdir/usr/lib/flea/flea-portal"
+  install -Dm644 packaging/flea.portal \
+    "$pkgdir/usr/share/xdg-desktop-portal/portals/flea.portal"
+  install -Dm644 packaging/org.freedesktop.impl.portal.desktop.flea.service \
+    "$pkgdir/usr/share/dbus-1/services/org.freedesktop.impl.portal.desktop.flea.service"
   install -Dm644 packaging/com.thisisgm.flea.desktop \
     "$pkgdir/usr/share/applications/com.thisisgm.flea.desktop"
   install -Dm644 packaging/com.thisisgm.flea.svg \


### PR DESCRIPTION
## Summary

- update Flea from 0.1.3 to 0.1.4 and refresh the release checksum
- sync the supported architectures, runtime dependencies, and portal files added by the release
- remove the four security backports now contained in the tagged source

## Why

Flea 0.1.3 can leave invisible `qs` and backend processes on hardware where Vulkan cannot initialize. Flea 0.1.4 fixes thisisgm/flea#14 by probing Vulkan before starting Quickshell and selecting OpenGL when the loader cannot provide a usable device.

This was reproduced on a MacBook running Omarchy: 0.1.3 failed with `VK_ERROR_INCOMPATIBLE_DRIVER`, while the v0.1.4 build reported `vkEnumeratePhysicalDevices answered -3`, selected OpenGL, and opened a visible window on the active workspace.

## Validation

- release archive checksum passed
- package built and packaged successfully with `makepkg -f --nodeps`; only the local preflight dependency check was bypassed because `expect` and `gvfs-dnssd` are not installed on the test machine
- 424 Rust tests passed
- 1,742 QML checks passed
- keymap validation passed
- package payload includes the new portal backend, D-Bus activation file, and GIO authorization helper
- all four removed security patch commits are ancestors of v0.1.4
