### PR TITLE
Fix ARM Snapper dependency and first-run keyboard service packaging

### DIFF
--- a/pkgbuilds/omarchy-dev/PKGBUILD
+++ b/pkgbuilds/omarchy-dev/PKGBUILD
@@ -44,6 +44,7 @@ depends=(
 
   # System font (UI assumes it)
   'ttf-jetbrains-mono-nerd-basic'
+  'snapper' # Root snapshots also apply to btrfs installations on Apple Silicon.
 )
 
 # Bootloader stack. Lives here rather than on omarchy-settings because
@@ -57,11 +58,10 @@ depends_x86_64=(
   'limine'
   'limine-mkinitcpio-hook'
   'limine-snapper-sync'
-  'snapper'
 )
 
 # Apple Silicon boots through m1n1 + GRUB from the Asahi packages and keeps
-# Arch Linux ARM's kernel and boot layout, so the Limine/Snapper stack does not
+# Arch Linux ARM's kernel and boot layout, so the Limine stack does not
 # apply. Wi-Fi on the Broadcom parts only scans reliably through the iwd
 # backend, which install/hardware/network.sh selects on Apple Silicon.
 depends_aarch64=(

--- a/pkgbuilds/omarchy-settings-dev/PKGBUILD
+++ b/pkgbuilds/omarchy-settings-dev/PKGBUILD
@@ -193,6 +193,11 @@ package() {
   install -Dm644 default/systemd/user/omarchy-tailscale-receive.service "$pkgdir/usr/lib/systemd/user/omarchy-tailscale-receive.service"
   install -Dm644 default/systemd/user/omarchy-fcitx5.service "$pkgdir/usr/lib/systemd/user/omarchy-fcitx5.service"
   install -Dm644 default/systemd/user/omarchy-crash-watch.service "$pkgdir/usr/lib/systemd/user/omarchy-crash-watch.service"
+  # Newer source trees enable this at first login; older pinned releases do
+  # not contain or request the unit. Keep both source layouts buildable.
+  if [[ -f default/systemd/user/omarchy-brightness-keyboard-auto.service ]]; then
+    install -Dm644 default/systemd/user/omarchy-brightness-keyboard-auto.service "$pkgdir/usr/lib/systemd/user/omarchy-brightness-keyboard-auto.service"
+  fi
   # Marks app.slice (and only app.slice) as a systemd-oomd kill candidate, so
   # memory pressure costs one app scope instead of the compositor session.
   # Thresholds live in etc/systemd/oomd.conf.d/10-omarchy.conf. Both this and

--- a/pkgbuilds/omarchy-settings/PKGBUILD
+++ b/pkgbuilds/omarchy-settings/PKGBUILD
@@ -188,6 +188,11 @@ package() {
   install -Dm644 default/systemd/user/omarchy-tailscale-receive.service "$pkgdir/usr/lib/systemd/user/omarchy-tailscale-receive.service"
   install -Dm644 default/systemd/user/omarchy-fcitx5.service "$pkgdir/usr/lib/systemd/user/omarchy-fcitx5.service"
   install -Dm644 default/systemd/user/omarchy-crash-watch.service "$pkgdir/usr/lib/systemd/user/omarchy-crash-watch.service"
+  # Newer source trees enable this at first login; older pinned releases do
+  # not contain or request the unit. Keep both source layouts buildable.
+  if [[ -f default/systemd/user/omarchy-brightness-keyboard-auto.service ]]; then
+    install -Dm644 default/systemd/user/omarchy-brightness-keyboard-auto.service "$pkgdir/usr/lib/systemd/user/omarchy-brightness-keyboard-auto.service"
+  fi
   # Marks app.slice (and only app.slice) as a systemd-oomd kill candidate, so
   # memory pressure costs one app scope instead of the compositor session.
   # Thresholds live in etc/systemd/oomd.conf.d/10-omarchy.conf. Both this and

--- a/pkgbuilds/omarchy/PKGBUILD
+++ b/pkgbuilds/omarchy/PKGBUILD
@@ -58,6 +58,7 @@ depends=(
 
   # System font (UI assumes it)
   'ttf-jetbrains-mono-nerd-basic'
+  'snapper' # Root snapshots also apply to btrfs installations on Apple Silicon.
 )
 
 # Bootloader stack. Lives here rather than on omarchy-settings because
@@ -71,11 +72,10 @@ depends_x86_64=(
   'limine'
   'limine-mkinitcpio-hook'
   'limine-snapper-sync'
-  'snapper'
 )
 
 # Apple Silicon boots through m1n1 + GRUB from the Asahi packages and keeps
-# Arch Linux ARM's kernel and boot layout, so the Limine/Snapper stack does not
+# Arch Linux ARM's kernel and boot layout, so the Limine stack does not
 # apply. Wi-Fi on the Broadcom parts only scans reliably through the iwd
 # backend, which install/hardware/network.sh selects on Apple Silicon.
 depends_aarch64=(


### PR DESCRIPTION
## Summary

- Require Snapper on aarch64 as well as x86_64 in both desktop recipes; only the Limine stack remains x86-specific. Fresh btrfs Apple Silicon installs need Snapper for root configuration.
- Install `omarchy-brightness-keyboard-auto.service` into systemd's user-unit directory from both settings recipes when the source contains it. Current Mac first-run setup requires this unit; its omission prevents the completion marker and repeats the notification stack.
- Keep the existing stable source pin buildable: it does not contain this newer unit, so installation is conditional. Source pins and release versions are unchanged.

## Verification

- Shell syntax and `git diff --check` pass.
- The companion desktop regression test executes the real package functions for all eight stable/development × aarch64/x86_64 × current-source/actual-stable-pin combinations. All pass; current-source cases verify every unit requested by the real first-run leaf.
- Full ISO/rootfs rebuild with local desktop/settings packages `4.0.2-5` and Snapper `0.13.1-3`, followed by a fresh encrypted M3 (j613) install: Snapper configuration and factory snapshot present, first-run marker complete, required user services enabled. Tester subsequently confirmed reboot and no repeated alerts.
- This is source for review, not a production release/publish operation; the local test build supplied its own package release override.

## Related work

- Desktop companion: https://github.com/omarchy-mac/omarchy-mac/pull/372 (regression test and explicit Snapper setup diagnostics).
- Installer companion: https://github.com/omarchy-mac/omarchy-mac-iso/pull/19.
- Related but separate desktop repair/build-wrapper approach: https://github.com/omarchy-mac/omarchy-mac/pull/367. This PR fixes the underlying upstream recipes; it does not change that PR or its migration.
