### PR TITLE
Add omadesign-bin 0.0.4alpha for ARM64 and x86_64

### DIFF
--- a/pkgbuilds/omadesign-bin/.omarchy/package.json
+++ b/pkgbuilds/omadesign-bin/.omarchy/package.json
@@ -1,0 +1,3 @@
+{
+  "source": "local"
+}

--- a/pkgbuilds/omadesign-bin/PKGBUILD
+++ b/pkgbuilds/omadesign-bin/PKGBUILD
@@ -1,0 +1,47 @@
+# Maintainer: michaelmonetized (https://github.com/michaelmonetized)
+pkgname=omadesign-bin
+pkgver=0.0.3alpha
+pkgrel=1
+pkgdesc='Native Linux studio for design, painting, photography, and motion (alpha binary release)'
+arch=('x86_64' 'aarch64')
+url='https://github.com/michaelmonetized/omadesign'
+license=('MIT' 'CDDL-1.0')
+# Window-system and GPU libraries are loaded at runtime, so ELF NEEDED alone
+# does not describe the complete dependency set. fontconfig supplies fc-match
+# and fc-list; dialogs use the desktop portal.
+depends=('glibc' 'fontconfig' 'hicolor-icon-theme' 'libglvnd' 'libx11'
+         'libxcursor' 'libxi' 'libxrandr' 'libxkbcommon' 'libxkbcommon-x11'
+         'vulkan-icd-loader' 'wayland' 'xdg-desktop-portal')
+optdepends=('vulkan-driver: GPU rendering with a Vulkan-capable driver'
+            'xdg-desktop-portal-impl: file picker backend for your desktop'
+            'ghostscript: EPS and PostScript-based Illustrator import')
+provides=("omadesign=$pkgver")
+conflicts=('omadesign')
+# Preserve the release binary already validated and stripped upstream.
+options=('!strip' '!debug')
+# Arch versions cannot contain hyphens; upstream tags and assets do.
+_release=${pkgver/alpha/-alpha}
+source_x86_64=("$url/releases/download/v$_release/omadesign-$_release-x86_64-unknown-linux-gnu.tar.gz")
+source_aarch64=("$url/releases/download/v$_release/omadesign-$_release-aarch64-unknown-linux-gnu.tar.gz")
+sha256sums_x86_64=('43df236e024caff47aa9ea89b9f5c8fdcc41d155b59a03dfdcd7eb49b7762436')
+sha256sums_aarch64=('da96eef59bc30e92c4f76b3a66cf04ad388dc3a7993f21d631eea4b8be76edb7')
+
+package() {
+  local release_dir="$srcdir/omadesign-$_release-$CARCH-unknown-linux-gnu"
+  install -Dm755 "$release_dir/omadesign" "$pkgdir/usr/bin/omadesign"
+  install -Dm644 "$release_dir/omadesign.desktop" "$pkgdir/usr/share/applications/omadesign.desktop"
+  install -Dm644 "$release_dir/omadesign.svg" "$pkgdir/usr/share/icons/hicolor/scalable/apps/omadesign.svg"
+  install -Dm644 "$release_dir/omadesign-mime.xml" "$pkgdir/usr/share/mime/packages/omadesign.xml"
+  install -Dm644 "$release_dir/README.md" "$pkgdir/usr/share/doc/omadesign/README.md"
+  install -Dm644 "$release_dir/LICENSE" "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+  install -Dm644 "$release_dir/LICENSE-Phosphor" "$pkgdir/usr/share/licenses/$pkgname/LICENSE-Phosphor"
+  # The unchanged LibRaw source is part of upstream's CDDL distribution.
+  # Keep every bundled source archive and native-library notice together.
+  local notice
+  for notice in "$release_dir"/licenses/libraw/*; do
+    install -Dm644 "$notice" "$pkgdir/usr/share/omadesign/licenses/libraw/${notice##*/}"
+  done
+  for notice in "$release_dir"/licenses/native-notices/*; do
+    install -Dm644 "$notice" "$pkgdir/usr/share/omadesign/licenses/native-notices/${notice##*/}"
+  done
+}

--- a/pkgbuilds/omadesign-bin/PKGBUILD
+++ b/pkgbuilds/omadesign-bin/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: michaelmonetized (https://github.com/michaelmonetized)
 pkgname=omadesign-bin
-pkgver=0.0.3alpha
+pkgver=0.0.4alpha
 pkgrel=1
 pkgdesc='Native Linux studio for design, painting, photography, and motion (alpha binary release)'
 arch=('x86_64' 'aarch64')
@@ -23,8 +23,8 @@ options=('!strip' '!debug')
 _release=${pkgver/alpha/-alpha}
 source_x86_64=("$url/releases/download/v$_release/omadesign-$_release-x86_64-unknown-linux-gnu.tar.gz")
 source_aarch64=("$url/releases/download/v$_release/omadesign-$_release-aarch64-unknown-linux-gnu.tar.gz")
-sha256sums_x86_64=('43df236e024caff47aa9ea89b9f5c8fdcc41d155b59a03dfdcd7eb49b7762436')
-sha256sums_aarch64=('da96eef59bc30e92c4f76b3a66cf04ad388dc3a7993f21d631eea4b8be76edb7')
+sha256sums_x86_64=('f52b13a2562ac50573ab11791ab55655a79f01782465af38907e19182bc0b59c')
+sha256sums_aarch64=('0ac8e506d2965f24a2d0c25439815a311b0edfef8e4388ce056435bb535c09b2')
 
 package() {
   local release_dir="$srcdir/omadesign-$_release-$CARCH-unknown-linux-gnu"


### PR DESCRIPTION
Adds **omadesign**, a native Rust/egui application for vector design, painting, RAW photo development, and motion. It follows Omarchy’s theme and desktop font. This is a submission from the application’s maintainer; no existing package was found in this repository or the AUR.

The package uses the verified [v0.0.4-alpha release](https://github.com/michaelmonetized/omadesign/releases/tag/v0.0.4-alpha), built from `44bb814241330f35aa5157e8f7362ca37f4c3ee6`. This update includes rotated-node editing, canvas-axis flips, and context-menu targeting corrections. [Project and screenshots](https://github.com/michaelmonetized/omadesign) · [Manual and format limitations](https://michaelmonetized.github.io/omadesign/docs/manual)

### Packaging

- Both `aarch64` and `x86_64` upstream archives are pinned with SHA-256 checksums. Binaries are preserved byte-for-byte; no source compilation or download of extra application content occurs during packaging.
- Installs the executable, desktop entry, scalable icon, MIME definitions, and documentation in standard `/usr` locations. No install script, user-configuration edits, MIME-default changes, privileges, or services.
- Retains MIT/Phosphor notices plus the unchanged LibRaw source archive and its CDDL/native-library notices shipped upstream.
- Minimal `source: local` metadata follows the normal repository pipeline. Updates will be maintained through version/checksum PRs. Arch uses `0.0.4alpha` because `pkgver` cannot contain the upstream tag’s hyphen; no incompatible automatic GitHub-version mapping is enabled.

### Validation

- Public downloads match their published checksum sidecars and the independently verified release hashes.
- `makepkg` builds both packages in an isolated, updated Arch Linux ARM container; the x86 package repackages its prebuilt payload without executing it. Both package binaries match the released binaries exactly.
- ARM package install → `omadesign --version` → `pacman -Qkk` → uninstall passes in the container (`42 total files, 0 altered files`). Desktop/MIME hooks run on install and removal. Launcher validation, icon/MIME/license presence, ownership, file modes, and package paths were inspected.
- Exact released payloads launch in actual ARM64 and x86_64 Wayland sessions. Independent x86 archive checks exercised both version flags, SVG → editable OMA → PNG conversion, and two native Vulkan/WGPU captures in an isolated temporary directory. [Release QA and native interaction evidence](https://github.com/michaelmonetized/omadesign/pull/46).
- Both ELFs have a GLIBC symbol ceiling of 2.35. The x86 binary additionally executed both version flags with Ubuntu's GLIBC 2.35 loader and libraries on the native x86 machine.
- Both repository build-plan dry runs pass. `.SRCINFO` was generated and checked locally, and is omitted here according to this repository’s ignore convention.

### Reviewed lint warnings and alpha limits

`namcap 3.6.0` reports warnings, no errors. Its shared-library cache assumes x86 architectures, so ARM libc/libm appear unresolved despite being owned by installed `glibc` and the packaged binary executing successfully; the x86 loader is also absent from the ARM container. “May not be needed” warnings are expected for the runtime-loaded window/GPU libraries, fontconfig commands, and desktop portals. The PKGBUILD’s literal x86 architecture name is intentional in its architecture-specific source array.

The application is still **alpha**. Document interchange has documented limits; Photo folder batches apply adjustment/settings sidecars while pixel export remains one active image at a time. Core editing is local and requires no account; optional font/asset browsing uses network services. A suitable GPU driver and desktop portal backend are needed, and Ghostscript is optional for PostScript imports. No package-repository signing or publishing commands were run.

