### PR TITLE
Package Muse Code for OPR

### DIFF
--- a/pkgbuilds/muse-code/.omarchy/package.json
+++ b/pkgbuilds/muse-code/.omarchy/package.json
@@ -1,0 +1,4 @@
+{
+  "source": "local",
+  "release_ring": "fast"
+}

--- a/pkgbuilds/muse-code/PKGBUILD
+++ b/pkgbuilds/muse-code/PKGBUILD
@@ -1,0 +1,27 @@
+# Maintainer: David Heinemeier Hansson <david@hey.com>
+
+pkgname=muse-code
+pkgver=1.0.3.r2198.1
+pkgrel=1
+pkgdesc="Meta's terminal coding agent"
+arch=('x86_64' 'aarch64')
+url="https://dev.meta.ai"
+license=('LicenseRef-Meta-Model-API')
+depends=('ca-certificates')
+optdepends=('git: workspace worktrees and version control')
+# Arch's unrelated MusE sequencer also owns /usr/bin/muse.
+conflicts=('muse' 'muse-code-bin' 'muse-bin' 'musecode-bin' 'musecode')
+options=('!debug' '!strip')
+
+# Meta publishes standalone, statically linked binaries. Keep the build number
+# in pkgver so releases with the same marketing version still upgrade.
+_upstream_ver="${pkgver/.r/-R}"
+_download="https://lookaside.facebook.com/lookaside/muse/download/"
+source_x86_64=("${pkgname}-${pkgver}-x86_64::${_download}?channel=muse&version=${_upstream_ver}&file=muse-x86-linux")
+source_aarch64=("${pkgname}-${pkgver}-aarch64::${_download}?channel=muse&version=${_upstream_ver}&file=muse-aarch64-linux")
+sha256sums_x86_64=('75a68f98c437dfd17d264730c5bc72d57e5f1e18d10472a9f53261ffcc091352')
+sha256sums_aarch64=('4ffcf55f5eb0668643f30c5febd90d188b9a2da65858918444d31f6046940120')
+
+package() {
+  install -Dm755 "${srcdir}/${pkgname}-${pkgver}-${CARCH}" "${pkgdir}/usr/bin/muse"
+}


### PR DESCRIPTION
Add `muse-code` 1.0.3.r2198.1 to OPR so Omarchy can offer Meta's coding agent without an AUR installation. The package downloads Meta's versioned, statically linked x86_64 and ARM64 binaries, verifies pinned SHA-256 checksums, and installs the native command at `/usr/bin/muse`.

Uses local-source metadata on the fast release ring. Declares conflicts with the AUR variants and Arch's unrelated MusE sequencer, which also owns `/usr/bin/muse`. Ships the upstream binary directly, without the AUR package's session/MCP wrappers. Updates are manually pinned; there is no AUR sync dependency.

Companion integration: https://github.com/omacom/omarchy/pull/9915. That PR will install `muse-code` through `omarchy-pkg-add` once this package is published.

Validation:
- Built both architecture packages locally with makepkg and verified their contents and package metadata. The ARM64 build repackages the vendor binary; it was not executed on ARM hardware.
- Both vendor downloads match the pinned checksums.
- Extracted x86_64 package reports `Muse Code 1.0.3 (1.0.3-R2198.1)`.
- OPR metadata discovery lists it as a local fast-ring package; Bash syntax and diff checks pass.

No package has been signed or published by this PR.
