### PR TITLE
Restore Hermes in-app setup in package release 2

### DIFF
--- a/pkgbuilds/hermes-desktop/PKGBUILD
+++ b/pkgbuilds/hermes-desktop/PKGBUILD
@@ -2,14 +2,14 @@
 
 pkgname=hermes-desktop
 pkgver=2026.8.31
-pkgrel=1
-pkgdesc='Installer and launcher for the self-updating Hermes desktop'
+pkgrel=2
+pkgdesc='Native desktop shell for the self-updating Hermes Agent'
 arch=('x86_64')
 url='https://github.com/NousResearch/hermes-agent'
 license=('MIT')
 
-# Hermes builds its desktop under the user's runtime so both the app and CLI
-# can update it. The compiler and Electron libraries must survive installation.
+# The package ships the first desktop; native updates rebuild it alongside the
+# user's runtime, so the compiler and Electron libraries remain dependencies.
 depends=(
   'alsa-lib'
   'at-spi2-core'
@@ -54,25 +54,70 @@ depends=(
 
 makedepends=('imagemagick')
 
-# Snapshot the bootstrap installer, including upstream's Linux sandbox fixes.
-# Only installation uses it; updates belong to the native runtime on main.
+# Electron bundles prebuilt binaries that stripping corrupts.
+options=('!strip' '!debug')
+
+# Build the first desktop from a fixed upstream commit. A complete Git seed
+# lets the app bootstrap and update its writable copy using upstream code.
 _commit=245e48008fa814b3251f50755eb656bd9fb86cb1
-source=("install-${_commit}.sh::https://raw.githubusercontent.com/NousResearch/hermes-agent/${_commit}/scripts/install.sh"
-        "LICENSE-${_commit}::https://raw.githubusercontent.com/NousResearch/hermes-agent/${_commit}/LICENSE"
+source=("hermes-agent::git+${url}.git#commit=${_commit}"
+        'graphical-bootstrap.patch'
         'hermes-desktop.sh'
         'hermes-desktop.desktop'
         'hermes-desktop.png')
-sha256sums=('5854b15670b51a8daae8f59ddfa917062de9f74be261eb73b4b8d719710f8968'
-            '821556e6336796450ab852d375117b48a4887e71d255794fd6318d99982a5ab6'
-            '27040084e691421dc1748e7646ae7ee79d5777e8ee1e1ec7581a68432d4a29c4'
+sha256sums=('SKIP'
+            'd373d018aa64a892b653c9bfebb59f2dac85cd36de1d77632460bc27e6da20c5'
+            '7e29b00193d267067d6c0c0f8046728ee8407a3befea428d088d90d75a5b0988'
             'c37d4cfa4801eccbd769fddaebb2115d54faa49a5b7bc0f305f563e3cefd9bd8'
             'd60d164e24fdcf6532133b8ea43c77a201e4b9e9dbc396187b58d51d8590ef52')
 
+prepare() {
+  # Keep first-run installation in the app: resume interrupted bootstraps,
+  # retain the matching source seed, and pause backend deadlines during setup.
+  patch -d "${srcdir}/hermes-agent" -p1 <"${srcdir}/graphical-bootstrap.patch"
+}
+
+build() {
+  cd "${srcdir}/hermes-agent"
+  export GITHUB_SHA="${_commit}"
+  export GITHUB_REF_NAME=main
+  npm ci
+  cd apps/desktop
+  npm run pack
+}
+
+check() {
+  cd "${srcdir}/hermes-agent/apps/desktop"
+  npx vitest run electron/bootstrap-request.test.ts electron/bootstrap-runner.test.ts \
+    src/lib/backend-boot-timeout.test.ts src/lib/with-timeout.test.ts \
+    src/app/gateway/hooks/use-gateway-boot.test.tsx src/store/connections.test.ts
+}
+
 package() {
-  install -Dm644 "${srcdir}/install-${_commit}.sh" \
+  local seed="${pkgdir}/usr/share/${pkgname}/seed"
+
+  # A fresh shallow clone includes every tracked file and its real Git objects,
+  # with no build paths, alternates or npm output. GUI bootstrap advances main.
+  git clone --no-local --depth 1 "${srcdir}/hermes-agent" "$seed"
+  git -C "$seed" branch -M main
+  git -C "$seed" remote remove origin
+  git -C "$seed" remote add origin "${url}.git"
+  git -C "$seed" update-ref refs/remotes/origin/main HEAD
+  git -C "$seed" branch --set-upstream-to=origin/main main
+  # Reflogs describe the build checkout and have no meaning on the user machine.
+  rm -rf "$seed/.git/logs"
+  printf '%s\n' "${_commit}" >"$seed/.git/omarchy-desktop-seed"
+  install -dm755 "$seed/apps/desktop/release"
+  cp -a "${srcdir}/hermes-agent/apps/desktop/release/linux-unpacked" \
+    "$seed/apps/desktop/release/"
+  chmod 0755 "$seed/apps/desktop/release/linux-unpacked/chrome-sandbox"
+
+  install -Dm644 "${srcdir}/hermes-agent/scripts/install.sh" \
     "${pkgdir}/usr/share/${pkgname}/install.sh"
-  install -Dm644 "${srcdir}/LICENSE-${_commit}" \
+  install -Dm644 "${srcdir}/hermes-agent/LICENSE" \
     "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"
+  install -Dm644 "$seed/apps/desktop/release/linux-unpacked/LICENSE.electron.txt" \
+    "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE.electron.txt"
   install -Dm755 "${srcdir}/hermes-desktop.sh" "${pkgdir}/usr/bin/${pkgname}"
 
   # Native registration uses hermes.desktop but omits URI handling. Keep the

--- a/pkgbuilds/hermes-desktop/PKGBUILD
+++ b/pkgbuilds/hermes-desktop/PKGBUILD
@@ -66,7 +66,7 @@ source=("hermes-agent::git+${url}.git#commit=${_commit}"
         'hermes-desktop.desktop'
         'hermes-desktop.png')
 sha256sums=('SKIP'
-            'd373d018aa64a892b653c9bfebb59f2dac85cd36de1d77632460bc27e6da20c5'
+            '242b0f19405c2b49fcc6b454e96c80c3ffb2e390fec58cfd72033efa8e24dcf1'
             '7e29b00193d267067d6c0c0f8046728ee8407a3befea428d088d90d75a5b0988'
             'c37d4cfa4801eccbd769fddaebb2115d54faa49a5b7bc0f305f563e3cefd9bd8'
             'd60d164e24fdcf6532133b8ea43c77a201e4b9e9dbc396187b58d51d8590ef52')
@@ -89,6 +89,7 @@ build() {
 check() {
   cd "${srcdir}/hermes-agent/apps/desktop"
   npx vitest run electron/bootstrap-request.test.ts electron/bootstrap-runner.test.ts \
+    electron/bootstrap-retry-main-process.test.ts \
     src/lib/backend-boot-timeout.test.ts src/lib/with-timeout.test.ts \
     src/app/gateway/hooks/use-gateway-boot.test.tsx src/store/connections.test.ts
 }
@@ -97,12 +98,13 @@ package() {
   local seed="${pkgdir}/usr/share/${pkgname}/seed"
 
   # A fresh shallow clone includes every tracked file and its real Git objects,
-  # with no build paths, alternates or npm output. GUI bootstrap advances main.
+  # with no build paths, alternates or npm output. Native updates advance main.
   git clone --no-local --depth 1 "${srcdir}/hermes-agent" "$seed"
   git -C "$seed" branch -M main
   git -C "$seed" remote remove origin
   git -C "$seed" remote add origin "${url}.git"
   git -C "$seed" update-ref refs/remotes/origin/main HEAD
+  git -C "$seed" remote set-head origin main
   git -C "$seed" branch --set-upstream-to=origin/main main
   # Reflogs describe the build checkout and have no meaning on the user machine.
   rm -rf "$seed/.git/logs"
@@ -111,6 +113,8 @@ package() {
   cp -a "${srcdir}/hermes-agent/apps/desktop/release/linux-unpacked" \
     "$seed/apps/desktop/release/"
   chmod 0755 "$seed/apps/desktop/release/linux-unpacked/chrome-sandbox"
+  git -C "$seed" fsck --full
+  [[ -z $(git -C "$seed" status --porcelain) ]]
 
   install -Dm644 "${srcdir}/hermes-agent/scripts/install.sh" \
     "${pkgdir}/usr/share/${pkgname}/install.sh"

--- a/pkgbuilds/hermes-desktop/graphical-bootstrap.patch
+++ b/pkgbuilds/hermes-desktop/graphical-bootstrap.patch
@@ -1,0 +1,800 @@
+diff --git a/apps/desktop/electron/bootstrap-runner.test.ts b/apps/desktop/electron/bootstrap-runner.test.ts
+index e94dcf3456..0bc83f4d8b 100644
+--- a/apps/desktop/electron/bootstrap-runner.test.ts
++++ b/apps/desktop/electron/bootstrap-runner.test.ts
+@@ -1,4 +1,5 @@
+ import assert from 'node:assert/strict'
++import { execFileSync } from 'node:child_process'
+ import fs from 'node:fs'
+ import os from 'node:os'
+ import path from 'node:path'
+@@ -81,6 +82,107 @@ test('existing checkout detection requires git metadata', () => {
+   }
+ })
+ 
++test
++  .skipIf(process.platform === 'win32')
++  .each([
++    'matching seed',
++    'missing seed',
++    'short seed',
++    'zero seed',
++    'different stamp',
++    'missing stamp',
++    'different HEAD'
++  ])('bootstrap skips only an already supplied matching repository: %s', async scenario => {
++  const home = mkTmpHome()
++  const root = path.join(home, 'hermes-agent')
++  const stages = ['prerequisites', 'repository', 'venv', 'path', 'complete']
++  fs.mkdirSync(path.join(root, 'scripts'), { recursive: true })
++
++  // Exercise the real runner and subprocess protocol without downloading or
++  // installing anything. Each fixture stage records whether it actually ran.
++  fs.writeFileSync(
++    path.join(root, 'scripts', 'install.sh'),
++    `#!/bin/bash
++if [[ $1 == --manifest ]]; then
++  printf '%s\\n' '${JSON.stringify({ protocol_version: 1, stages: stages.map(name => ({ name })) })}'
++else
++  printf '%s\\n' "$2" >> "$HERMES_HOME/stages.log"
++  printf '{"ok":true,"stage":"%s"}\\n' "$2"
++fi
++`
++  )
++
++  const git = (...args: string[]) =>
++    execFileSync('git', args, { cwd: root, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] }).trim()
++
++  try {
++    git('init', '--quiet')
++    git('add', 'scripts/install.sh')
++    git(
++      '-c',
++      'user.name=Bootstrap Test',
++      '-c',
++      'user.email=bootstrap@example.invalid',
++      '-c',
++      'commit.gpgsign=false',
++      'commit',
++      '--quiet',
++      '-m',
++      'fixture'
++    )
++    const head = git('rev-parse', 'HEAD')
++    const other = head === 'a'.repeat(40) ? 'b'.repeat(40) : 'a'.repeat(40)
++
++    const seedCommit =
++      scenario === 'missing seed'
++        ? undefined
++        : scenario === 'short seed'
++          ? head.slice(0, 7)
++          : scenario === 'zero seed'
++            ? ZERO_COMMIT
++            : scenario === 'different HEAD'
++              ? other
++              : head
++
++    const installStamp =
++      scenario === 'missing stamp'
++        ? null
++        : {
++            commit: scenario === 'different stamp' || scenario === 'different HEAD' ? other : head,
++            branch: 'main'
++          }
++
++    const events = []
++
++    const result = await runBootstrap({
++      installStamp,
++      seedCommit,
++      activeRoot: root,
++      sourceRepoRoot: root,
++      hermesHome: home,
++      onEvent: event => events.push(event)
++    })
++
++    assert.equal(result.ok, true)
++    const skipped = scenario === 'matching seed'
++    assert.deepEqual(
++      fs.readFileSync(path.join(home, 'stages.log'), 'utf8').trim().split('\n'),
++      skipped ? stages.filter(stage => stage !== 'repository') : stages
++    )
++    assert.equal(
++      events.some(event => event.type === 'stage' && event.name === 'repository' && event.state === 'skipped'),
++      skipped
++    )
++    assert.equal(git('rev-parse', 'HEAD'), head, 'the hint never rewrites the repository')
++
++    if (skipped) {
++      assert.equal(result.marker.pinnedCommit, head)
++    }
++  } finally {
++    fs.rmSync(home, { recursive: true, force: true })
++  }
++})
++
+ test('fresh bootstrap args include the packaged commit pin', () => {
+   const installStamp = { commit: 'a'.repeat(40), branch: 'main' }
+ 
+diff --git a/apps/desktop/electron/bootstrap-runner.ts b/apps/desktop/electron/bootstrap-runner.ts
+index dee008ff5d..0633a28b1b 100644
+--- a/apps/desktop/electron/bootstrap-runner.ts
++++ b/apps/desktop/electron/bootstrap-runner.ts
+@@ -859,6 +859,7 @@ function openRunLog(logRoot) {
+ async function runBootstrap(opts) {
+   const {
+     installStamp,
++    seedCommit,
+     activeRoot,
+     sourceRepoRoot,
+     hermesHome,
+@@ -958,6 +959,29 @@ async function runBootstrap(opts) {
+         return { ok: false, cancelled: true }
+       }
+ 
++      // A package can supply the matching source alongside its desktop build.
++      // Pulling this pristine seed to main would leave the source newer than the
++      // running desktop and make the updater incorrectly report "up to date".
++      // Recheck HEAD here; this hint never resets or replaces an existing repo.
++      if (
++        stage.name === 'repository' &&
++        typeof seedCommit === 'string' &&
++        /^[0-9a-f]{40}$/.test(seedCommit) &&
++        isPinnedCommit(seedCommit) &&
++        seedCommit === installStamp?.commit &&
++        seedCommit === resolveCheckoutHead(activeRoot)
++      ) {
++        emit({
++          type: 'stage',
++          name: stage.name,
++          state: 'skipped',
++          durationMs: 0,
++          json: { ok: true, stage: stage.name, skipped: true, reason: 'Source already matches the packaged desktop' }
++        })
++
++        continue
++      }
++
+       const ev = await runStage({
+         scriptPath: scriptInfo.path,
+         installerKind,
+diff --git a/apps/desktop/electron/main.ts b/apps/desktop/electron/main.ts
+index 5116cdb7bc..21f76b84bf 100644
+--- a/apps/desktop/electron/main.ts
++++ b/apps/desktop/electron/main.ts
+@@ -80,6 +80,7 @@ import {
+   resolveLinuxPasswordStore
+ } from './bootstrap-platform'
+ import { decideBootstrapRepair } from './bootstrap-repair-guard'
++import { consumeBootstrapRequest, consumeBootstrapSeed } from './bootstrap-request'
+ import { runBootstrap } from './bootstrap-runner'
+ import {
+   BROWSER_WINDOW_HEIGHT,
+@@ -1577,7 +1578,8 @@ let bootstrapAbortController = null
+ // problem was a transient backend error (#72166). Intent now lives here, so
+ // repair can force the installer without destroying provenance about how the
+ // install was created. Cleared once the reinstall is under way.
+-let bootstrapRepairRequested = false
++let bootstrapRepairRequested = consumeBootstrapRequest(process.env)
++const bootstrapSeedCommit = consumeBootstrapSeed(process.env)
+ // Counter for in-flight repair attempts. Reset on a clean boot completion
+ // (see runBootstrap -> ensureRuntime resolve path). Each successive repair
+ // in the same failure episode increments this; once it crosses
+@@ -5128,6 +5130,7 @@ async function ensureRuntime(backend) {
+ 
+     const bootstrapResult = await runBootstrap({
+       installStamp: backend.installStamp,
++      seedCommit: bootstrapSeedCommit,
+       activeRoot: backend.activeRoot,
+       sourceRepoRoot: SOURCE_REPO_ROOT,
+       hermesHome: HERMES_HOME,
+diff --git a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx
+index 58a4389fb8..6b2c20725f 100644
+--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx
++++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx
+@@ -1,7 +1,7 @@
+ import { act, cleanup, render } from '@testing-library/react'
+ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+ 
+-import type { DesktopConnectionsRegistry } from '@/global'
++import type { DesktopBootstrapEvent, DesktopConnectionsRegistry } from '@/global'
+ import { createClientSessionState } from '@/lib/chat-runtime'
+ import { $desktopBoot } from '@/store/boot'
+ import {
+@@ -1230,6 +1230,44 @@ describe('useGatewayBoot remote reconnect loop (real hook, fake socket)', () =>
+     expect($desktopBoot.get().error).toBeTruthy()
+   })
+ 
++  it('initial installation can outlive the backend deadline without poisoning boot', async () => {
++    let installing = true
++    const listeners = new Set<(event: DesktopBootstrapEvent) => void>()
++    const connection = deferred<typeof primaryConn>()
++
++    const desktop = {
++      ...fakeDesktop(),
++      getBootstrapState: vi.fn(async () => ({ active: installing, setupChoice: null })),
++      onBootstrapEvent: (listener: (event: DesktopBootstrapEvent) => void) => {
++        listeners.add(listener)
++
++        return () => void listeners.delete(listener)
++      }
++    }
++
++    desktop.getConnection.mockImplementation(() => connection.promise)
++    ;(window as { hermesDesktop?: unknown }).hermesDesktop = desktop
++
++    render(<Harness />)
++    await act(async () => {
++      await vi.advanceTimersByTimeAsync(120_000)
++    })
++    expect($desktopBoot.get().error).toBeNull()
++    expect(desktop.getConnection).toHaveBeenCalledTimes(1)
++
++    installing = false
++
++    for (const listener of listeners) {
++      listener({ type: 'complete', marker: {} })
++    }
++
++    connection.resolve(primaryConn)
++    await flushAsync()
++    expect($connection.get()).toMatchObject(primaryConn)
++    expect($desktopBoot.get().error).toBeNull()
++    expect(listeners.size).toBe(0)
++  })
++
+   it('softSwitch(): a getConnection() that hangs on a connection-apply switch does not latch $gatewaySwitching forever (#93454)', async () => {
+     // Repro: main applies a new connection (onConnectionApplied), softSwitch()
+     // re-dials via getConnection(), and the IPC round-trip wedges. Without an
+diff --git a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
+index f5ee2ca66c..510ce99af9 100644
+--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
++++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
+@@ -5,10 +5,11 @@ import { shouldApplyPostBootProgressError } from '@/components/boot-failure-reau
+ import type { HermesConnection } from '@/global'
+ import { HermesGateway } from '@/hermes'
+ import { translateNow } from '@/i18n'
++import { withBackendBootTimeout } from '@/lib/backend-boot-timeout'
+ import { desktopDefaultCwd } from '@/lib/desktop-fs'
+ import { decideLivenessForceClose, LIVENESS_REPROBE_DELAY_MS } from '@/lib/gateway-liveness-policy'
+ import { reconnectBackoffDelayMs } from '@/lib/reconnect-backoff'
+-import { BACKEND_BOOT_WAIT_TIMEOUT_MS, RECONNECT_ATTEMPT_TIMEOUT_MS, withTimeout } from '@/lib/with-timeout'
++import { RECONNECT_ATTEMPT_TIMEOUT_MS, withTimeout } from '@/lib/with-timeout'
+ import {
+   $desktopBoot,
+   applyDesktopBootProgress,
+@@ -199,6 +200,8 @@ export function useGatewayBoot({
+       return () => void (cancelled = true)
+     }
+ 
++    const bootWaitAbort = new AbortController()
++
+     // Store-driven switches (Sessions switcher → selectConnection) commit
+     // through beginGatewaySwitch(), which runs this window's machine-context
+     // reset — the same one a Settings apply (softSwitch below) runs. One owner,
+@@ -606,10 +609,11 @@ export function useGatewayBoot({
+         // the `finally` below only runs once this promise settles. Uses the
+         // shared backend-boot budget rather than the reconnect budget because
+         // ensureBackend may cold-spawn a pooled helper backend here.
+-        const conn = await withTimeout(
++        const conn = await withBackendBootTimeout(
+           desktop.getConnection(windowProfileOverride() ?? undefined),
+-          BACKEND_BOOT_WAIT_TIMEOUT_MS,
+-          'Timed out reconnecting to Hermes backend'
++          desktop,
++          'Timed out reconnecting to Hermes backend',
++          bootWaitAbort.signal
+         )
+ 
+         if (!ownsSwitch()) {
+@@ -988,10 +992,11 @@ export function useGatewayBoot({
+         // round-trip must not hang "Starting Hermes…" forever. Initial boot
+         // rides out a full backend cold spawn, so it gets the shared 45s
+         // backend-boot budget, not the 20s reconnect budget.
+-        const conn = await withTimeout(
++        const conn = await withBackendBootTimeout(
+           desktop.getConnection(windowProfileOverride() ?? undefined),
+-          BACKEND_BOOT_WAIT_TIMEOUT_MS,
+-          'Timed out connecting to Hermes backend'
++          desktop,
++          'Timed out connecting to Hermes backend',
++          bootWaitAbort.signal
+         )
+ 
+         if (cancelled) {
+@@ -1147,6 +1152,7 @@ export function useGatewayBoot({
+ 
+     return () => {
+       cancelled = true
++      bootWaitAbort.abort()
+       offSwitchLifecycle()
+       endGatewaySwitch()
+       clearReconnectTimer()
+diff --git a/apps/desktop/src/store/connections.test.ts b/apps/desktop/src/store/connections.test.ts
+index edd9764dd8..273bec98ac 100644
+--- a/apps/desktop/src/store/connections.test.ts
++++ b/apps/desktop/src/store/connections.test.ts
+@@ -779,6 +779,28 @@ describe('selectConnection', () => {
+     expect($showAllProfiles.get()).toBe(true)
+   })
+ 
++  it('bootstrap does not expire descriptor restoration and start a duplicate connection', async () => {
++    vi.useFakeTimers()
++
++    try {
++      Object.assign(window.hermesDesktop!, {
++        getBootstrapState: vi.fn(async () => ({ active: true, setupChoice: null }))
++      })
++      list.mockResolvedValueOnce({ ...registry, lastUsed: 'homelab', launchMode: 'last-used' })
++      const restoring = initializeConnectionsRegistry()
++
++      await vi.advanceTimersByTimeAsync(120_000)
++      expect(ensureGatewayAgent).not.toHaveBeenCalled()
++
++      $connection.set({ connectionId: 'homelab', mode: 'remote' })
++      await restoring
++      expect(ensureGatewayAgent).not.toHaveBeenCalled()
++      expect(setLastUsed).toHaveBeenCalledWith('homelab')
++    } finally {
++      vi.useRealTimers()
++    }
++  })
++
+   it('boot restore proceeds after the descriptor wait deadline (bounded wait)', async () => {
+     // A primary that never publishes (spawn failure, dead SSH target) must
+     // not strand the registry restore forever: after the deadline the restore
+diff --git a/apps/desktop/src/store/connections.ts b/apps/desktop/src/store/connections.ts
+index 7951e3bbe2..46c24ce0d3 100644
+--- a/apps/desktop/src/store/connections.ts
++++ b/apps/desktop/src/store/connections.ts
+@@ -1,8 +1,9 @@
+ import { atom, computed } from 'nanostores'
+ 
+ import type { DesktopConnectionsRegistry } from '@/global'
++import { withBackendBootTimeout } from '@/lib/backend-boot-timeout'
+ import { persistStringRecord, storedStringRecord } from '@/lib/storage'
+-import { BACKEND_BOOT_WAIT_TIMEOUT_MS, isTimeoutError, withTimeout } from '@/lib/with-timeout'
++import { isTimeoutError, withTimeout } from '@/lib/with-timeout'
+ import { $connectionsRegistry } from '@/store/connection-registry-state'
+ import {
+   beginGatewaySwitch,
+@@ -32,11 +33,6 @@ const LAST_PROFILE_STORAGE_KEY = 'hermes.desktop.lastProfileByConnection'
+ const SWITCH_DIAL_TIMEOUT_MS = 20_000
+ const SWITCH_COMMIT_TIMEOUT_MS = 20_000
+ const SWITCH_REMEMBER_TIMEOUT_MS = 5_000
+-// Matches the primary spawn budget: a healthy cold boot publishes well within
+-// this; anything longer means the primary is not coming and the registry
+-// restore should stop waiting for it. Shared constant so the boot-class
+-// budgets can't drift apart (see with-timeout.ts).
+-const BOOT_DESCRIPTOR_WAIT_TIMEOUT_MS = BACKEND_BOOT_WAIT_TIMEOUT_MS
+ 
+ export { $connectionsRegistry } from '@/store/connection-registry-state'
+ 
+@@ -170,9 +166,9 @@ function waitForInitialConnection(): Promise<void> {
+     })
+   })
+ 
+-  return withTimeout(
++  return withBackendBootTimeout(
+     published,
+-    BOOT_DESCRIPTOR_WAIT_TIMEOUT_MS,
++    window.hermesDesktop,
+     'Timed out waiting for the primary connection descriptor'
+   ).catch(error => {
+     unlisten?.()
+diff --git a/apps/desktop/electron/bootstrap-request.test.ts b/apps/desktop/electron/bootstrap-request.test.ts
+new file mode 100644
+index 0000000000..29d5acd26d
+--- /dev/null
++++ b/apps/desktop/electron/bootstrap-request.test.ts
+@@ -0,0 +1,37 @@
++import { expect, test } from 'vitest'
++
++import { consumeBootstrapRequest, consumeBootstrapSeed } from './bootstrap-request'
++
++test('the launcher request is consumed before an updater can inherit it', () => {
++  const env = { HERMES_DESKTOP_BOOTSTRAP: '1', HERMES_HOME: '/tmp/hermes' }
++
++  expect(consumeBootstrapRequest(env)).toBe(true)
++  expect(consumeBootstrapRequest({ ...env })).toBe(false)
++  expect(env).toEqual({ HERMES_HOME: '/tmp/hermes' })
++})
++
++test.each([undefined, '', '0', 'true'])('only the explicit launcher opt-in forces bootstrap (%s)', value => {
++  const env = { HERMES_DESKTOP_BOOTSTRAP: value }
++
++  expect(consumeBootstrapRequest(env)).toBe(false)
++  expect(env).toEqual({})
++})
++
++test('the seed hint is consumed before an updater can inherit it', () => {
++  const commit = 'a'.repeat(40)
++  const env = { HERMES_DESKTOP_BOOTSTRAP_SEED: commit, HERMES_HOME: '/tmp/hermes' }
++
++  expect(consumeBootstrapSeed(env)).toBe(commit)
++  expect(consumeBootstrapSeed({ ...env })).toBeNull()
++  expect(env).toEqual({ HERMES_HOME: '/tmp/hermes' })
++})
++
++test.each([undefined, '', 'main', 'a'.repeat(7), 'a'.repeat(41), '0'.repeat(40), 'g'.repeat(40)])(
++  'invalid seed hints are consumed without enabling the shortcut (%s)',
++  value => {
++    const env = { HERMES_DESKTOP_BOOTSTRAP_SEED: value }
++
++    expect(consumeBootstrapSeed(env)).toBeNull()
++    expect(env).toEqual({})
++  }
++)
+diff --git a/apps/desktop/electron/bootstrap-request.ts b/apps/desktop/electron/bootstrap-request.ts
+new file mode 100644
+index 0000000000..04d510594b
+--- /dev/null
++++ b/apps/desktop/electron/bootstrap-request.ts
+@@ -0,0 +1,18 @@
++/** A package launcher can resume an interrupted first install through the GUI.
++ * Consume the request before spawning children so an updater/relaunch cannot
++ * inherit it and reinstall an otherwise healthy runtime. */
++export function consumeBootstrapRequest(env: Record<string, string | undefined>): boolean {
++  const requested = env.HERMES_DESKTOP_BOOTSTRAP === '1'
++  delete env.HERMES_DESKTOP_BOOTSTRAP
++
++  return requested
++}
++
++/** The bundled checkout is usable only when the runner also verifies its HEAD
++ * against the desktop's install stamp. Never forward this hint to updates. */
++export function consumeBootstrapSeed(env: Record<string, string | undefined>): string | null {
++  const commit = env.HERMES_DESKTOP_BOOTSTRAP_SEED
++  delete env.HERMES_DESKTOP_BOOTSTRAP_SEED
++
++  return typeof commit === 'string' && /^[0-9a-f]{40}$/.test(commit) && !/^0{40}$/.test(commit) ? commit : null
++}
+diff --git a/apps/desktop/src/lib/backend-boot-timeout.test.ts b/apps/desktop/src/lib/backend-boot-timeout.test.ts
+new file mode 100644
+index 0000000000..bc483ba513
+--- /dev/null
++++ b/apps/desktop/src/lib/backend-boot-timeout.test.ts
+@@ -0,0 +1,168 @@
++import { afterEach, beforeEach, expect, test, vi } from 'vitest'
++
++import type { DesktopBootstrapEvent, DesktopBootstrapState } from '@/global'
++
++import { deferred } from '../test/deferred'
++
++import { withBackendBootTimeout } from './backend-boot-timeout'
++import { BACKEND_BOOT_WAIT_TIMEOUT_MS, RECONNECT_ATTEMPT_TIMEOUT_MS, TimeoutError } from './with-timeout'
++
++function bridge(initial: Partial<DesktopBootstrapState> = {}) {
++  const state: DesktopBootstrapState = {
++    active: false,
++    manifest: null,
++    stages: {},
++    error: null,
++    log: [],
++    startedAt: null,
++    completedAt: null,
++    setupChoice: null,
++    unsupportedPlatform: null,
++    ...initial
++  }
++
++  const listeners = new Set<(event: DesktopBootstrapEvent) => void>()
++
++  const desktop = {
++    getBootstrapState: vi.fn(async () => ({ ...state })),
++    onBootstrapEvent: vi.fn((listener: (event: DesktopBootstrapEvent) => void) => {
++      listeners.add(listener)
++
++      return () => void listeners.delete(listener)
++    })
++  }
++
++  return {
++    desktop,
++    state,
++    listeners,
++    emit: (event: DesktopBootstrapEvent) => {
++      state.active = event.type === 'manifest'
++      state.setupChoice =
++        event.type === 'setup-choice' && event.active ? { platform: 'linux', activeRoot: '/tmp/hermes' } : null
++
++      for (const listener of listeners) {
++        listener(event)
++      }
++    }
++  }
++}
++
++beforeEach(() => vi.useFakeTimers())
++afterEach(() => vi.useRealTimers())
++
++test.each<DesktopBootstrapEvent>([
++  { type: 'complete', marker: {} },
++  { type: 'failed', error: 'cancelled by user' },
++  { type: 'failed', error: 'dependency installation failed' },
++  { type: 'dismissed' },
++  { type: 'setup-choice', active: false }
++])('preserves the remaining backend budget across setup and resumes on $type', async event => {
++  const h = bridge()
++  const work = deferred<void>()
++  const settled = vi.fn()
++  const result = withBackendBootTimeout(work.promise, h.desktop, 'backend stalled').catch(settled)
++  await vi.advanceTimersByTimeAsync(10_000)
++  h.emit({ type: 'manifest', stages: [], protocolVersion: 1 })
++  await vi.advanceTimersByTimeAsync(BACKEND_BOOT_WAIT_TIMEOUT_MS * 2)
++  expect(settled).not.toHaveBeenCalled()
++  h.emit(event)
++  await vi.advanceTimersByTimeAsync(BACKEND_BOOT_WAIT_TIMEOUT_MS - 10_000 - 1)
++  expect(settled).not.toHaveBeenCalled()
++  await vi.advanceTimersByTimeAsync(1)
++  await result
++  expect(settled).toHaveBeenCalledWith(expect.any(TimeoutError))
++  expect(h.listeners.size).toBe(0)
++  expect(vi.getTimerCount()).toBe(0)
++})
++
++test('an initial install choice can remain open and resolving the backend cleans up observation', async () => {
++  const h = bridge({ setupChoice: { platform: 'linux', activeRoot: '/tmp/hermes' } })
++  const work = deferred<string>()
++  const result = withBackendBootTimeout(work.promise, h.desktop, 'backend stalled')
++  await vi.advanceTimersByTimeAsync(BACKEND_BOOT_WAIT_TIMEOUT_MS * 3)
++  work.resolve('connected')
++  await expect(result).resolves.toBe('connected')
++  expect(h.listeners.size).toBe(0)
++  expect(vi.getTimerCount()).toBe(0)
++})
++
++test.each([true, false])(
++  'a stale initial snapshot cannot replace newer live state (snapshot active=%s)',
++  async active => {
++    const h = bridge()
++    const snapshot = deferred<DesktopBootstrapState>()
++    h.desktop.getBootstrapState.mockImplementationOnce(() => snapshot.promise)
++    const work = deferred<void>()
++    const settled = vi.fn()
++    const result = withBackendBootTimeout(work.promise, h.desktop, 'backend stalled').catch(settled)
++    h.emit(active ? { type: 'complete', marker: {} } : { type: 'manifest', stages: [], protocolVersion: 1 })
++    snapshot.resolve({ ...h.state, active })
++    await vi.advanceTimersByTimeAsync(BACKEND_BOOT_WAIT_TIMEOUT_MS)
++    expect(settled).toHaveBeenCalledTimes(active ? 1 : 0)
++    work.resolve()
++    await result
++    expect(h.listeners.size).toBe(0)
++    expect(vi.getTimerCount()).toBe(0)
++  }
++)
++
++test('a main process that wedges during bootstrap loses its pause lease and still times out', async () => {
++  const h = bridge({ active: true })
++  h.desktop.getBootstrapState
++    .mockResolvedValueOnce({ ...h.state })
++    .mockImplementation(() => new Promise(() => undefined))
++  const settled = vi.fn()
++  const result = withBackendBootTimeout(new Promise(() => undefined), h.desktop, 'backend stalled').catch(settled)
++  await vi.advanceTimersByTimeAsync(RECONNECT_ATTEMPT_TIMEOUT_MS + BACKEND_BOOT_WAIT_TIMEOUT_MS - 1)
++  expect(settled).not.toHaveBeenCalled()
++  await vi.advanceTimersByTimeAsync(1)
++  await result
++  expect(settled).toHaveBeenCalledWith(expect.any(TimeoutError))
++  expect(h.listeners.size).toBe(0)
++  expect(vi.getTimerCount()).toBe(0)
++})
++
++test.each(['absent', 'rejected', 'wedged'])(
++  'unavailable bootstrap IPC retains the ordinary deadline (%s)',
++  async failure => {
++    const h = bridge()
++    h.desktop.getBootstrapState.mockImplementation(() =>
++      failure === 'rejected' ? Promise.reject(new Error('IPC unavailable')) : new Promise(() => undefined)
++    )
++
++    const result = withBackendBootTimeout(
++      new Promise(() => undefined),
++      failure === 'absent' ? undefined : h.desktop,
++      'backend stalled'
++    )
++
++    const rejection = expect(result).rejects.toBeInstanceOf(TimeoutError)
++    await vi.advanceTimersByTimeAsync(BACKEND_BOOT_WAIT_TIMEOUT_MS)
++    await rejection
++    expect(vi.getTimerCount()).toBe(0)
++  }
++)
++
++test.each(['abort', 'reject'])(
++  'a cancelled owner or failed backend releases paused observation (%s)',
++  async outcome => {
++    const h = bridge({ active: true })
++    const work = deferred<void>()
++    const owner = new AbortController()
++    const result = withBackendBootTimeout(work.promise, h.desktop, 'backend stalled', owner.signal)
++    const error = new Error(outcome)
++    const rejection = expect(result).rejects.toBe(error)
++    await vi.advanceTimersByTimeAsync(1)
++
++    if (outcome === 'abort') {
++      owner.abort(error)
++    } else {
++      work.reject(error)
++    }
++
++    await rejection
++    expect(h.listeners.size).toBe(0)
++    expect(vi.getTimerCount()).toBe(0)
++  }
++)
+diff --git a/apps/desktop/src/lib/backend-boot-timeout.ts b/apps/desktop/src/lib/backend-boot-timeout.ts
+new file mode 100644
+index 0000000000..300dca0d05
+--- /dev/null
++++ b/apps/desktop/src/lib/backend-boot-timeout.ts
+@@ -0,0 +1,169 @@
++import type { DesktopBootstrapEvent } from '@/global'
++
++import { BACKEND_BOOT_WAIT_TIMEOUT_MS, RECONNECT_ATTEMPT_TIMEOUT_MS, TimeoutError } from './with-timeout'
++
++type BootstrapBridge = Partial<Pick<NonNullable<Window['hermesDesktop']>, 'getBootstrapState' | 'onBootstrapEvent'>>
++
++/** Bootstrap and the initial install choice precede backend startup. Count
++ * only backend time against its normal deadline. A paused deadline needs
++ * fresh events or responsive state IPC; a wedged main process still times out. */
++export function withBackendBootTimeout<T>(
++  promise: Promise<T>,
++  desktop: BootstrapBridge | undefined,
++  message: string,
++  signal?: AbortSignal
++): Promise<T> {
++  return new Promise<T>((resolve, reject) => {
++    let settled = false
++    let paused = false
++    let remaining = BACKEND_BOOT_WAIT_TIMEOUT_MS
++    let resumedAt = performance.now()
++    let revision = 0
++    let reading = false
++    let budgetTimer: ReturnType<typeof setTimeout> | undefined
++    let leaseTimer: ReturnType<typeof setTimeout> | undefined
++    let pollTimer: ReturnType<typeof setInterval> | undefined
++    let unlisten: (() => void) | undefined
++
++    const cleanup = () => {
++      clearTimeout(budgetTimer)
++      clearTimeout(leaseTimer)
++      clearInterval(pollTimer)
++      unlisten?.()
++      signal?.removeEventListener('abort', abort)
++    }
++
++    const fail = (error: unknown) => {
++      if (settled) {
++        return
++      }
++
++      settled = true
++      cleanup()
++      reject(error)
++    }
++
++    const abort = () => fail(signal?.reason ?? new DOMException('Backend wait cancelled', 'AbortError'))
++
++    const armBudget = () => {
++      resumedAt = performance.now()
++      budgetTimer = setTimeout(() => fail(new TimeoutError(message)), Math.max(0, remaining))
++    }
++
++    const update = (nextPaused: boolean) => {
++      if (settled) {
++        return
++      }
++
++      clearTimeout(leaseTimer)
++
++      if (nextPaused !== paused) {
++        if (nextPaused) {
++          remaining -= performance.now() - resumedAt
++          clearTimeout(budgetTimer)
++        } else {
++          armBudget()
++        }
++
++        paused = nextPaused
++      }
++
++      if (paused) {
++        leaseTimer = setTimeout(() => {
++          revision += 1 // A late snapshot from before this wedge is stale.
++          update(false)
++        }, RECONNECT_ATTEMPT_TIMEOUT_MS)
++      }
++    }
++
++    const onEvent = (event: DesktopBootstrapEvent) => {
++      revision += 1
++
++      switch (event.type) {
++        case 'manifest':
++          update(true)
++
++          break
++
++        case 'setup-choice':
++          update(event.active)
++
++          break
++
++        case 'stage':
++          update(event.state !== 'failed')
++
++          break
++
++        case 'complete':
++
++        case 'failed':
++
++        case 'dismissed':
++
++        case 'unsupported-platform':
++          update(false)
++
++          break
++
++        case 'log':
++          update(paused)
++      }
++    }
++
++    const refresh = async () => {
++      if (settled || reading || !desktop?.getBootstrapState) {
++        return
++      }
++
++      reading = true
++      const observedRevision = revision
++
++      try {
++        const state = await desktop.getBootstrapState()
++
++        if (!settled && observedRevision === revision) {
++          update(state.active || Boolean(state.setupChoice))
++        }
++      } catch {
++        if (observedRevision === revision) {
++          update(false)
++        }
++      } finally {
++        reading = false
++      }
++    }
++
++    armBudget()
++    signal?.addEventListener('abort', abort, { once: true })
++
++    if (signal?.aborted) {
++      abort()
++    }
++
++    if (!settled) {
++      // Subscribe first: a slow initial snapshot must never overwrite a newer
++      // live completion, cancellation, or bootstrap-start event.
++      try {
++        unlisten = desktop?.onBootstrapEvent?.(onEvent)
++      } catch {
++        // Older/missing IPC keeps the ordinary bounded backend wait.
++      }
++
++      if (desktop?.getBootstrapState) {
++        pollTimer = setInterval(() => void refresh(), 5_000)
++        void refresh()
++      }
++    }
++
++    Promise.resolve(promise).then(value => {
++      if (settled) {
++        return
++      }
++
++      settled = true
++      cleanup()
++      resolve(value)
++    }, fail)
++  })
++}

--- a/pkgbuilds/hermes-desktop/graphical-bootstrap.patch
+++ b/pkgbuilds/hermes-desktop/graphical-bootstrap.patch
@@ -11,7 +11,7 @@ index e94dcf3456..0bc83f4d8b 100644
 @@ -81,6 +82,107 @@ test('existing checkout detection requires git metadata', () => {
    }
  })
- 
+
 +test
 +  .skipIf(process.platform === 'win32')
 +  .each([
@@ -115,7 +115,7 @@ index e94dcf3456..0bc83f4d8b 100644
 +
  test('fresh bootstrap args include the packaged commit pin', () => {
    const installStamp = { commit: 'a'.repeat(40), branch: 'main' }
- 
+
 diff --git a/apps/desktop/electron/bootstrap-runner.ts b/apps/desktop/electron/bootstrap-runner.ts
 index dee008ff5d..0633a28b1b 100644
 --- a/apps/desktop/electron/bootstrap-runner.ts
@@ -131,7 +131,7 @@ index dee008ff5d..0633a28b1b 100644
 @@ -958,6 +959,29 @@ async function runBootstrap(opts) {
          return { ok: false, cancelled: true }
        }
- 
+
 +      // A package can supply the matching source alongside its desktop build.
 +      // Pulling this pristine seed to main would leave the source newer than the
 +      // running desktop and make the updater incorrectly report "up to date".
@@ -159,7 +159,7 @@ index dee008ff5d..0633a28b1b 100644
          scriptPath: scriptInfo.path,
          installerKind,
 diff --git a/apps/desktop/electron/main.ts b/apps/desktop/electron/main.ts
-index 5116cdb7bc..21f76b84bf 100644
+index 5116cdb7bc..151e6f6bf4 100644
 --- a/apps/desktop/electron/main.ts
 +++ b/apps/desktop/electron/main.ts
 @@ -80,6 +80,7 @@ import {
@@ -170,24 +170,72 @@ index 5116cdb7bc..21f76b84bf 100644
  import { runBootstrap } from './bootstrap-runner'
  import {
    BROWSER_WINDOW_HEIGHT,
-@@ -1577,7 +1578,8 @@ let bootstrapAbortController = null
+@@ -1576,8 +1577,9 @@ let bootstrapAbortController = null
+ // deleting the bootstrap marker, which stranded healthy installs whose only
  // problem was a transient backend error (#72166). Intent now lives here, so
  // repair can force the installer without destroying provenance about how the
- // install was created. Cleared once the reinstall is under way.
+-// install was created. Cleared once the reinstall is under way.
 -let bootstrapRepairRequested = false
++// install was created. Cleared only after the installer completes successfully.
 +let bootstrapRepairRequested = consumeBootstrapRequest(process.env)
 +const bootstrapSeedCommit = consumeBootstrapSeed(process.env)
  // Counter for in-flight repair attempts. Reset on a clean boot completion
  // (see runBootstrap -> ensureRuntime resolve path). Each successive repair
  // in the same failure episode increments this; once it crosses
-@@ -5128,6 +5130,7 @@ async function ensureRuntime(backend) {
- 
+@@ -4950,7 +4952,7 @@ function resolveHermesBackend(backendArgs) {
+   //    do NOT write a bootstrap marker; the user did this themselves and we
+   //    don't want to take ownership of an install we didn't perform.
+   //    HERMES_DESKTOP_IGNORE_EXISTING=1 forces the bootstrap path for testing.
+-  if (process.env.HERMES_DESKTOP_IGNORE_EXISTING !== '1') {
++  if (!bootstrapRepairRequested && process.env.HERMES_DESKTOP_IGNORE_EXISTING !== '1') {
+     let hermesCommand = null
+     const hermesOverride = process.env.HERMES_DESKTOP_HERMES
+
+@@ -5021,7 +5023,7 @@ function resolveHermesBackend(backendArgs) {
+   // 5. Last-ditch: pip-installed hermes_cli module via system Python.
+   //    Same rationale as #4 -- the user installed this; we use it but don't
+   //    take ownership.
+-  const python = findSystemPython()
++  const python = bootstrapRepairRequested ? null : findSystemPython()
+
+   if (python) {
+     // Same smoke-test rationale as step 4: a system Python in the
+@@ -5121,13 +5123,14 @@ async function ensureRuntime(backend) {
+
+     bootstrapAbortController = new AbortController()
+
+-    // The repair request has been honoured by reaching the installer; clear it
+-    // so a later boot isn't forced through bootstrap again.
+-    bootstrapRepairRequested = false
++    // A late failure can leave an importable venv and CLI shim. Keep bootstrap
++    // intent through reset/reload retries until every installer stage succeeds.
++    bootstrapRepairRequested = true
+     bootstrapRepairAttempt = 0
+
      const bootstrapResult = await runBootstrap({
        installStamp: backend.installStamp,
 +      seedCommit: bootstrapSeedCommit,
        activeRoot: backend.activeRoot,
        sourceRepoRoot: SOURCE_REPO_ROOT,
        hermesHome: HERMES_HOME,
+@@ -5179,6 +5182,7 @@ async function ensureRuntime(backend) {
+       throw bootstrapError
+     }
+
++    bootstrapRepairRequested = false
+     rememberLog('[bootstrap] bootstrap complete; marker written. Re-resolving backend.')
+
+     // Re-resolve now that the install exists. The new resolution lands in
+@@ -15099,7 +15103,8 @@ ipcMain.handle('hermes:bootstrap:repair', async () => {
+   // to the normal restart branch, which just kills the current child
+   // and respawns it against the same venv. See #74874 — this is what
+   // breaks the infinite reinstall loop the user hit.
+-  bootstrapRepairRequested = repairDecision.hardReinstall
++  // A soft backend restart must not discard an unfinished installer attempt.
++  bootstrapRepairRequested ||= repairDecision.hardReinstall
+   bootstrapFailure = null
+   backendStartFailure = null
+   remoteReauthFailure = null
 diff --git a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx
 index 58a4389fb8..6b2c20725f 100644
 --- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx
@@ -195,7 +243,7 @@ index 58a4389fb8..6b2c20725f 100644
 @@ -1,7 +1,7 @@
  import { act, cleanup, render } from '@testing-library/react'
  import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
- 
+
 -import type { DesktopConnectionsRegistry } from '@/global'
 +import type { DesktopBootstrapEvent, DesktopConnectionsRegistry } from '@/global'
  import { createClientSessionState } from '@/lib/chat-runtime'
@@ -204,7 +252,7 @@ index 58a4389fb8..6b2c20725f 100644
 @@ -1230,6 +1230,44 @@ describe('useGatewayBoot remote reconnect loop (real hook, fake socket)', () =>
      expect($desktopBoot.get().error).toBeTruthy()
    })
- 
+
 +  it('initial installation can outlive the backend deadline without poisoning boot', async () => {
 +    let installing = true
 +    const listeners = new Set<(event: DesktopBootstrapEvent) => void>()
@@ -266,7 +314,7 @@ index f5ee2ca66c..510ce99af9 100644
 @@ -199,6 +200,8 @@ export function useGatewayBoot({
        return () => void (cancelled = true)
      }
- 
+
 +    const bootWaitAbort = new AbortController()
 +
      // Store-driven switches (Sessions switcher → selectConnection) commit
@@ -285,7 +333,7 @@ index f5ee2ca66c..510ce99af9 100644
 +          'Timed out reconnecting to Hermes backend',
 +          bootWaitAbort.signal
          )
- 
+
          if (!ownsSwitch()) {
 @@ -988,10 +992,11 @@ export function useGatewayBoot({
          // round-trip must not hang "Starting Hermes…" forever. Initial boot
@@ -300,10 +348,10 @@ index f5ee2ca66c..510ce99af9 100644
 +          'Timed out connecting to Hermes backend',
 +          bootWaitAbort.signal
          )
- 
+
          if (cancelled) {
 @@ -1147,6 +1152,7 @@ export function useGatewayBoot({
- 
+
      return () => {
        cancelled = true
 +      bootWaitAbort.abort()
@@ -317,7 +365,7 @@ index edd9764dd8..273bec98ac 100644
 @@ -779,6 +779,28 @@ describe('selectConnection', () => {
      expect($showAllProfiles.get()).toBe(true)
    })
- 
+
 +  it('bootstrap does not expire descriptor restoration and start a duplicate connection', async () => {
 +    vi.useFakeTimers()
 +
@@ -349,7 +397,7 @@ index 7951e3bbe2..46c24ce0d3 100644
 +++ b/apps/desktop/src/store/connections.ts
 @@ -1,8 +1,9 @@
  import { atom, computed } from 'nanostores'
- 
+
  import type { DesktopConnectionsRegistry } from '@/global'
 +import { withBackendBootTimeout } from '@/lib/backend-boot-timeout'
  import { persistStringRecord, storedStringRecord } from '@/lib/storage'
@@ -367,13 +415,13 @@ index 7951e3bbe2..46c24ce0d3 100644
 -// restore should stop waiting for it. Shared constant so the boot-class
 -// budgets can't drift apart (see with-timeout.ts).
 -const BOOT_DESCRIPTOR_WAIT_TIMEOUT_MS = BACKEND_BOOT_WAIT_TIMEOUT_MS
- 
+
  export { $connectionsRegistry } from '@/store/connection-registry-state'
- 
+
 @@ -170,9 +166,9 @@ function waitForInitialConnection(): Promise<void> {
      })
    })
- 
+
 -  return withTimeout(
 +  return withBackendBootTimeout(
      published,
@@ -449,6 +497,183 @@ index 0000000000..04d510594b
 +
 +  return typeof commit === 'string' && /^[0-9a-f]{40}$/.test(commit) && !/^0{40}$/.test(commit) ? commit : null
 +}
+diff --git a/apps/desktop/electron/bootstrap-retry-main-process.test.ts b/apps/desktop/electron/bootstrap-retry-main-process.test.ts
+new file mode 100644
+index 0000000000..230f269ebd
+--- /dev/null
++++ b/apps/desktop/electron/bootstrap-retry-main-process.test.ts
+@@ -0,0 +1,171 @@
++import assert from 'node:assert/strict'
++import fs from 'node:fs'
++import path from 'node:path'
++import vm from 'node:vm'
++
++import ts from 'typescript'
++import { expect, test, vi } from 'vitest'
++
++import { decideBootstrapRepair } from './bootstrap-repair-guard'
++import { consumeBootstrapRequest, consumeBootstrapSeed } from './bootstrap-request'
++
++// Execute the actual resolver, installer lifecycle, and IPC handlers without
++// importing main.ts's app/window side effects. Only process and installer I/O
++// are substituted; the retry state and handler ordering remain production code.
++const source = fs.readFileSync(new URL('./main.ts', import.meta.url), 'utf8')
++const parsed = ts.createSourceFile('main.ts', source, ts.ScriptTarget.Latest, true)
++
++const variables = new Set([
++  'bootstrapFailure',
++  'backendStartFailure',
++  'remoteReauthFailure',
++  'bootstrapAbortController',
++  'bootstrapRepairRequested',
++  'bootstrapSeedCommit',
++  'bootstrapRepairAttempt',
++  'MAX_BOOTSTRAP_REPAIR_SOFT_ATTEMPTS'
++])
++
++const functions = new Set(['resolveHermesBackend', 'ensureRuntime'])
++const handlers = new Set(['hermes:bootstrap:reset', 'hermes:bootstrap:repair'])
++
++const selected = parsed.statements.filter(node => {
++  if (ts.isVariableStatement(node)) {
++    return node.declarationList.declarations.some(declaration => variables.has(declaration.name.getText(parsed)))
++  }
++
++  if (ts.isFunctionDeclaration(node)) {
++    return Boolean(node.name && functions.has(node.name.text))
++  }
++
++  if (ts.isExpressionStatement(node) && ts.isCallExpression(node.expression)) {
++    const call = node.expression
++    const channel = call.arguments[0]
++
++    return (
++      call.expression.getText(parsed) === 'ipcMain.handle' && ts.isStringLiteral(channel) && handlers.has(channel.text)
++    )
++  }
++
++  return false
++})
++
++assert.equal(selected.length, variables.size + functions.size + handlers.size)
++
++const code = ts.transpileModule(
++  selected.map(node => node.getText(parsed)).join('\n') +
++    `;\n({
++      start: () => ensureRuntime(resolveHermesBackend(['serve'])),
++      requested: () => bootstrapRepairRequested,
++      failed: () => Boolean(bootstrapFailure)
++    })`,
++  { compilerOptions: { target: ts.ScriptTarget.ES2022 } }
++).outputText
++
++function fixture({ requested = false, healthy = false, fallback = '' } = {}) {
++  let usable = healthy
++  const env: Record<string, string> = requested ? { HERMES_DESKTOP_BOOTSTRAP: '1' } : {}
++  const ipc = new Map<string, () => Promise<unknown>>()
++
++  const runBootstrap = vi.fn(async () => {
++    usable = true
++
++    return { ok: true }
++  })
++
++  const readState = () => ({ shouldUseActiveRuntime: usable, hasValidMarker: false })
++
++  const runtime = vm.runInNewContext(code, {
++    process: { env, platform: 'linux' },
++    path,
++    AbortController,
++    consumeBootstrapRequest,
++    consumeBootstrapSeed,
++    decideBootstrapRepair,
++    ACTIVE_HERMES_ROOT: '/tmp/bootstrap-fixture/hermes-agent',
++    HERMES_HOME: '/tmp/bootstrap-fixture',
++    VENV_ROOT: '/tmp/bootstrap-fixture/hermes-agent/venv',
++    SOURCE_REPO_ROOT: '/packaged',
++    INSTALL_STAMP: { commit: 'a'.repeat(40), branch: 'main' },
++    IS_PACKAGED: true,
++    IS_WINDOWS: false,
++    IS_WSL: false,
++    ipcMain: { handle: (channel: string, handler: () => Promise<unknown>) => ipc.set(channel, handler) },
++    activeRuntimeState: readState,
++    createActiveBackend: (args: string[]) => ({ kind: 'python', bootstrap: true, args }),
++    isHermesSourceRoot: () => true,
++    findOnPath: () => (fallback === 'PATH' ? '/tmp/native-hermes' : null),
++    findSystemPython: () => (fallback === 'Python' ? '/tmp/python' : null),
++    unwrapWindowsVenvHermesCommand: () => null,
++    looksLikeDesktopAppBinary: () => false,
++    isCommandScript: () => false,
++    shouldTrustHermesOverride: () => false,
++    verifyHermesCli: () => true,
++    canImportHermesCli: () => true,
++    getVenvPython: () => '/tmp/bootstrap-fixture/hermes-agent/venv/bin/python',
++    fileExists: () => true,
++    handOffWindowsBootstrapRecovery: async () => false,
++    advanceBootProgress: async () => {},
++    updateBootProgress: () => {},
++    rememberLog: () => {},
++    broadcastBootstrapEvent: () => {},
++    writeBootstrapMarker: () => {},
++    runBootstrap,
++    teardownPrimaryBackendAndWait: async () => {},
++    resetBootstrapSnapshot: () => {},
++    resetHermesConnection: () => {},
++    backendConnectionState: { getProcess: () => ({ exitCode: null, signalCode: null }) },
++    getFirstRunSetupGate: () => ({ resetForRetry: () => {}, resetForRepair: () => {} })
++  }) as { start: () => Promise<unknown>; requested: () => boolean; failed: () => boolean }
++
++  return { ...runtime, env, ipc, runBootstrap, makeUsable: () => void (usable = true) }
++}
++
++test.each(
++  ['reset', 'repair'].flatMap(handler =>
++    [false, true].flatMap(requested => ['failed', 'cancelled'].map(outcome => ({ handler, requested, outcome })))
++  )
++)(
++  'late $outcome survives $handler and retries setup (launcher request=$requested)',
++  async ({ handler, requested, outcome }) => {
++    const app = fixture({ requested, healthy: requested })
++    app.runBootstrap.mockImplementationOnce(async () => {
++      app.makeUsable() // venv/path succeeded; a later stage failed or was cancelled.
++
++      return outcome === 'cancelled'
++        ? { ok: false, cancelled: true }
++        : { ok: false, failedStage: 'complete', error: 'late fixture failure' }
++    })
++
++    expect(app.env).toEqual({})
++    await expect(app.start()).rejects.toMatchObject({ isBootstrapFailure: true })
++    expect(app.failed()).toBe(true)
++    await app.ipc.get(`hermes:bootstrap:${handler}`)!()
++    expect(app.failed()).toBe(false)
++    await app.start()
++    expect(app.runBootstrap).toHaveBeenCalledTimes(2)
++    expect(app.requested()).toBe(false)
++
++    // A subsequent ordinary restart must use the completed native runtime.
++    await app.start()
++    expect(app.runBootstrap).toHaveBeenCalledTimes(2)
++  }
++)
++
++test('a healthy native runtime with no marker keeps soft repairs out of the installer', async () => {
++  const app = fixture({ healthy: true })
++  await app.ipc.get('hermes:bootstrap:repair')!()
++  await app.start()
++  expect(app.requested()).toBe(false)
++  expect(app.runBootstrap).not.toHaveBeenCalled()
++})
++
++test.each(['PATH', 'Python'])(
++  'an explicit pending install cannot escape through a usable %s fallback',
++  async fallback => {
++    const app = fixture({ requested: true, fallback })
++    await app.start()
++    expect(app.runBootstrap).toHaveBeenCalledTimes(1)
++    expect(app.requested()).toBe(false)
++  }
++)
 diff --git a/apps/desktop/src/lib/backend-boot-timeout.test.ts b/apps/desktop/src/lib/backend-boot-timeout.test.ts
 new file mode 100644
 index 0000000000..bc483ba513

--- a/pkgbuilds/hermes-desktop/hermes-desktop.sh
+++ b/pkgbuilds/hermes-desktop/hermes-desktop.sh
@@ -17,6 +17,7 @@ export HERMES_HOME
 root="$HERMES_HOME/hermes-agent"
 marker="$root/.omarchy-hermes-desktop"
 installer=/usr/share/hermes-desktop/install.sh
+seed=/usr/share/hermes-desktop/seed
 cli=("$root/venv/bin/python" "$root/hermes")
 
 desktop_executable() {
@@ -76,6 +77,7 @@ stage() {
 }
 
 install_desktop() {
+  local graphical=${1:-false}
   (( EUID != 0 )) || die "Run this installer as your desktop user, without sudo."
   mkdir -p "$HERMES_HOME"
   exec 9>"$HERMES_HOME/.omarchy-hermes-desktop.lock"
@@ -133,13 +135,15 @@ PY
       https://github.com/NousResearch/hermes-agent.git | git@github.com:NousResearch/hermes-agent.git) ;;
       *) die "Keeping the checkout's custom origin. Install its desktop with 'hermes desktop'." ;;
     esac
-    if [[ $legacy == true ]]; then
+    # GUI bootstrap updates existing Git checkouts and can hard-reset a
+    # divergent main. Admit only published history before giving it the root.
+    if [[ $legacy == true || $graphical == true ]]; then
       case "$(git -C "$root" rev-parse HEAD)" in
         e624e9fde561e1add9388384012b295fde669ade | 29112bef099274229cadff79cdff7bf7b99c4b77) ;;
         *)
           if [[ $(git -C "$root" symbolic-ref --short -q HEAD) != "main" ]] ||
             ! git -C "$root" merge-base --is-ancestor HEAD refs/remotes/origin/main; then
-            die "The legacy checkout has moved. Run 'hermes update', then 'hermes desktop'."
+            die "Keeping the checkout branch or unpublished commits. Run 'hermes desktop' from that installation."
           fi
           ;;
       esac
@@ -172,16 +176,23 @@ PY
     if ! git -C "$root" config --get-all remote.origin.fetch | grep -qxF "$refspec"; then
       git -C "$root" config --add remote.origin.fetch "$refspec"
     fi
-    git -C "$root" fetch origin "$refspec"
-    env -u PYTHONPATH -u PYTHONHOME "${cli[@]}" update --yes --branch main
+    if [[ $graphical == false ]]; then
+      git -C "$root" fetch origin "$refspec"
+      env -u PYTHONPATH -u PYTHONHOME "${cli[@]}" update --yes --branch main
+    fi
   elif [[ ! -e $root ]]; then
-    stage prerequisites
+    if [[ $graphical == false ]]; then stage prerequisites; fi
     # Publish only a complete clone with its ownership marker. An interrupted
     # clone stays aside for inspection and cannot block the next installation.
     local repository_dir
     repository_dir=$(mktemp -d "$HERMES_HOME/.omarchy-hermes-repository.XXXXXX")
     echo "Preparing the Hermes checkout in $repository_dir"
-    stage repository "$repository_dir/hermes-agent"
+    if [[ $graphical == true ]]; then
+      cp -a --reflink=auto "$seed" "$repository_dir/hermes-agent"
+      chmod -R u+w "$repository_dir/hermes-agent"
+    else
+      stage repository "$repository_dir/hermes-agent"
+    fi
     printf '/.omarchy-hermes-desktop\n' >>"$repository_dir/hermes-agent/.git/info/exclude"
     printf 'pending\n' >"$repository_dir/hermes-agent/.omarchy-hermes-desktop"
     mv -T --no-clobber "$repository_dir/hermes-agent" "$root"
@@ -191,6 +202,35 @@ PY
 
   if [[ $mise_predecessor == true ]]; then
     printf '%s\n' 'pipx:hermes-agent[extras=all]' >"$root/.git/omarchy-mise-predecessor"
+  fi
+
+  if [[ $graphical == true ]]; then
+    # Existing managed bootstraps may have a runtime but no writable desktop.
+    # Seed only the absent app; never replace a newer executable or source.
+    if ! desktop_executable >/dev/null; then
+      [[ ! -e $root/apps/desktop/release/linux-unpacked ]] || die "Keeping the incomplete desktop at $root/apps/desktop/release/linux-unpacked."
+      local desktop_dir
+      desktop_dir=$(mktemp -d "$root/.git/omarchy-desktop.XXXXXX")
+      cp -a --reflink=auto "$seed/apps/desktop/release/linux-unpacked" "$desktop_dir/"
+      chmod -R u+w "$desktop_dir/linux-unpacked"
+      mkdir -p "$root/apps/desktop/release"
+      mv -T --no-clobber "$desktop_dir/linux-unpacked" "$root/apps/desktop/release/linux-unpacked"
+      [[ ! -e $desktop_dir/linux-unpacked ]] || die "Keeping the desktop that appeared during setup."
+      rmdir "$desktop_dir"
+    fi
+    # The GUI owns bootstrap and cancellation. Keep the old launchers as a
+    # recovery copy until it succeeds; never race an installer with rollback.
+    graphical_existing=false
+    if [[ -f $root/.hermes-bootstrap-complete && -x ${cli[0]} ]] &&
+      timeout 15 env -u PYTHONPATH -u PYTHONHOME "${cli[0]}" -c 'import yaml; import dotenv; import hermes_cli.config' >/dev/null 2>&1; then
+      graphical_existing=true
+    fi
+    graphical_legacy=$graphical_existing
+    graphical_marker=$(stat -c '%d:%i:%y' "$root/.hermes-bootstrap-complete" 2>/dev/null || true)
+    printf 'pending\n' >"$marker"
+    graphical_setup=true
+    trap - EXIT INT TERM
+    return
   fi
 
   if [[ $legacy == false ]]; then
@@ -223,29 +263,31 @@ PY
 case "${1:-}" in
   --check) ready; exit ;;
   --install) install_desktop; exit ;;
-  --setup)
-    shift
-    if /usr/bin/hermes-desktop --install; then
-      setsid --fork /usr/bin/hermes-desktop "$@" >/dev/null 2>&1
-      exit
-    else
-      status=$?
-      echo "Hermes installation failed. Retry with: hermes-desktop --install" >&2
-      if [[ -t 0 ]]; then read -r -p 'Press Enter to close.'; fi
-      exit "$status"
-    fi
-    ;;
+  --setup) shift ;;
 esac
 
+graphical_setup=false
 if ! ready; then
-  if [[ -t 0 && -t 1 ]]; then
-    install_desktop
-  else
-    exec xdg-terminal-exec /usr/bin/hermes-desktop --setup "$@"
-  fi
+  install_desktop true
 fi
 
-export HERMES_DESKTOP_HERMES_ROOT="$root"
+# HERMES_HOME selects the native root. A developer source/Python override
+# bypasses GUI bootstrap and falls back to system Python before the venv exists.
+unset HERMES_DESKTOP_HERMES_ROOT HERMES_DESKTOP_PYTHON HERMES_DESKTOP_BOOTSTRAP HERMES_DESKTOP_BOOTSTRAP_SEED
+export HERMES_DESKTOP_IGNORE_EXISTING=1
+if [[ $graphical_setup == true && $graphical_existing == false ]]; then
+  # A cancelled first install can already import the CLI, even though it has
+  # never completed. The packaged app consumes this one-shot bootstrap request.
+  export HERMES_DESKTOP_BOOTSTRAP=1
+  seed_receipt="$root/.git/omarchy-desktop-seed"
+  if [[ -f $seed_receipt && ! -L $seed_receipt ]] &&
+    cmp -s "$seed_receipt" "$seed/.git/omarchy-desktop-seed"; then
+    seed_commit=$(cat "$seed_receipt")
+    if [[ $seed_commit =~ ^[0-9a-f]{40}$ && $(git -C "$root" rev-parse HEAD) == "$seed_commit" ]]; then
+      export HERMES_DESKTOP_BOOTSTRAP_SEED=$seed_commit
+    fi
+  fi
+fi
 export HERMES_DESKTOP_PASSWORD_STORE="${HERMES_DESKTOP_PASSWORD_STORE:-gnome-libsecret}"
 # Upstream desktop registration resolves its launcher through PATH.
 export PATH="$HOME/.local/bin:$PATH"
@@ -263,4 +305,51 @@ fi
 if unshare --user --map-root-user true 2>/dev/null; then
   flags+=(--disable-setuid-sandbox)
 fi
-exec "$(desktop_executable)" "${flags[@]}" "$@"
+if [[ $graphical_setup == false ]]; then
+  exec "$(desktop_executable)" "${flags[@]}" "$@"
+fi
+
+# Keep the installation lock until the GUI's native bootstrap has finished.
+# The app gets no lock descriptor: its updater must be able to outlive it.
+"$(desktop_executable)" "${flags[@]}" "$@" 9>&- &
+app_pid=$!
+(
+  while kill -0 "$app_pid" 2>/dev/null; do
+    # An existing healthy legacy runtime skips GUI bootstrap. Register its
+    # admitted CLI shims without reinstalling dependencies or building the app.
+    if [[ $graphical_legacy == true ]] &&
+      timeout 15 env -u PYTHONPATH -u PYTHONHOME "${cli[@]}" --version >/dev/null 2>&1; then
+      stage path
+      graphical_legacy=false
+    fi
+    # Electron adds desktopVersion after the final installer child exits.
+    # The installer's earlier marker alone must not finalize a cold GUI setup.
+    if { [[ $graphical_existing == true ]] || {
+      [[ $(stat -c '%d:%i:%y' "$root/.hermes-bootstrap-complete" 2>/dev/null || true) != "$graphical_marker" ]] && python -I -c '
+import json, sys
+try:
+    assert json.load(open(sys.argv[1])).get("desktopVersion")
+except (OSError, ValueError, AssertionError, AttributeError):
+    sys.exit(1)
+' "$root/.hermes-bootstrap-complete"; }; } && runtime_ready; then
+      # Keep the package desktop entry until a real native update builds and
+      # stamps the app. A premature `hermes desktop` entry would build on launch.
+      printf 'ready\n' >"$marker"
+      rm -rf "$install_backup"
+      exec 9>&-
+      if [[ -f $root/.git/omarchy-mise-predecessor ]] && command -v omarchy-install-hermes-cli >/dev/null 2>&1; then
+        omarchy-install-hermes-cli || echo 'Run omarchy-install-hermes-cli again to finish the old CLI cleanup.' >&2
+      fi
+      exit
+    fi
+    sleep 2
+  done
+  echo "Hermes setup did not finish. Previous CLI launchers are preserved in $install_backup." >&2
+  echo "Retry in Hermes, or finish setup from a terminal with: hermes-desktop --install" >&2
+) &
+completion_pid=$!
+exec 9>&-
+status=0
+wait "$app_pid" || status=$?
+wait "$completion_pid" || true
+exit "$status"

--- a/test/hermes-desktop-test.py
+++ b/test/hermes-desktop-test.py
@@ -8,6 +8,7 @@ import time
 from pathlib import Path
 import subprocess
 import tempfile
+import shutil
 import unittest
 
 SOURCE = Path(__file__).resolve().parents[1] / 'pkgbuilds/hermes-desktop/hermes-desktop.sh'
@@ -22,13 +23,15 @@ printf '%s\n' "$stage" >> "$TEST_LOG"
 case $stage in
 repository)
   mkdir -p "$root/venv/bin"
-  git init -q "$root"
+  git init -q -b main "$root"
   [[ ${FAIL_PARTIAL_CLONE:-} != 1 ]] || exit 44
   git -C "$root" remote add origin https://github.com/NousResearch/hermes-agent.git
   touch "$root/hermes"
   cp "$TEST_PYTHON" "$root/venv/bin/python"
-  git -C "$root" add hermes venv
+  printf '/venv/\n' >> "$root/.git/info/exclude"
+  git -C "$root" add hermes
   git -C "$root" -c user.email=test@example.com -c user.name=Test commit -qm initial
+  git -C "$root" update-ref refs/remotes/origin/main HEAD
   if [[ ${RACE_CLONE:-} == 1 ]]; then
     mkdir -p "$HOME/.hermes/hermes-agent"
     printf 'foreign checkout\n' > "$HOME/.hermes/hermes-agent/keep"
@@ -94,13 +97,38 @@ else
 fi
 ''')
         self.write(self.base / 'gui', '''#!/usr/bin/env python3
-import json,os,sys,time
-json.dump({'pid':os.getpid(),'args':sys.argv[1:],'root':os.environ['HERMES_DESKTOP_HERMES_ROOT'],'home':os.environ['HERMES_HOME'],'node':os.environ.get('ELECTRON_RUN_AS_NODE'),'password':os.environ['HERMES_DESKTOP_PASSWORD_STORE']},open(os.environ['TEST_OUTPUT'],'w'))
+import json,os,sys,time,subprocess,shutil
+json.dump({'pid':os.getpid(),'args':sys.argv[1:],'root':os.path.join(os.environ['HERMES_HOME'],'hermes-agent'),'home':os.environ['HERMES_HOME'],'seed':os.environ.get('HERMES_DESKTOP_BOOTSTRAP_SEED'),'bootstrap':os.environ.get('HERMES_DESKTOP_BOOTSTRAP'),'override':os.environ.get('HERMES_DESKTOP_HERMES_ROOT'),'python_override':os.environ.get('HERMES_DESKTOP_PYTHON'),'node':os.environ.get('ELECTRON_RUN_AS_NODE'),'password':os.environ['HERMES_DESKTOP_PASSWORD_STORE']},open(os.environ['TEST_OUTPUT'],'w'))
+if os.environ.get('TEST_BOOTSTRAP'):
+    root=__import__('pathlib').Path(os.path.join(os.environ['HERMES_HOME'],'hermes-agent'))
+    (root/'venv/bin').mkdir(parents=True,exist_ok=True)
+    shutil.copy2(os.environ['TEST_PYTHON'],root/'venv/bin/python')
+    for stage in ['path','complete']:
+        subprocess.run(['bash',os.environ['TEST_INSTALLER'],'--dir',str(root),'--stage',stage],check=True)
+        if stage=='path' and os.environ.get('TEST_BOOTSTRAP_FAIL_LATE'):
+            time.sleep(3)
+            sys.exit(21)
+    (root/'.hermes-bootstrap-complete').write_text(json.dumps({'desktopVersion':'test'}))
+if os.environ.get('TEST_BOOTSTRAP') or os.environ.get('TEST_WAIT_READY'):
+    root=__import__('pathlib').Path(os.path.join(os.environ['HERMES_HOME'],'hermes-agent'))
+    deadline=time.monotonic()+10
+    while (root/'.omarchy-hermes-desktop').read_text()!='ready\\n' and time.monotonic()<deadline:
+        time.sleep(.05)
 if os.environ.get('TEST_GUI_WAIT'): time.sleep(30)
 ''')
         self.write(self.bin / 'unshare', '#!/bin/bash\nexit 0\n')
         self.write(self.bin / 'xdg-terminal-exec', '#!/bin/bash\nprintf "%s\\n" "$@" > "$TEST_OUTPUT"\n')
+        self.seed = self.base / 'seed'
+        self.write(self.seed / 'hermes', '')
+        self.write(self.seed / '.gitignore', 'apps/desktop/release/\nvenv/\n.hermes-bootstrap-complete\n')
+        self.write(self.seed / 'apps/desktop/release/linux-unpacked/Hermes', (self.base / 'gui').read_text())
+        for args in [['init','-q','-b','main'],['add','hermes','.gitignore'],['-c','user.email=test@example.com','-c','user.name=Test','commit','-qm','seed'],['remote','add','origin','https://github.com/NousResearch/hermes-agent.git'],['update-ref','refs/remotes/origin/main','HEAD']]:
+            subprocess.run(['git','-C',str(self.seed),*args],check=True,env=self.env)
+        self.seed_commit=subprocess.check_output(['git','-C',str(self.seed),'rev-parse','HEAD'],env=self.env,text=True).strip()
+        (self.seed/'.git/omarchy-desktop-seed').write_text(self.seed_commit+'\n')
+        self.env['TEST_INSTALLER'] = str(self.base / 'installer')
         source = SOURCE.read_text().replace('/usr/share/hermes-desktop/install.sh', str(self.base / 'installer'))
+        source = source.replace('/usr/share/hermes-desktop/seed', str(self.seed))
         source = source.replace('/usr/bin/hermes-desktop', str(self.base / 'launcher'))
         self.write(self.base / 'launcher', source)
 
@@ -289,10 +317,98 @@ if os.environ.get('TEST_GUI_WAIT'): time.sleep(30)
         self.assertEqual((self.root/'hermes').read_text(),'user changes')
         self.assertEqual(self.log.read_bytes(),before)
 
-    def test_cold_graphical_launch_opens_visible_setup(self):
-        self.run_launcher('hermes://open')
-        self.assertEqual(self.output.read_text().splitlines(),[str(self.base/'launcher'),'--setup','hermes://open'])
+    def test_cold_graphical_launch_opens_app_before_runtime_install(self):
+        self.run_launcher('hermes://open',HERMES_DESKTOP_HERMES_ROOT='/foreign/source',HERMES_DESKTOP_PYTHON='/foreign/python')
+        observed=json.loads(self.output.read_text())
+        self.assertIn('hermes://open',observed['args'])
+        self.assertEqual(observed['root'],str(self.root))
+        self.assertEqual(observed['bootstrap'],'1')
+        self.assertEqual(observed['seed'],self.seed_commit)
+        self.assertIsNone(observed['override'])
+        self.assertIsNone(observed['python_override'])
         self.assertFalse(self.log.exists())
+        self.assertFalse((self.root/'venv').exists())
+        self.assertEqual((self.root/'.omarchy-hermes-desktop').read_text(),'pending\n')
+        self.assertEqual(subprocess.check_output(['git','-C',str(self.root),'status','--porcelain'],env=self.env),b'')
+        self.run_launcher('--check',ok=False)
+
+    def test_gui_bootstrap_publishes_readiness_without_replacing_package_entry(self):
+        self.run_launcher(TEST_BOOTSTRAP='1')
+        self.run_launcher('--check')
+        self.assertEqual(self.log.read_text().splitlines(),['path','complete'])
+        entry=self.home/'.local/share/applications/hermes.desktop'
+        self.assertFalse(entry.exists())
+        lock=self.home/'.hermes/.omarchy-hermes-desktop.lock'
+        self.assertEqual(subprocess.run(['flock','--nonblock',str(lock),'true']).returncode,0)
+
+    def test_early_gui_cancellation_preserves_predecessor_and_can_retry(self):
+        wrapper=self.home/'.local/bin/hermes'
+        self.write(wrapper,'#!/bin/bash\n# Written by omarchy-install-hermes-cli.\necho old\n')
+        before=wrapper.read_bytes()
+        self.run_launcher()
+        self.assertEqual(wrapper.read_bytes(),before)
+        self.assertEqual((self.root/'.git/omarchy-mise-predecessor').read_text(),'pipx:hermes-agent[extras=all]\n')
+        self.run_launcher('--check',ok=False)
+        self.run_launcher(TEST_BOOTSTRAP='1')
+        self.run_launcher('--check')
+
+    def test_existing_healthy_runtime_gets_prebuilt_app_without_update_or_build(self):
+        self.install()
+        head=subprocess.check_output(['git','-C',str(self.root),'rev-parse','HEAD'],env=self.env)
+        shutil.rmtree(self.root/'apps/desktop/release/linux-unpacked')
+        before=self.log.read_text().splitlines()
+        self.run_launcher(TEST_WAIT_READY='1')
+        self.run_launcher('--check')
+        self.assertEqual(subprocess.check_output(['git','-C',str(self.root),'rev-parse','HEAD'],env=self.env),head)
+        self.assertNotIn('desktop',self.log.read_text().splitlines()[len(before):])
+        self.assertNotIn('repository',self.log.read_text().splitlines()[len(before):])
+
+    def test_a_newer_runtime_does_not_request_seed_repository_skip(self):
+        self.run_launcher()
+        (self.root/'hermes').write_text('newer upstream source\n')
+        for args in [['add','hermes'],['-c','user.email=test@example.com','-c','user.name=Test','commit','-qm','new upstream'],['update-ref','refs/remotes/origin/main','HEAD']]:
+            subprocess.run(['git','-C',str(self.root),*args],check=True,env=self.env)
+        self.run_launcher(TEST_BOOTSTRAP='1',HERMES_DESKTOP_BOOTSTRAP_SEED=self.seed_commit)
+        observed=json.loads(self.output.read_text())
+        self.assertIsNone(observed['seed'])
+        self.run_launcher('--check')
+
+    def test_incomplete_usable_runtime_requests_graphical_bootstrap_on_retry(self):
+        self.run_launcher()
+        self.write(self.root/'venv/bin/python',(self.base/'python').read_text())
+        self.run_launcher(TEST_BOOTSTRAP='1')
+        observed=json.loads(self.output.read_text())
+        self.assertEqual(observed['bootstrap'],'1')
+        self.run_launcher('--check')
+
+    def test_graphical_repair_preserves_unpublished_committed_source(self):
+        self.install()
+        (self.root/'hermes').write_text('local committed source\n')
+        for args in [['add','hermes'],['-c','user.email=test@example.com','-c','user.name=Test','commit','-qm','local work']]:
+            subprocess.run(['git','-C',str(self.root),*args],check=True,env=self.env)
+        self.write(self.root/'venv/bin/python','#!/bin/bash\nexit 1\n')
+        before=subprocess.check_output(['git','-C',str(self.root),'rev-parse','HEAD'],env=self.env)
+        result=self.run_launcher(ok=False)
+        self.assertIn('unpublished commits',result.stdout)
+        self.assertFalse(self.output.exists())
+        self.assertEqual(subprocess.check_output(['git','-C',str(self.root),'rev-parse','HEAD'],env=self.env),before)
+
+    def test_damaged_runtime_does_not_reuse_stale_gui_completion(self):
+        self.install()
+        (self.root/'.hermes-bootstrap-complete').write_text(json.dumps({'desktopVersion':'old'}))
+        self.write(self.root/'venv/bin/python','#!/bin/bash\nexit 1\n')
+        self.run_launcher(TEST_BOOTSTRAP='1',TEST_BOOTSTRAP_FAIL_LATE='1',ok=False)
+        self.assertEqual((self.root/'.omarchy-hermes-desktop').read_text(),'pending\n')
+        self.run_launcher('--check',ok=False)
+        self.assertTrue(list((self.home/'.hermes').glob('.omarchy-hermes-launchers.*')))
+
+    def test_graphical_launch_preserves_foreign_wrapper_and_checkout(self):
+        wrapper=self.home/'.local/bin/hermes'
+        self.write(wrapper,'#!/bin/bash\necho custom\n')
+        self.run_launcher(ok=False)
+        self.assertFalse(self.root.exists())
+        self.assertFalse(self.output.exists())
+        self.assertEqual(wrapper.read_text(),'#!/bin/bash\necho custom\n')
 
     def test_unexecutable_native_cli_is_repaired(self):
         self.install()
@@ -309,36 +425,19 @@ if os.environ.get('TEST_GUI_WAIT'): time.sleep(30)
         receipt=self.root/'.git/omarchy-mise-predecessor'
         self.assertEqual(receipt.read_text(),'pipx:hermes-agent[extras=all]\n')
 
-    def test_graphical_setup_detaches_and_releases_install_lock(self):
-        started=time.monotonic()
-        self.run_launcher('--setup', 'hermes://open', TEST_GUI_WAIT='1')
-        self.assertLess(time.monotonic()-started,5)
-        for _ in range(100):
-            if self.output.exists(): break
-            time.sleep(.02)
-        observed=json.loads(self.output.read_text())
-        self.addCleanup(lambda: os.kill(observed['pid'],signal.SIGTERM))
-        self.assertIn('hermes://open',observed['args'])
-        self.run_launcher('--install')
-        lock=self.home/'.hermes/.omarchy-hermes-desktop.lock'
-        self.assertEqual(subprocess.run(['flock','--nonblock',str(lock),'true']).returncode,0)
-
-    def test_cold_terminal_launch_releases_lock_before_exec(self):
+    def test_cold_launch_from_terminal_still_bootstraps_inside_app(self):
         master,slave=pty.openpty()
-        process=subprocess.Popen(['bash',str(self.base/'launcher')],stdin=slave,stdout=slave,stderr=slave,env=self.env | {'TEST_GUI_WAIT':'1'})
+        process=subprocess.Popen(['bash',str(self.base/'launcher')],stdin=slave,stdout=slave,stderr=slave,env=self.env | {'TEST_BOOTSTRAP':'1'})
         os.close(slave)
-        def cleanup():
-            if process.poll() is None: process.terminate()
-            process.wait(timeout=5)
+        try:
+            self.assertEqual(process.wait(timeout=15),0)
+            self.run_launcher('--check')
+            self.assertEqual(self.log.read_text().splitlines(),['path','complete'])
+        finally:
+            if process.poll() is None:
+                process.terminate()
+                process.wait(timeout=5)
             os.close(master)
-        self.addCleanup(cleanup)
-        for _ in range(100):
-            if self.output.exists(): break
-            time.sleep(.02)
-        self.assertTrue(self.output.exists())
-        self.assertIsNone(process.poll())
-        lock=self.home/'.hermes/.omarchy-hermes-desktop.lock'
-        self.assertEqual(subprocess.run(['flock','--nonblock',str(lock),'true']).returncode,0)
 
     def test_pending_marker_overrides_old_completion(self):
         self.install()


### PR DESCRIPTION
`hermes-desktop 2026.8.31-1` moved the first runtime install and desktop build into a terminal. This follow-up to #325 restores the expected app-first installation and bumps the package to `2026.8.31-2` so existing installations receive the correction.

Ship a prebuilt desktop with a complete Git seed, then copy it into the user's writable native Hermes directory before opening the app. Hermes installs its dependencies inside its existing setup UI. The seed keeps the initial source and desktop on the same revision; subsequent app and CLI updates use upstream's native updater. Existing working runtimes, custom source, foreign launchers, Wayland selection, and keyring handling are preserved.

The package also carries first-run fixes for interrupted setup and the false 45-second backend timeout during installation. The coordinated menu change remains in draft at https://github.com/omacom/omarchy/pull/10443 and checks the prebuilt package before launching it.

This remains draft. The launcher regressions and focused upstream tests pass; an isolated prototype reached onboarding and exposed the first-run issues addressed here. Independent review is still checking same-window retry behavior, and final release-2 cold installation, native updates, and normal-session browser routing are not yet accepted. No production package is published by this PR.

🤖 Generated by GPT-6 in Codex/T3 Code. Independent GPT-6 Codex review at xhigh is in progress.
