### PR TITLE
Package the locate service defaults

### DIFF
--- a/pkgbuilds/omarchy-settings-dev/PKGBUILD
+++ b/pkgbuilds/omarchy-settings-dev/PKGBUILD
@@ -202,6 +202,7 @@ package() {
     install -Dm644 default/systemd/user/app.slice.d/10-oomd.conf "$pkgdir/usr/lib/systemd/user/app.slice.d/10-oomd.conf"
     install -Dm644 default/systemd/zram-generator.conf.d/90-omarchy.conf "$pkgdir/usr/lib/systemd/zram-generator.conf.d/90-omarchy.conf"
   fi
+  install -Dm644 default/systemd/system/plocate-updatedb.service.d/10-omarchy.conf "$pkgdir/usr/lib/systemd/system/plocate-updatedb.service.d/10-omarchy.conf"
 
   # Same for applications/** — used by omarchy-refresh-applications,
   # omarchy-install-gaming-*, etc. to copy .desktop files into ~/.local/share.

--- a/pkgbuilds/omarchy-settings/PKGBUILD
+++ b/pkgbuilds/omarchy-settings/PKGBUILD
@@ -197,6 +197,10 @@ package() {
     install -Dm644 default/systemd/user/app.slice.d/10-oomd.conf "$pkgdir/usr/lib/systemd/user/app.slice.d/10-oomd.conf"
     install -Dm644 default/systemd/zram-generator.conf.d/90-omarchy.conf "$pkgdir/usr/lib/systemd/zram-generator.conf.d/90-omarchy.conf"
   fi
+  # Older release pins still configure locate through install/config/locate.sh.
+  if [[ -f default/systemd/system/plocate-updatedb.service.d/10-omarchy.conf ]]; then
+    install -Dm644 default/systemd/system/plocate-updatedb.service.d/10-omarchy.conf "$pkgdir/usr/lib/systemd/system/plocate-updatedb.service.d/10-omarchy.conf"
+  fi
 
   # Same for applications/** — used by omarchy-refresh-applications,
   # omarchy-install-gaming-*, etc. to copy .desktop files into ~/.local/share.


### PR DESCRIPTION
Companion to https://github.com/omacom/omarchy/pull/10579, which supersedes omacom/omarchy#10202 by removing the locate configuration script and its migration.

Install `default/systemd/system/plocate-updatedb.service.d/10-omarchy.conf` at `/usr/lib/systemd/system/plocate-updatedb.service.d/10-omarchy.conf` in both settings packages, on x86_64 and aarch64. The existing service then runs updatedb with Omarchy's fixed Btrfs options. Arch's systemd package hook picks up this vendor path and reloads the unit configuration; `/etc/updatedb.conf` needs no rewrite.

Merge after the source PR lands, and ship the updated runtime and settings packages together. The dev package requires the new file. Stable's current 4.0.2 source pin predates it, so the stable PKGBUILD installs it when present. The release pins remain unchanged; stable users receive the fix when the runtime/settings pair advances to source containing the change.

Validation:

- Ran both final PKGBUILDs' `package()` functions against the replacement source with `CARCH=x86_64` and `CARCH=aarch64`. All four staged the exact drop-in with mode 0644, retained the AC-power override, and left `/etc/updatedb.conf` unowned.
- Confirmed the existing stable pin contains the old helper and lacks the new drop-in, and exercised the stable compatibility block without the new file. Bash syntax and diff checks passed.
- Built and installed the earlier local dev packages carrying the same drop-in. The live service completed in 78 seconds, indexed a new file on `/home`, excluded snapshot contents, and preserved updatedb.conf and service restrictions. The final rebased PKGBUILDs were validated by staging as described above.
