### PR TITLE
linux-ptl: carry working Zenbook S14 audio fixes

### DIFF
--- a/pkgbuilds/linux-ptl/0030-soundwire-disable-ghost-realtek.patch
+++ b/pkgbuilds/linux-ptl/0030-soundwire-disable-ghost-realtek.patch
@@ -1,0 +1,80 @@
+From 4dab2b904414fac53535c4e4cdad808132f4cdc2 Mon Sep 17 00:00:00 2001
+From: Charles Keepax <ckeepax@opensource.cirrus.com>
+Date: Wed, 20 May 2026 17:36:31 +0100
+Subject: [PATCH] soundwire: dmi-quirks: Disable ghost Realtek devices
+
+Many systems ship with a Realtek audio codec in the ACPI that doesn't
+physically exist in the system. This confuses the newer function
+topology system that creates the soundcard, as it builds the card based
+on the ACPI information.
+
+Whilst we are working with the laptop vendors to try and stop this
+happening there are quite a few systems where this has shipped. Add a
+quirk to disable this "ghost" device.
+
+Currently this patch should cover:
+ - Asus UX5406AA
+ - Lenovo Yoga Pro 9i (83SF)
+ - Lenovo Yoga Slim 7 Ultra (83QK)
+
+Signed-off-by: Charles Keepax <ckeepax@opensource.cirrus.com>
+Reviewed-by: Pierre-Louis Bossart <pierre-louis.bossart@linux.dev>
+Link: https://patch.msgid.link/20260520163631.3300102-4-ckeepax@opensource.cirrus.com
+Signed-off-by: Vinod Koul <vkoul@kernel.org>
+---
+ drivers/soundwire/dmi-quirks.c | 35 ++++++++++++++++++++++++++++++++++
+ 1 file changed, 35 insertions(+)
+
+diff --git a/drivers/soundwire/dmi-quirks.c b/drivers/soundwire/dmi-quirks.c
+index 5854218e1a274e..32a46a2d90f7ca 100644
+--- a/drivers/soundwire/dmi-quirks.c
++++ b/drivers/soundwire/dmi-quirks.c
+@@ -90,6 +90,19 @@ static const struct adr_remap intel_rooks_county[] = {
+ 	{}
+ };
+ 
++/*
++ * Many platforms have ghost realtek devices in the ACPI that don't physically
++ * exist, remove those devices.
++ */
++static const struct adr_remap ghost_realtek[] = {
++	/* rt722 on link3 */
++	{
++		0x000330025d072201ull,
++		0x0000000000000000ull
++	},
++	{}
++};
++
+ static const struct dmi_system_id adr_remap_quirk_table[] = {
+ 	/* TGL devices */
+ 	{
+@@ -164,6 +177,28 @@ static const struct dmi_system_id adr_remap_quirk_table[] = {
+ 		},
+ 		.driver_data = (void *)hp_omen_16,
+ 	},
++	/* PTL devices */
++	{
++		.matches = {
++			DMI_MATCH(DMI_SYS_VENDOR, "ASUS"),
++			DMI_MATCH(DMI_BOARD_NAME, "UX5406AA"),
++		},
++		.driver_data = (void *)ghost_realtek,
++	},
++	{
++		.matches = {
++			DMI_MATCH(DMI_SYS_VENDOR, "LENOVO"),
++			DMI_MATCH(DMI_PRODUCT_NAME, "83QK"),
++		},
++		.driver_data = (void *)ghost_realtek,
++	},
++	{
++		.matches = {
++			DMI_MATCH(DMI_SYS_VENDOR, "LENOVO"),
++			DMI_MATCH(DMI_PRODUCT_NAME, "83SF"),
++		},
++		.driver_data = (void *)ghost_realtek,
++	},
+ 	{}
+ };
+ 

--- a/pkgbuilds/linux-ptl/0031-asoc-ux5406aa-audio-layout.patch
+++ b/pkgbuilds/linux-ptl/0031-asoc-ux5406aa-audio-layout.patch
@@ -1,0 +1,117 @@
+Subject: [PATCH] ASoC: Intel: preserve the working UX5406AA audio layout
+
+Carry the CS42L43 and four-CS35L56 layout from the working UX5406AA
+7.1.8 build, based on the workaround discussed in:
+https://github.com/thesofproject/linux/pull/5754
+https://github.com/thesofproject/linux/issues/5721
+
+The local build also required snd_soc_sof_sdw quirk=0 for the built-in
+microphone. Encode that effective setting in the SSID entry instead of
+requiring a global module override. SOC_SDW_CODEC_MIC excludes the
+CS42L43 microphone in this kernel's function-topology path.
+
+This is a downstream 7.1.8 compatibility patch carried with the
+SoundWire ghost-device fix, not a new upstream hardware-table proposal.
+
+---
+
+--- a/sound/soc/intel/common/soc-acpi-intel-ptl-match.c
++++ b/sound/soc/intel/common/soc-acpi-intel-ptl-match.c
+@@ -169,6 +169,26 @@
+ 	}
+ };
+ 
++/*
++ * The ASUS UX5406AA BIOS advertises an RT722 on link 3 which is not
++ * physically populated. Keep it in the match table so the firmware
++ * description can be matched, but expose no endpoints for it.
++ */
++static const struct snd_soc_acpi_adr_device cs42l43_3_asus_ux5406aa_adr[] = {
++	{
++		.adr = 0x00033001FA424301ull,
++		.num_endpoints = ARRAY_SIZE(cs42l43_amp_spkagg_endpoints),
++		.endpoints = cs42l43_amp_spkagg_endpoints,
++		.name_prefix = "cs42l43"
++	},
++	{
++		.adr = 0x000330025D072201ull,
++		.num_endpoints = 0,
++		.endpoints = NULL,
++		.name_prefix = "rt722"
++	}
++};
++
+ static const struct snd_soc_acpi_adr_device cs35l56_2_lr_adr[] = {
+ 	{
+ 		.adr = 0x00023001fa355601ull,
+@@ -184,6 +204,21 @@
+ 	}
+ };
+ 
++static const struct snd_soc_acpi_adr_device cs35l56_1_lr_adr[] = {
++	{
++		.adr = 0x00013201fa355601ull,
++		.num_endpoints = 1,
++		.endpoints = &spk_l_endpoint,
++		.name_prefix = "AMP3"
++	},
++	{
++		.adr = 0x00013301fa355601ull,
++		.num_endpoints = 1,
++		.endpoints = &spk_r_endpoint,
++		.name_prefix = "AMP4"
++	}
++};
++
+ static const struct snd_soc_acpi_adr_device rt711_sdca_0_adr[] = {
+ 	{
+ 		.adr = 0x000030025D071101ull,
+@@ -315,6 +350,25 @@
+ 	{}
+ };
+ 
++static const struct snd_soc_acpi_link_adr ptl_asus_ux5406aa_links[] = {
++	{
++		.mask = BIT(3),
++		.num_adr = ARRAY_SIZE(cs42l43_3_asus_ux5406aa_adr),
++		.adr_d = cs42l43_3_asus_ux5406aa_adr,
++	},
++	{
++		.mask = BIT(2),
++		.num_adr = ARRAY_SIZE(cs35l56_2_lr_adr),
++		.adr_d = cs35l56_2_lr_adr,
++	},
++	{
++		.mask = BIT(1),
++		.num_adr = ARRAY_SIZE(cs35l56_1_lr_adr),
++		.adr_d = cs35l56_1_lr_adr,
++	},
++	{}
++};
++
+ static const struct snd_soc_acpi_link_adr ptl_rt722_l0_rt1320_l23[] = {
+ 	{
+ 		.mask = BIT(0),
+@@ -462,6 +516,12 @@
+ 		.drv_name = "sof_sdw",
+ 		.sof_tplg_filename = "sof-ptl-rt715-rt711-rt1308-mono.tplg",
+ 	},
++	{
++		.link_mask = BIT(1) | BIT(2) | BIT(3),
++		.links = ptl_asus_ux5406aa_links,
++		.drv_name = "sof_sdw",
++		.get_function_tplg_files = sof_sdw_get_tplg_files,
++	},
+ 	{
+ 		.link_mask = BIT(0),
+ 		.links = sdw_mockup_multi_func,
+--- a/sound/soc/intel/boards/sof_sdw.c
++++ b/sound/soc/intel/boards/sof_sdw.c
+@@ -851,6 +851,7 @@
+ static const struct snd_pci_quirk sof_sdw_ssid_quirk_table[] = {
+ 	SND_PCI_QUIRK(0x1043, 0x1e13, "ASUS Zenbook S14", SOC_SDW_CODEC_MIC),
+ 	SND_PCI_QUIRK(0x1043, 0x1f43, "ASUS Zenbook S16", SOC_SDW_CODEC_MIC),
++	SND_PCI_QUIRK(0x1043, 0x1464, "ASUS Zenbook S14 UX5406AA", 0),
+ 	SND_PCI_QUIRK(0x17aa, 0x2347, "Lenovo P16", SOC_SDW_CODEC_MIC),
+ 	SND_PCI_QUIRK(0x17aa, 0x2348, "Lenovo P16", SOC_SDW_CODEC_MIC),
+ 	SND_PCI_QUIRK(0x17aa, 0x2349, "Lenovo P1", SOC_SDW_CODEC_MIC),

--- a/pkgbuilds/linux-ptl/PKGBUILD
+++ b/pkgbuilds/linux-ptl/PKGBUILD
@@ -44,6 +44,7 @@ source=(
   0028-drm-i915-psr-exit-Panel-Replay-for-ALPM-lag.patch
   0029-drm-edid-populate-monitor-range-from-displayid-adaptive-sync.patch
   0030-soundwire-disable-ghost-realtek.patch
+  0031-asoc-ux5406aa-audio-layout.patch
 )
 source_x86_64=(config.x86_64)
 validpgpkeys=(
@@ -58,7 +59,8 @@ b2sums=('84b59e5572d91f5ea1bb603aa7691851bd9549e1bf18a6bec8e27eb8a6e2de2e33da2ad
         'e672cd8d1f48756cf1062f84b83b4f676504cc6b44496511816a670435e00ccc22720fcbc36d013fd9b393389b955de5ec90715429ddbdcea860e1be80ab13fd'
         '82b976261ed6f9c9ab4e30466eb91c74e94d38b489628d2de5b9974a0406a38bdec493112b84ed9f4b917662c871e70b1ea1c626d467eda245eaf7bfd973848b'
         'ed167ad347e83f072316b0d980ad192d97d0c4a69f6d1841a96089aa17caa0e57cb785214ed9297290f034420b5d0838dc75f84c7e9a9459eb49fd9dc22f3a3e'
-        '9efaeaf9db3f8812cf9d1def6b5505f15e8dba85b1767d9a758cf39ae2be68d52a8c79c779beb133b7f28268b815650ccbbd698a2ededfdeaf9d47d0c6109a6c')
+        '9efaeaf9db3f8812cf9d1def6b5505f15e8dba85b1767d9a758cf39ae2be68d52a8c79c779beb133b7f28268b815650ccbbd698a2ededfdeaf9d47d0c6109a6c'
+        'f3e0391bffe99b96f8ffe501a131082a1ab3dfe437283c6666a4f1ecfed74e73d5dd6a1ccae0ab06abd5b91deb78dcdb6721b7ba5a73d8e5a9203131c21be097')
 b2sums_x86_64=('b10d80423aa3eb65e2046bf5b1998f9a7bdbc97494c6881881f50ffcdb5fe2e242782f59dbb6402cd77ce64b988dbf295fd9fa54f20180c76fbe88b82e1dbc9d')
 
 # https://www.kernel.org/pub/linux/kernel/v7.x/sha256sums.asc
@@ -69,7 +71,8 @@ sha256sums=('ff01dcb449279d5b4cfccdb01fee639cf5ff1803f1749a77844dd33915422c49'
             '150f059eaf36580f9ca8eff4f917d8c3ee4eb5493507cbc29ce8e91b3ec56a93'
             '4a1f12817a985361c7497965b7474efb5dd8dcc36d47d04d1bb98fd1941b5901'
             '1a0bebfba76248bbda67f8812278835de71754412369454ce60f4dde0bd81916'
-            'b59277ae655f24919f2077ca2403d2eb5e5e825b82742ca4135774e3e0e68037')
+            'b59277ae655f24919f2077ca2403d2eb5e5e825b82742ca4135774e3e0e68037'
+            'e4907a63bf2182050d615907a2706f83c3d1b042c9f7c4a77674912585dbb275')
 
 export KBUILD_BUILD_HOST=archlinux
 export KBUILD_BUILD_USER=$pkgbase

--- a/pkgbuilds/linux-ptl/PKGBUILD
+++ b/pkgbuilds/linux-ptl/PKGBUILD
@@ -3,8 +3,8 @@
 
 pkgbase=linux-ptl
 pkgver=7.1.8.arch1
-pkgrel=2
-pkgdesc='Linux for Panther Lake with Panel Replay power and OLED VRR fixes'
+pkgrel=3
+pkgdesc='Linux for Panther Lake with Panel Replay, OLED VRR and SoundWire audio fixes'
 url='https://github.com/archlinux/linux'
 arch=(
   x86_64
@@ -43,6 +43,7 @@ source=(
   0020-drm-i915-alpm-limit-pr-alpm-to-panel-replay.patch
   0028-drm-i915-psr-exit-Panel-Replay-for-ALPM-lag.patch
   0029-drm-edid-populate-monitor-range-from-displayid-adaptive-sync.patch
+  0030-soundwire-disable-ghost-realtek.patch
 )
 source_x86_64=(config.x86_64)
 validpgpkeys=(
@@ -56,7 +57,8 @@ b2sums=('84b59e5572d91f5ea1bb603aa7691851bd9549e1bf18a6bec8e27eb8a6e2de2e33da2ad
         'SKIP'
         'e672cd8d1f48756cf1062f84b83b4f676504cc6b44496511816a670435e00ccc22720fcbc36d013fd9b393389b955de5ec90715429ddbdcea860e1be80ab13fd'
         '82b976261ed6f9c9ab4e30466eb91c74e94d38b489628d2de5b9974a0406a38bdec493112b84ed9f4b917662c871e70b1ea1c626d467eda245eaf7bfd973848b'
-        'ed167ad347e83f072316b0d980ad192d97d0c4a69f6d1841a96089aa17caa0e57cb785214ed9297290f034420b5d0838dc75f84c7e9a9459eb49fd9dc22f3a3e')
+        'ed167ad347e83f072316b0d980ad192d97d0c4a69f6d1841a96089aa17caa0e57cb785214ed9297290f034420b5d0838dc75f84c7e9a9459eb49fd9dc22f3a3e'
+        '9efaeaf9db3f8812cf9d1def6b5505f15e8dba85b1767d9a758cf39ae2be68d52a8c79c779beb133b7f28268b815650ccbbd698a2ededfdeaf9d47d0c6109a6c')
 b2sums_x86_64=('b10d80423aa3eb65e2046bf5b1998f9a7bdbc97494c6881881f50ffcdb5fe2e242782f59dbb6402cd77ce64b988dbf295fd9fa54f20180c76fbe88b82e1dbc9d')
 
 # https://www.kernel.org/pub/linux/kernel/v7.x/sha256sums.asc
@@ -66,7 +68,8 @@ sha256sums=('ff01dcb449279d5b4cfccdb01fee639cf5ff1803f1749a77844dd33915422c49'
             'SKIP'
             '150f059eaf36580f9ca8eff4f917d8c3ee4eb5493507cbc29ce8e91b3ec56a93'
             '4a1f12817a985361c7497965b7474efb5dd8dcc36d47d04d1bb98fd1941b5901'
-            '1a0bebfba76248bbda67f8812278835de71754412369454ce60f4dde0bd81916')
+            '1a0bebfba76248bbda67f8812278835de71754412369454ce60f4dde0bd81916'
+            'b59277ae655f24919f2077ca2403d2eb5e5e825b82742ca4135774e3e0e68037')
 
 export KBUILD_BUILD_HOST=archlinux
 export KBUILD_BUILD_USER=$pkgbase


### PR DESCRIPTION
ASUS Zenbook S14 UX5406AA audio failed on my Omarchy install: SOF could not register the sound card, leaving only Dummy Output. This packages the audio changes from my working custom Linux 7.1.8 setup for `linux-ptl`, including the effective microphone setting.

- Backport Charles Keepax's merged [SoundWire ghost-device fix](https://github.com/torvalds/linux/commit/4dab2b904414fac53535c4e4cdad808132f4cdc2), preserving its authorship and review trailers. It removes the nonexistent RT722 advertised by the BIOS. The upstream patch also covers Lenovo 83QK/83SF.
- Carry the working CS42L43 plus four-CS35L56 machine layout on links 3 and 1/2. This downstream 7.1.8 workaround comes from the approach discussed in thesofproject/linux#5754 and thesofproject/linux#5721; it is not a proposal to add new machine tables upstream.
- Set the UX5406AA SSID `1043:1464` quirk to zero. The installed custom kernel added `SOC_SDW_CODEC_MIC`, but required a later `snd_soc_sof_sdw quirk=0` override to expose the built-in microphone. Encoding the effective value for this model avoids requiring that global modprobe setting.
- Add verified SHA-256/BLAKE2 checksums and bump pkgrel to 3.

Related: #90, which carries the earlier Zenbook workaround against an older package base. This PR targets the current 7.1.8 package and includes both the upstream ghost-device fix and the working layout/microphone configuration. These related audio changes are submitted together, separately from keyboard behavior.

Validation:
- My UX5406AA, BIOS UX5406AA.303, has repeatedly booted the custom `7.1.8-arch1-3-ux5406aa` kernel with working sound. Current inspection confirms the `sof-soundwire` card and active `quirk=0` override.
- The patched Panther Lake layout file matches the working build byte-for-byte. The machine-driver file differs only in replacing the microphone-excluding quirk with the effective zero override. The upstream ghost patch retains the same ASUS address remap as the working build, with additional upstream Lenovo entries.
- Both audio patches apply without fuzz to pristine 7.1.8; the Arch patch does not alter these files.
- All three changed driver files compile against the configured 7.1.8 kernel tree.
- Kernel checkpatch reports 0 errors and 0 warnings (`--no-signoff` for the downstream layout patch).
- PKGBUILD syntax, `makepkg --printsrcinfo`, checksum array lengths, all five local patch checksums, and `git diff --check` pass.
- Repository self-tests passed during preparation: sync-upstream, sync-rebuilds, omarchy-pkgs, omarchy-release.

The boot evidence is from the installed custom kernel, not a full build/boot of this exact `linux-ptl` artifact. Moving the microphone override into the SSID table is source-verified and compile-tested, not separately boot-tested. Lenovo models have not been tested here. Existing `skip_build: true` package policy is unchanged.
