### PR TITLE
1password: start at a fixed device scale factor

### DIFF
--- a/pkgbuilds/1password/PKGBUILD
+++ b/pkgbuilds/1password/PKGBUILD
@@ -1,6 +1,6 @@
 pkgname=1password
 pkgver=8.12.34
-pkgrel=35
+pkgrel=36
 conflicts=('1password-beta' '1password-beta-bin')
 pkgdesc="Password manager and secure wallet"
 arch=('x86_64' 'aarch64')
@@ -50,6 +50,12 @@ package() {
     done
     # Install desktop file
     install -Dm0644 resources/1password.desktop -t "${pkgdir}"/usr/share/applications/
+
+    # 1Password reads the display scale itself, the way Electron apps do, and
+    # comes up oversized next to every other window on a scaled monitor. Pin it
+    # and let the compositor do the scaling.
+    sed -i 's|^Exec=.*|Exec=/opt/1Password/1password --force-device-scale-factor=1 %U|' \
+        "${pkgdir}/usr/share/applications/1password.desktop"
 
     # Fill in policy kit file with a list of (the first 10) human users of the system.
     export POLICY_OWNERS


### PR DESCRIPTION
1Password reads the display scale itself, the way Electron apps do, so on a scaled monitor it comes up oversized next to every other window. Pin it with `--force-device-scale-factor=1` in the `.desktop` we install, and let the compositor do the scaling.

Rewriting `Exec=` on the way into `$pkgdir` is the existing idiom here — `spotify`, `perplexity`, `sublime-text-4`, `t3code-bin` and `localsend-bin` all do it.

Only the stable package. `1password-beta` is `"source": "aur"` in its `.omarchy/package.json`, so a patch there would be overwritten by the next `chore: sync AUR packages`; `1password` is `"source": "local"`, which is why this one holds.

Fixing it in the package means the app menu, `xdg-open` on a `onepassword://` link, and anything else that goes through the desktop entry all get it, with no user-level override shadowing the packaged entry. The omarchy side keeps a matching flag in `omarchy-launch-1password` for the `Super + Shift + /` hotkey, which runs the binary directly and never reads this file — omacom/omarchy#10673.

### Testing

Ran the `sed` against the real vendor entry from the installed package; it produces `Exec=/opt/1Password/1password --force-device-scale-factor=1 %U` and `desktop-file-validate` passes. `pkgrel` bumped so the rebuild ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JB9phxP56gnP7qSidkkUJE
