### PR TITLE
Update Herdr to 0.9.0

### DIFF
--- a/pkgbuilds/herdr/PKGBUILD
+++ b/pkgbuilds/herdr/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: David Heinemeier Hansson <david@hey.com>
 
 pkgname=herdr
-pkgver=0.8.2
+pkgver=0.9.0
 pkgrel=1
 pkgdesc="Herdr terminal workspace manager for AI coding agents"
 arch=('x86_64' 'aarch64')
@@ -17,7 +17,7 @@ _zigver=0.15.2
 source=("herdr-$pkgver.tar.gz::$url/archive/refs/tags/v$pkgver.tar.gz")
 source_x86_64=("zig-x86_64-linux-$_zigver.tar.xz::https://ziglang.org/download/$_zigver/zig-x86_64-linux-$_zigver.tar.xz")
 source_aarch64=("zig-aarch64-linux-$_zigver.tar.xz::https://ziglang.org/download/$_zigver/zig-aarch64-linux-$_zigver.tar.xz")
-sha256sums=('60453051025ee44ebf055d26cdaf665a0accd99a992cddd22c166a26c49cd161')
+sha256sums=('1e83bff4b05834ed8281e16f1680e8f3e58375a94b2e3f2b3d021e28e293ef9a')
 sha256sums_x86_64=('02aa270f183da276e5b5920b1dac44a63f1a49e55050ebde3aecc9eb82f93239')
 sha256sums_aarch64=('958ed7d1e00d0ea76590d27666efbf7a932281b3d7ba0c6b01b0ff26498f667f')
 


### PR DESCRIPTION
Update the Herdr package from 0.8.2 to [upstream 0.9.0](https://github.com/herdrdev/herdr/releases/tag/v0.9.0), bringing multi-machine sessions, independent client views, and fixes for Wayland clipboard hangs and session preservation during shutdown.

Bump `pkgver` and the release source SHA-256. The existing Zig 0.15.2 build recipe and package dependencies remain sufficient; release-channel metadata is unchanged.

Validation:
- Built `herdr-0.9.0-1-x86_64.pkg.tar.zst` locally on Arch/Omarchy with `mise exec rust@1.96.1 -- makepkg --nodeps --noconfirm`. Rust matches upstream's toolchain pin; `--nodeps` was used because Rust/Cargo came from mise rather than pacman.
- Source and Zig checksums passed; packaging completed successfully. The packaged executable reports `herdr 0.9.0`, and `ldd` resolves all shared libraries.
- `bash -n`, `makepkg --printsrcinfo`, and `git diff --check` passed.
- All four repository CI self-test commands passed: `sync-upstream self-test`, `sync-rebuilds --self-test`, `omarchy-pkgs self-test`, and `omarchy-release self-test`.

Not validated in a clean container or on aarch64; no running Herdr sessions were upgraded during testing.
