### PR TITLE
Package the generic fingerprint manager and T1Bridge stack

### DIFF
--- a/pkgbuilds/fingerprint-tui/.omarchy/package.json
+++ b/pkgbuilds/fingerprint-tui/.omarchy/package.json
@@ -1,0 +1,3 @@
+{
+  "source": "local"
+}

--- a/pkgbuilds/fingerprint-tui/PKGBUILD
+++ b/pkgbuilds/fingerprint-tui/PKGBUILD
@@ -1,5 +1,5 @@
 pkgname=fingerprint-tui
-pkgver=0.1.0
+pkgver=0.1.1
 pkgrel=1
 pkgdesc='Fingerprint manager for fprintd, including Apple Touch ID'
 arch=('any')
@@ -9,7 +9,7 @@ depends=('python' 'python-dbus' 'python-gobject' 'sudo')
 checkdepends=('dbus')
 optdepends=('fprintd: fingerprint service and sensor drivers')
 source=("${pkgname}-${pkgver}.tar.gz::${url}/archive/refs/tags/v${pkgver}.tar.gz")
-sha256sums=('668f3b1a632a727ba0cefc2c0ad9c438c22711bb2ada57f4e8c8143c317d8f43')
+sha256sums=('b4605dbd73ee1a6685156778a2a406df29f6e2e2a22631a269f1b1bca807c940')
 
 check() {
   cd "${pkgname}-${pkgver}"

--- a/pkgbuilds/fingerprint-tui/PKGBUILD
+++ b/pkgbuilds/fingerprint-tui/PKGBUILD
@@ -1,0 +1,22 @@
+pkgname=fingerprint-tui
+pkgver=0.1.0
+pkgrel=1
+pkgdesc='Fingerprint manager for fprintd, including Apple Touch ID'
+arch=('any')
+url='https://github.com/standardagents/fingerprint-tui'
+license=('MIT')
+depends=('python' 'python-dbus' 'python-gobject' 'sudo')
+checkdepends=('dbus')
+optdepends=('fprintd: fingerprint service and sensor drivers')
+source=("${pkgname}-${pkgver}.tar.gz::${url}/archive/refs/tags/v${pkgver}.tar.gz")
+sha256sums=('668f3b1a632a727ba0cefc2c0ad9c438c22711bb2ada57f4e8c8143c317d8f43')
+
+check() {
+  cd "${pkgname}-${pkgver}"
+  make check
+}
+
+package() {
+  cd "${pkgname}-${pkgver}"
+  make install DESTDIR="$pkgdir"
+}

--- a/pkgbuilds/fprintd-t1bridge/.omarchy/package.json
+++ b/pkgbuilds/fprintd-t1bridge/.omarchy/package.json
@@ -1,0 +1,3 @@
+{
+  "source": "local"
+}

--- a/pkgbuilds/fprintd-t1bridge/PKGBUILD
+++ b/pkgbuilds/fprintd-t1bridge/PKGBUILD
@@ -1,0 +1,69 @@
+pkgname=fprintd-t1bridge
+pkgver=1.94.5
+pkgrel=8
+pkgdesc='fprintd with native duplicate detection support for T1Bridge'
+arch=('x86_64')
+url='https://github.com/standardagents/t1bridge'
+license=('GPL-2.0-or-later')
+_libfprint_t1bridge_version='1.94.100-11'
+depends=(
+  'dbus'
+  'glib2'
+  'glibc'
+  'libgcc'
+  "libfprint-t1bridge=${_libfprint_t1bridge_version}"
+  'pam'
+  'polkit'
+  'systemd'
+  'systemd-libs'
+)
+makedepends=(
+  'glib2-devel'
+  'gtk-doc'
+  'meson'
+  'pam_wrapper'
+  'python-cairo'
+  'python-dbus'
+  'python-dbusmock'
+  'python-packaging'
+)
+provides=("fprintd=${pkgver}")
+conflicts=('fprintd')
+groups=('fprint')
+options=('!debug')
+
+_commit='b54a007ccf58ac0ae074c7151b223f35cbd17306'
+_t1bridge_version='0.1.3'
+_arch_version='1.94.5-2'
+source=(
+  "fprintd-${_commit}.tar.gz::https://gitlab.freedesktop.org/libfprint/fprintd/-/archive/${_commit}/fprintd-${_commit}.tar.gz"
+  "https://linux.standardagents.ai/arch/standardagents/x86_64/t1bridge-${_t1bridge_version}.tar.gz"
+)
+sha256sums=('26be694733389ad615a93da2803aba57bcb05a0cceca2e814b2075aae9d80cfb'
+            '8a02c19b5e7a37b5ab6fe16cb913552e7357c82a5d34f78fcd7d1698d6ffecb1')
+
+prepare() {
+  cd "fprintd-${_commit}"
+  patch -Np1 -i "${srcdir}/t1bridge-${_t1bridge_version}/packaging/arch/fprintd-t1bridge/0001-Honor-driver-native-duplicate-detection.patch"
+  patch -Np1 -i "${srcdir}/t1bridge-${_t1bridge_version}/packaging/arch/fprintd-t1bridge/0002-Fix-tests-for-current-GLib.patch"
+}
+
+build() {
+  local meson_options=(
+    -D gtk_doc=true
+    -D pam_modules_dir=/usr/lib/security
+  )
+  CFLAGS+=" -ffile-prefix-map=${srcdir}=/usr/src/${pkgname}"
+
+  arch-meson "fprintd-${_commit}" build "${meson_options[@]}"
+  meson compile -C build
+}
+
+check() {
+  meson test -C build --print-errorlogs
+}
+
+package() {
+  depends+=('libfprint-2.so')
+  meson install -C build --destdir "${pkgdir}"
+}

--- a/pkgbuilds/libfprint-t1bridge/.omarchy/package.json
+++ b/pkgbuilds/libfprint-t1bridge/.omarchy/package.json
@@ -1,0 +1,3 @@
+{
+  "source": "local"
+}

--- a/pkgbuilds/libfprint-t1bridge/PKGBUILD
+++ b/pkgbuilds/libfprint-t1bridge/PKGBUILD
@@ -1,0 +1,68 @@
+pkgname=libfprint-t1bridge
+pkgver=1.94.100
+pkgrel=11
+pkgdesc='libfprint with Apple Touch ID support through T1Bridge'
+arch=('x86_64')
+url='https://github.com/standardagents/t1bridge'
+license=('LGPL-2.1-or-later' 'MIT')
+depends=(
+  'libgcc'
+  'glib2'
+  'glibc'
+  'libgudev'
+  'libgusb'
+  'openssl'
+  'pixman'
+)
+makedepends=(
+  'glib2-devel'
+  'gobject-introspection'
+  'gtk-doc'
+  'meson'
+  'python-cairo'
+  'python-gobject'
+  'systemd'
+)
+checkdepends=('cairo' 'umockdev')
+provides=("libfprint=${pkgver}" 'libfprint-2.so')
+conflicts=('libfprint')
+groups=('fprint')
+options=('!debug')
+
+_commit='3f1e2817ed01660d0b422a0283effc0e5d3e4b80'
+_t1bridge_version='0.1.3'
+_arch_version='1.94.100-1'
+source=(
+  "libfprint-${_commit}.tar.gz::https://gitlab.freedesktop.org/libfprint/libfprint/-/archive/${_commit}/libfprint-${_commit}.tar.gz"
+  "https://linux.standardagents.ai/arch/standardagents/x86_64/t1bridge-${_t1bridge_version}.tar.gz"
+)
+sha256sums=('e892f6b938c61db1956614cc143f3ad14f09b84808c790c2affe090854e540e4'
+            '8a02c19b5e7a37b5ab6fe16cb913552e7357c82a5d34f78fcd7d1698d6ffecb1')
+
+prepare() {
+  cd "libfprint-${_commit}"
+  patch -Np1 -i "${srcdir}/t1bridge-${_t1bridge_version}/packaging/arch/libfprint-t1bridge/0001-Add-T1Bridge-fingerprint-driver.patch"
+  patch -Np1 -i "${srcdir}/t1bridge-${_t1bridge_version}/packaging/arch/libfprint-t1bridge/0002-Use-relative-test-helper-path.patch"
+}
+
+build() {
+  local meson_options=(
+    -D drivers=all
+    -D installed-tests=false
+  )
+  CFLAGS+=" -ffile-prefix-map=${srcdir}=/usr/src/${pkgname}"
+  CXXFLAGS+=" -ffile-prefix-map=${srcdir}=/usr/src/${pkgname}"
+
+  arch-meson "libfprint-${_commit}" build "${meson_options[@]}"
+  meson compile -C build
+}
+
+check() {
+  meson test -C build --print-errorlogs
+}
+
+package() {
+  meson install -C build --destdir "${pkgdir}"
+  install -Dm644 "${srcdir}/t1bridge-${_t1bridge_version}/LICENSE" \
+    "${pkgdir}/usr/share/licenses/${pkgname}/T1Bridge-MIT.txt"
+}

--- a/pkgbuilds/t1bridge-dkms/.omarchy/package.json
+++ b/pkgbuilds/t1bridge-dkms/.omarchy/package.json
@@ -1,0 +1,3 @@
+{
+  "source": "local"
+}

--- a/pkgbuilds/t1bridge-dkms/PKGBUILD
+++ b/pkgbuilds/t1bridge-dkms/PKGBUILD
@@ -1,0 +1,49 @@
+pkgname=t1bridge-dkms
+pkgver=0.1.3
+pkgrel=1
+pkgdesc='Kernel modules for the Apple T1 iBridge display, camera, and private NCM link'
+arch=('x86_64')
+url='https://github.com/standardagents/t1bridge'
+license=('GPL-2.0-only' 'GPL-2.0-or-later' 'MIT')
+depends=('dkms')
+optdepends=('linux-headers: build modules for the Arch kernel')
+options=('!debug')
+source=("https://linux.standardagents.ai/arch/standardagents/x86_64/t1bridge-${pkgver}.tar.gz")
+sha256sums=('8a02c19b5e7a37b5ab6fe16cb913552e7357c82a5d34f78fcd7d1698d6ffecb1')
+backup=('etc/mkinitcpio.conf.d/t1bridge.conf')
+
+package() {
+	local source_root="${srcdir}/t1bridge-${pkgver}"
+	local dkms_root="${pkgdir}/usr/src/${pkgname}-${pkgver}"
+
+	install -d \
+		"${dkms_root}/kernel/t1-cfgsel" \
+		"${dkms_root}/kernel/appletbdrm-t1" \
+		"${dkms_root}/kernel/apple-t1-ncm" \
+		"${dkms_root}/kernel/uvcvideo-t1" \
+		"${dkms_root}/kernel/dkms"
+	install -m644 "${source_root}/kernel/t1-cfgsel/"{Makefile,t1_cfgsel.c} \
+		"${dkms_root}/kernel/t1-cfgsel/"
+	install -m644 "${source_root}/kernel/appletbdrm-t1/"{Makefile,appletbdrm.c} \
+		"${dkms_root}/kernel/appletbdrm-t1/"
+	install -m644 "${source_root}/kernel/apple-t1-ncm/"{Makefile,apple_t1_ncm.c} \
+		"${dkms_root}/kernel/apple-t1-ncm/"
+	install -m644 "${source_root}/kernel/uvcvideo-t1/"{Makefile,uvc_*.c,uvc_*.h,uvcvideo.h} \
+		"${dkms_root}/kernel/uvcvideo-t1/"
+	install -m644 "${source_root}/kernel/dkms/Makefile" \
+		"${dkms_root}/kernel/dkms/Makefile"
+	install -Dm644 "${source_root}/kernel/dkms/dkms.conf" \
+		"${dkms_root}/dkms.conf"
+	install -Dm644 "${source_root}/packaging/arch/t1bridge-dkms/t1bridge.conf" \
+		"${pkgdir}/etc/mkinitcpio.conf.d/t1bridge.conf"
+	install -Dm644 "${source_root}/packaging/arch/t1bridge-dkms/t1bridge.modules-load.conf" \
+		"${pkgdir}/usr/lib/modules-load.d/t1bridge.conf"
+	install -Dm644 "${source_root}/packaging/arch/t1bridge-dkms/t1bridge.modprobe.conf" \
+		"${pkgdir}/usr/lib/modprobe.d/t1bridge.conf"
+	install -Dm644 "${source_root}/LICENSE" \
+		"${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"
+	install -Dm644 "${source_root}/kernel/LICENSE.md" \
+		"${pkgdir}/usr/share/licenses/${pkgname}/KERNEL-LICENSES.md"
+	install -Dm644 "${source_root}/LICENSES/GPL-2.0-only.txt" \
+		"${pkgdir}/usr/share/licenses/${pkgname}/GPL-2.0.txt"
+}

--- a/pkgbuilds/t1bridge/.omarchy/package.json
+++ b/pkgbuilds/t1bridge/.omarchy/package.json
@@ -1,0 +1,3 @@
+{
+  "source": "local"
+}

--- a/pkgbuilds/t1bridge/PKGBUILD
+++ b/pkgbuilds/t1bridge/PKGBUILD
@@ -1,15 +1,22 @@
 pkgname=t1bridge
 pkgver=0.1.3
-pkgrel=1
+pkgrel=2
 pkgdesc='Apple T1 iBridge userspace services'
 arch=('x86_64')
 url='https://github.com/standardagents/t1bridge'
 license=('MIT')
-depends=('gcc-libs' 'glibc' 'systemd>=256')
+depends=('gcc-libs' 'glibc' 'systemd>=256' 'util-linux-libs')
 makedepends=('cargo' 'pkgconf' 'rust' 'xz')
 options=('!debug')
-source=("https://linux.standardagents.ai/arch/standardagents/x86_64/t1bridge-${pkgver}.tar.gz")
-sha256sums=('8a02c19b5e7a37b5ab6fe16cb913552e7357c82a5d34f78fcd7d1698d6ffecb1')
+source=("https://linux.standardagents.ai/arch/standardagents/x86_64/t1bridge-${pkgver}.tar.gz"
+        "mounted-efi-discovery.patch")
+sha256sums=('8a02c19b5e7a37b5ab6fe16cb913552e7357c82a5d34f78fcd7d1698d6ffecb1'
+            '2a0659ab29eb1dd72cc21f16755329fd8d767e7684b11c78888d5427cb88135b')
+
+prepare() {
+	cd "${srcdir}/${pkgname}-${pkgver}"
+	patch -Np1 -i "${srcdir}/mounted-efi-discovery.patch"
+}
 
 build() {
 	local source_root="${srcdir}/${pkgname}-${pkgver}"

--- a/pkgbuilds/t1bridge/PKGBUILD
+++ b/pkgbuilds/t1bridge/PKGBUILD
@@ -1,0 +1,112 @@
+pkgname=t1bridge
+pkgver=0.1.3
+pkgrel=1
+pkgdesc='Apple T1 iBridge userspace services'
+arch=('x86_64')
+url='https://github.com/standardagents/t1bridge'
+license=('MIT')
+depends=('gcc-libs' 'glibc' 'systemd>=256')
+makedepends=('cargo' 'pkgconf' 'rust' 'xz')
+options=('!debug')
+source=("https://linux.standardagents.ai/arch/standardagents/x86_64/t1bridge-${pkgver}.tar.gz")
+sha256sums=('8a02c19b5e7a37b5ab6fe16cb913552e7357c82a5d34f78fcd7d1698d6ffecb1')
+
+build() {
+	local source_root="${srcdir}/${pkgname}-${pkgver}"
+
+	cd "${source_root}"
+	cargo build --locked --release \
+		-p t1-touchbar-hw --bin t1-touchbar-hw --features service
+	cargo build --locked --release \
+		-p t1-touchbar --bin t1-touchbar
+	cargo build --locked --release \
+		-p t1-daemons --bin t1-xart-storage
+	cargo build --locked --release \
+		-p t1-daemons --bin t1-ncm-ready
+	cargo build --locked --release \
+		-p t1-daemons --bin t1-keybag-relay \
+		--features keybag-relay-service
+	cargo build --locked --release \
+		-p t1-daemons --bin t1-touchid-auth \
+		--features auth-broker-service
+	cargo build --locked --release \
+		-p t1-daemons --bin t1-touchid
+	cargo build --locked --release \
+		-p t1-daemons --bin t1-legacy-recovery \
+		--features legacy-recovery
+	cargo build --locked --release \
+		-p t1-import --bin t1bridge
+}
+
+check() {
+	local source_root="${srcdir}/${pkgname}-${pkgver}"
+
+	cd "${source_root}"
+	cargo test --locked --workspace --all-targets --all-features
+	local dynamic_dependencies
+	dynamic_dependencies="$(readelf -d target/release/t1bridge)"
+	[[ "${dynamic_dependencies}" != *'Shared library: [liblzma.so.5]'* ]]
+	make -C packaging/arch/t1bridge verify PKGBUILD="${startdir}/PKGBUILD"
+}
+
+package() {
+	local source_root="${srcdir}/${pkgname}-${pkgver}"
+
+	install -Dm755 "${source_root}/target/release/t1-touchbar-hw" \
+		"${pkgdir}/usr/lib/t1bridge/t1-touchbar-hw"
+	install -Dm755 "${source_root}/target/release/t1-touchbar" \
+		"${pkgdir}/usr/lib/t1bridge/t1-touchbar"
+	install -Dm755 "${source_root}/target/release/t1-xart-storage" \
+		"${pkgdir}/usr/lib/t1bridge/t1-xart-storage"
+	install -Dm755 "${source_root}/target/release/t1-ncm-ready" \
+		"${pkgdir}/usr/lib/t1bridge/t1-ncm-ready"
+	install -Dm755 "${source_root}/target/release/t1-keybag-relay" \
+		"${pkgdir}/usr/lib/t1bridge/t1-keybag-relay"
+	install -Dm755 "${source_root}/target/release/t1-touchid-auth" \
+		"${pkgdir}/usr/lib/t1bridge/t1-touchid-auth"
+	install -Dm755 "${source_root}/target/release/t1-touchid" \
+		"${pkgdir}/usr/bin/t1-touchid"
+	install -Dm750 "${source_root}/target/release/t1-legacy-recovery" \
+		"${pkgdir}/usr/lib/t1bridge/t1-legacy-recovery"
+	install -Dm755 "${source_root}/target/release/t1bridge" \
+		"${pkgdir}/usr/bin/t1bridge"
+	install -Dm644 "${source_root}/LICENSE" \
+		"${pkgdir}/usr/share/licenses/t1bridge/LICENSE"
+	install -Dm644 "${source_root}/THIRD_PARTY_NOTICES.md" \
+		"${pkgdir}/usr/share/licenses/t1bridge/THIRD_PARTY_NOTICES.md"
+
+	install -Dm644 "${source_root}/systemd/t1-touchbar-hw.service" \
+		"${pkgdir}/usr/lib/systemd/system/t1-touchbar-hw.service"
+	install -Dm644 "${source_root}/systemd/t1-touchbar-hw.socket" \
+		"${pkgdir}/usr/lib/systemd/system/t1-touchbar-hw.socket"
+	install -Dm644 "${source_root}/systemd/t1-xart-storage@.service" \
+		"${pkgdir}/usr/lib/systemd/system/t1-xart-storage@.service"
+	install -Dm644 "${source_root}/systemd/t1-ncm-ready@.service" \
+		"${pkgdir}/usr/lib/systemd/system/t1-ncm-ready@.service"
+	install -Dm644 "${source_root}/systemd/t1bridge-keybag.service" \
+		"${pkgdir}/usr/lib/systemd/system/t1bridge-keybag.service"
+	install -Dm644 "${source_root}/systemd/t1-touchid-auth.service" \
+		"${pkgdir}/usr/lib/systemd/system/t1-touchid-auth.service"
+	install -Dm644 "${source_root}/systemd/t1-touchid-auth.socket" \
+		"${pkgdir}/usr/lib/systemd/system/t1-touchid-auth.socket"
+	install -Dm644 "${source_root}/systemd/t1bridge-fingerprint.socket" \
+		"${pkgdir}/usr/lib/systemd/system/t1bridge-fingerprint.socket"
+	install -Dm644 "${source_root}/systemd/t1bridge-import.service" \
+		"${pkgdir}/usr/lib/systemd/system/t1bridge-import.service"
+	install -Dm644 "${source_root}/systemd/user/t1-touchbar.service" \
+		"${pkgdir}/usr/lib/systemd/user/t1-touchbar.service"
+	install -Dm644 "${source_root}/systemd/80-t1bridge.preset" \
+		"${pkgdir}/usr/lib/systemd/system-preset/80-t1bridge.preset"
+	install -Dm644 "${source_root}/systemd/user/80-t1bridge.preset" \
+		"${pkgdir}/usr/lib/systemd/user-preset/80-t1bridge.preset"
+	install -Dm644 "${source_root}/systemd/t1bridge.sysusers" \
+		"${pkgdir}/usr/lib/sysusers.d/t1bridge.conf"
+	install -Dm644 "${source_root}/systemd/t1bridge.conf" \
+		"${pkgdir}/usr/lib/tmpfiles.d/t1bridge.conf"
+	install -Dm644 "${source_root}/systemd/50-t1bridge-ncm.link" \
+		"${pkgdir}/usr/lib/systemd/network/50-t1bridge-ncm.link"
+	install -Dm644 "${source_root}/systemd/99-zz-t1bridge-touchbar.rules" \
+		"${pkgdir}/usr/lib/udev/rules.d/99-zz-t1bridge-touchbar.rules"
+	install -Dm644 "${source_root}/systemd/90-t1bridge-xart.rules" \
+		"${pkgdir}/usr/lib/udev/rules.d/90-t1bridge-xart.rules"
+}

--- a/pkgbuilds/t1bridge/README.md
+++ b/pkgbuilds/t1bridge/README.md
@@ -1,0 +1,13 @@
+# T1Bridge packages
+
+These four x86_64 recipes use the pinned T1Bridge 0.1.3 source archive. Fingerprint patches and licenses come from that archive; libfprint and fprintd retain their upstream source pins. Keep `fprintd-t1bridge`'s exact `libfprint-t1bridge` dependency synchronized when updating the pair.
+
+Build the cohort together so the temporary build repository supplies the fingerprint dependency:
+
+```bash
+bin/build --arch x86_64 --package t1bridge t1bridge-dkms libfprint-t1bridge fprintd-t1bridge
+```
+
+This builds unsigned packages. Publication requires owner approval and the repository's normal release process.
+
+Admission to the ISO's selected Omarchy channel is a prerequisite for offline T1 installation. Verify a clean channel build, DKMS compilation against its kernel, and an offline installation before promotion. Local source checks and host builds do not establish channel compatibility.

--- a/pkgbuilds/t1bridge/README.md
+++ b/pkgbuilds/t1bridge/README.md
@@ -2,6 +2,8 @@
 
 These four x86_64 recipes use the pinned T1Bridge 0.1.3 source archive. Fingerprint patches and licenses come from that archive; libfprint and fprintd retain their upstream source pins. Keep `fprintd-t1bridge`'s exact `libfprint-t1bridge` dependency synchronized when updating the pair.
 
+Core release `0.1.3-2` backports mounted-ESP discovery from local T1Bridge commit `86cc359` and declares its libmount dependency. Remove the patch when the pinned source includes it. The original source archive and the patch both have fixed checksums.
+
 Build the cohort together so the temporary build repository supplies the fingerprint dependency:
 
 ```bash

--- a/pkgbuilds/t1bridge/mounted-efi-discovery.patch
+++ b/pkgbuilds/t1bridge/mounted-efi-discovery.patch
@@ -1,0 +1,141 @@
+diff --git a/crates/t1-import/c/t1_efi_roots.c b/crates/t1-import/c/t1_efi_roots.c
+index 340efbc..dab621e 100644
+--- a/crates/t1-import/c/t1_efi_roots.c
++++ b/crates/t1-import/c/t1_efi_roots.c
+@@ -8,6 +8,9 @@
+ #include <errno.h>
+ #include <fcntl.h>
+ #include <libudev.h>
++#include <libmount/libmount.h>
++#include <linux/magic.h>
++#include <linux/openat2.h>
+ #include <sched.h>
+ #include <stdint.h>
+ #include <stdio.h>
+@@ -16,6 +19,8 @@
+ #include <strings.h>
+ #include <sys/mount.h>
+ #include <sys/stat.h>
++#include <sys/statfs.h>
++#include <sys/syscall.h>
+ #include <sys/sysmacros.h>
+ #include <unistd.h>
+ 
+@@ -229,6 +234,85 @@ static int remove_unmounted_directory(char *mountpoint)
+ 	return T1_EFI_ROOTS_OK;
+ }
+ 
++/* A second read-only block mount cannot share an existing writable FAT
++ * superblock. Clone the matching full filesystem mount instead; make the
++ * detached clone read-only before exposing a directory descriptor. */
++static int clone_mounted_root(struct libmnt_fs *filesystem, dev_t device)
++{
++	struct open_how how = {
++		.flags = O_PATH | O_DIRECTORY | O_CLOEXEC,
++		.resolve = RESOLVE_NO_SYMLINKS | RESOLVE_NO_MAGICLINKS,
++	};
++	struct mount_attr attributes = {
++		.attr_set = MOUNT_ATTR_RDONLY | MOUNT_ATTR_NOSUID |
++			MOUNT_ATTR_NODEV | MOUNT_ATTR_NOEXEC | MOUNT_ATTR_NOSYMFOLLOW,
++		.propagation = MS_PRIVATE,
++	};
++	struct stat info;
++	struct statx extended;
++	struct statfs filesystem_info;
++	const char *target = mnt_fs_get_target(filesystem);
++	int anchor = -1, tree = -1, root = -1;
++	int cleanup_failed = 0;
++
++	if (target == NULL)
++		return -1;
++	anchor = (int)syscall(SYS_openat2, AT_FDCWD, target, &how, sizeof(how));
++	if (anchor < 0 || fstat(anchor, &info) < 0 || info.st_dev != device ||
++	    fstatfs(anchor, &filesystem_info) < 0 ||
++	    filesystem_info.f_type != MSDOS_SUPER_MAGIC ||
++	    statx(anchor, "", AT_EMPTY_PATH, STATX_MNT_ID, &extended) < 0 ||
++	    !(extended.stx_mask & STATX_MNT_ID) ||
++	    extended.stx_mnt_id != (uint64_t)mnt_fs_get_id(filesystem))
++		goto out;
++	tree = (int)syscall(SYS_open_tree, anchor, "",
++		OPEN_TREE_CLONE | OPEN_TREE_CLOEXEC | AT_EMPTY_PATH);
++	if (tree < 0 || syscall(SYS_mount_setattr, tree, "", AT_EMPTY_PATH,
++	    &attributes, sizeof(attributes)) < 0)
++		goto out;
++	root = open_directory_component(tree, ".");
++out:
++	if (tree >= 0 && close_owned(tree) < 0)
++		cleanup_failed = 1;
++	if (anchor >= 0 && close_owned(anchor) < 0)
++		cleanup_failed = 1;
++	if (cleanup_failed) {
++		if (root >= 0)
++			(void)close_owned(root);
++		root = -1;
++	}
++	return root;
++}
++
++static int open_mounted_root(const struct t1_efi_test_candidate *candidate)
++{
++	struct libmnt_table *table = mnt_new_table();
++	struct libmnt_iter *iterator = mnt_new_iter(MNT_ITER_FORWARD);
++	struct libmnt_fs *filesystem;
++	dev_t device = makedev(candidate->major_number, candidate->minor_number);
++	int root = -1;
++
++	if (table == NULL || iterator == NULL ||
++	    mnt_table_parse_file(table, "/proc/self/mountinfo") != 0)
++		goto out;
++	while (mnt_table_next_fs(table, iterator, &filesystem) == 0) {
++		const char *mount_root = mnt_fs_get_root(filesystem);
++		const char *type = mnt_fs_get_fstype(filesystem);
++
++		/* Subdirectory bind mounts cannot stand in for an ESP root. */
++		if (mnt_fs_get_devno(filesystem) != device || mount_root == NULL ||
++		    strcmp(mount_root, "/") != 0 || type == NULL ||
++		    strcmp(type, "vfat") != 0)
++			continue;
++		root = clone_mounted_root(filesystem, device);
++		break;
++	}
++out:
++	mnt_free_iter(iterator);
++	mnt_free_table(table);
++	return root;
++}
++
+ static int real_open_root(void *context,
+ 	const struct t1_efi_test_candidate *candidate,
+ 	unsigned long mount_flags, int *root_descriptor)
+@@ -260,11 +344,15 @@ static int real_open_root(void *context,
+ 	if (mount(source, mountpoint, "vfat", mount_flags, NULL) < 0) {
+ 		int mount_status = mount_error_status(errno);
+ 
+-		status = remove_unmounted_directory(mountpoint);
+-		return status == T1_EFI_ROOTS_OK ? mount_status : status;
++		if (errno != EBUSY) {
++			status = remove_unmounted_directory(mountpoint);
++			return status == T1_EFI_ROOTS_OK ? mount_status : status;
++		}
++		root = open_mounted_root(candidate);
++	} else {
++		mounted = 1;
++		root = open_directory_component(AT_FDCWD, mountpoint);
+ 	}
+-	mounted = 1;
+-	root = open_directory_component(AT_FDCWD, mountpoint);
+ 	if (root < 0)
+ 		goto out;
+ 	contains_apple = root_contains_apple(root);
+diff --git a/crates/t1-platform/build.rs b/crates/t1-platform/build.rs
+index 7ea9e8e..a66ee40 100644
+--- a/crates/t1-platform/build.rs
++++ b/crates/t1-platform/build.rs
+@@ -148,6 +148,7 @@ fn link_native(
+     }
+     if preserved_efi_discovery {
+         println!("cargo:rustc-link-lib=udev");
++        println!("cargo:rustc-link-lib=mount");
+     }
+ }
+ 


### PR DESCRIPTION
Add `fingerprint-tui` as a general package for Omarchy and four T1 hardware packages: `t1bridge`, `t1bridge-dkms`, `libfprint-t1bridge`, and `fprintd-t1bridge`.

The TUI pins the published 0.1.1 source and checksum. Its Python UI remains unprivileged; a short-lived sudo helper uses standard fprintd operations. fprintd is optional at package-install time, so installing the TUI on every machine neither installs a sensor driver nor replaces the T1 compatibility pair.

The T1 recipes pin the released 0.1.3 archive and its upstream fingerprint dependencies. Core 0.1.3-2 carries a checksum-pinned mounted-ESP backport; remove it when updating to a released source containing the fix. The daemon requires the exact matching library package.

Validation: all five unsigned packages build. T1 checks passed 1,004 Rust tests, 131 libfprint tests, 560 fprintd/PAM tests, and all four DKMS modules against 7.1.9 headers. Fresh T1 and generic ISO installs pass with TUI 0.1.1. All 21 tests pass against each installed package, covering generic fourth-finger enrollment, Touch ID capacity, verification, exact removal, concurrent access, and cancellation/release. The generic install does not pull in T1Bridge. Readers were simulated; physical generic-reader and Touch ID acceptance remain unverified. Maintainers must build and admit these recipes in the selected Omarchy channel before shipping an offline ISO.

Companions: [Omarchy integration](https://github.com/omacom/omarchy/pull/10694) and [EFI preservation](https://github.com/omacom/omarchy-iso/pull/162). The [TUI implementation](https://github.com/standardagents/fingerprint-tui/pull/1) and [exclusive-claim fix](https://github.com/standardagents/fingerprint-tui/pull/2) are merged.
