### PR TITLE
fix(flea): detect O_NOFOLLOW after the 0.1.4 refactor

### DIFF
--- a/pkgbuilds/flea/.omarchy/upstream.sh
+++ b/pkgbuilds/flea/.omarchy/upstream.sh
@@ -76,6 +76,7 @@ mediaprobe_rs=$(tar -xOzf "$tarball" "$expected_root/src/backend/mediaprobe.rs")
 metareq_rs=$(tar -xOzf "$tarball" "$expected_root/src/backend/metareq.rs")
 sharelink_qml=$(tar -xOzf "$tarball" "$expected_root/ui/ShareLink.qml")
 copyfile_rs=$(tar -xOzf "$tarball" "$expected_root/src/backend/copyfile.rs")
+regfile_rs=$(tar -xOzf "$tarball" "$expected_root/src/backend/regfile.rs" 2>/dev/null || true)
 
 if ! grep -Fq 'a.push("--".to_string());' <<<"$archive_rs" ||
   ! grep -Fq 'let input = std::fs::canonicalize(input)' <<<"$archiveops_rs" ||
@@ -84,7 +85,9 @@ if ! grep -Fq 'a.push("--".to_string());' <<<"$archive_rs" ||
   ! grep -Fq 'if !sandbox::available()' <<<"$mediaprobe_rs" ||
   ! grep -Fq 'if !sandbox::available()' <<<"$metareq_rs" ||
   ! grep -Fq 'copyToClipboard.command = ["wl-copy", url]' <<<"$sharelink_qml" ||
-  ! grep -Fq '.custom_flags(O_NOFOLLOW)' <<<"$copyfile_rs"; then
+  ! { grep -Fq '.custom_flags(O_NOFOLLOW)' <<<"$copyfile_rs" ||
+      { grep -Fq 'open_if_regular(src, O_NOFOLLOW)' <<<"$copyfile_rs" &&
+        grep -Fq 'custom_flags(O_NONBLOCK | extra_flags)' <<<"$regfile_rs"; }; }; then
   printf 'Release %s does not contain every required upstream security fix\n' "$best_tag" >&2
   exit 1
 fi

--- a/pkgbuilds/flea/PKGBUILD
+++ b/pkgbuilds/flea/PKGBUILD
@@ -76,7 +76,11 @@ prepare() {
         grep -Fq 'copyToClipboard.command = ["wl-copy", url]' ui/ShareLink.qml
         ;;
       b4b7ee47244b52457eec2874e21a8656d8ace647)
-        grep -Fq '.custom_flags(O_NOFOLLOW)' src/backend/copyfile.rs
+        # 0.1.4 moved the open behind regfile::open_if_regular and the flag into src/oflags.rs, which
+        # also gave it the correct aarch64 value; either spelling carries the fix.
+        grep -Fq '.custom_flags(O_NOFOLLOW)' src/backend/copyfile.rs ||
+          { grep -Fq 'open_if_regular(src, O_NOFOLLOW)' src/backend/copyfile.rs &&
+            grep -Fq 'custom_flags(O_NONBLOCK | extra_flags)' src/backend/regfile.rs; }
         ;;
       *)
         return 1


### PR DESCRIPTION
The b4b7ee4 check greps `copyfile.rs` for a literal `.custom_flags(O_NOFOLLOW)` that Flea 0.1.4 moved behind `regfile::open_if_regular`, so `upstream.sh` has refused every release since and flea is pinned at 0.1.3 -> both sites now accept either spelling, verified present on v0.1.3, v0.1.4 and v0.1.5.