### PR TITLE
Add claude-desktop, Anthropic's Linux desktop beta

### DIFF
--- a/pkgbuilds/claude-desktop/.omarchy/package.json
+++ b/pkgbuilds/claude-desktop/.omarchy/package.json
@@ -1,0 +1,12 @@
+{
+  "source": "local",
+  "release_ring": "fast",
+  "upstream": {
+    "debian": "https://downloads.claude.ai/claude-desktop/apt/stable/dists/stable/main/binary-amd64/Packages",
+    "package": "claude-desktop",
+    "sources": {
+      "x86_64": ["https://downloads.claude.ai/claude-desktop/apt/stable/pool/main/c/claude-desktop/claude-desktop_{pkgver}_amd64.deb"],
+      "aarch64": ["https://downloads.claude.ai/claude-desktop/apt/stable/pool/main/c/claude-desktop/claude-desktop_{pkgver}_arm64.deb"]
+    }
+  }
+}

--- a/pkgbuilds/claude-desktop/PKGBUILD
+++ b/pkgbuilds/claude-desktop/PKGBUILD
@@ -1,0 +1,83 @@
+# Maintainer: Spencer Bull <spencerbull2554@gmail.com>
+
+# Omarchy tracks Anthropic's own Debian repository, the only channel the
+# Linux beta ships through. The declarative "debian" upstream provider in
+# .omarchy/package.json rewrites the version and checksums below from that
+# repository's package index.
+
+pkgname=claude-desktop
+pkgver=1.46388.2
+pkgrel=1
+pkgdesc="Official Claude desktop app with Claude Code"
+arch=('x86_64' 'aarch64')
+url="https://claude.ai"
+license=('custom')
+
+depends=(
+  'alsa-lib'
+  'at-spi2-core'
+  'bash'
+  'gcc-libs'
+  'glibc'
+  'gtk3'
+  'libdrm'
+  'libnotify'
+  'libsecret'
+  'libxcb'
+  'libxtst'
+  'mesa'
+  'nss'
+  'util-linux-libs'
+  'xdg-desktop-portal'
+  'xdg-utils'
+)
+
+optdepends=(
+  'gnome-keyring: store credentials in a system keyring'
+  'edk2-ovmf: UEFI firmware for the Cowork virtual machine'
+  'virtiofsd: file sharing with the Cowork virtual machine'
+)
+optdepends_x86_64=('qemu-system-x86: run Cowork tasks in a local virtual machine')
+optdepends_aarch64=('qemu-system-aarch64: run Cowork tasks in a local virtual machine')
+
+makedepends=('libarchive')
+options=('!debug' '!strip')
+
+# Omarchy: same treatment as openai-codex-desktop. The build image compresses
+# with zstd at its default level, which leaves this 560 MB Electron tree at
+# 210 MB. Maximum zstd takes it to 160 MB for ~3 extra minutes of build time
+# -- worth it for a package every user re-downloads on each of Anthropic's
+# frequent releases.
+COMPRESSZST=(zstd -c -z -q --ultra -22 --threads=0 -)
+
+_deb_x86_64="claude-desktop_${pkgver}_amd64.deb"
+_deb_aarch64="claude-desktop_${pkgver}_arm64.deb"
+source=('claude-desktop-launcher.sh')
+_pool="https://downloads.claude.ai/claude-desktop/apt/stable/pool/main/c/claude-desktop"
+source_x86_64=("${_deb_x86_64}::${_pool}/${_deb_x86_64}")
+source_aarch64=("${_deb_aarch64}::${_pool}/${_deb_aarch64}")
+noextract=("${_deb_x86_64}" "${_deb_aarch64}")
+sha256sums=('edfdbc63b65891ef7c481b07086c7e630fc102c042b6ed65331a52fcaf72b14a')
+sha256sums_x86_64=('98bf54e85e4916068c4281459b0f0431d8ff68034773f3ee98311d7206566ab1')
+sha256sums_aarch64=('b944a2154528815bb476bfb1e7091f8a3e329b3c67f6c11de8d41668a603bd9e')
+
+package() {
+  cd "${srcdir}"
+
+  local deb_var="_deb_${CARCH}"
+  local deb="${!deb_var}"
+
+  bsdtar -xOf "${deb}" data.tar.xz |
+    bsdtar --no-same-owner -xf - -C "${pkgdir}"
+
+  # Upstream's /usr/bin/claude-desktop is a bare symlink to the Electron
+  # binary; replace it with a launcher that picks the right Ozone platform.
+  rm "${pkgdir}/usr/bin/claude-desktop"
+  install -Dm755 claude-desktop-launcher.sh "${pkgdir}/usr/bin/claude-desktop"
+
+  install -Dm644 "${pkgdir}/usr/share/doc/claude-desktop/copyright" \
+    "${pkgdir}/usr/share/licenses/${pkgname}/copyright"
+
+  # Debian package-policy files are not used on Arch Linux.
+  rm -rf "${pkgdir}/usr/share/doc" "${pkgdir}/usr/share/lintian"
+}

--- a/pkgbuilds/claude-desktop/PKGBUILD
+++ b/pkgbuilds/claude-desktop/PKGBUILD
@@ -34,11 +34,16 @@ depends=(
 
 optdepends=(
   'gnome-keyring: store credentials in a system keyring'
-  'edk2-ovmf: UEFI firmware for the Cowork virtual machine'
+  'bubblewrap: Claude Code sandboxing'
+  'socat: Claude Code sandboxing'
   'virtiofsd: file sharing with the Cowork virtual machine'
 )
-optdepends_x86_64=('qemu-system-x86: run Cowork tasks in a local virtual machine')
-optdepends_aarch64=('qemu-system-aarch64: run Cowork tasks in a local virtual machine')
+optdepends_x86_64=(
+  'qemu-system-x86: run Cowork tasks in a local virtual machine'
+  'edk2-ovmf: UEFI firmware for the Cowork virtual machine'
+)
+# No Cowork optdepends on aarch64: Arch Linux ARM ships no UEFI firmware
+# package, so the app's /usr/share/AAVMF probe has nothing to resolve to.
 
 makedepends=('libarchive')
 options=('!debug' '!strip')
@@ -77,6 +82,17 @@ package() {
 
   install -Dm644 "${pkgdir}/usr/share/doc/claude-desktop/copyright" \
     "${pkgdir}/usr/share/licenses/${pkgname}/copyright"
+
+  # Cowork probes Debian's paths for its VM stack; map them onto Arch's.
+  # The links dangle harmlessly until the matching optdepends are installed.
+  install -d "${pkgdir}/usr/libexec"
+  ln -s ../lib/virtiofsd "${pkgdir}/usr/libexec/virtiofsd"
+  if [[ "${CARCH}" == x86_64 ]]; then
+    # The app derives the VARS path from the CODE path, so both need a link.
+    install -d "${pkgdir}/usr/share/edk2"
+    ln -s x64/OVMF_CODE.4m.fd "${pkgdir}/usr/share/edk2/OVMF_CODE_4M.fd"
+    ln -s x64/OVMF_VARS.4m.fd "${pkgdir}/usr/share/edk2/OVMF_VARS_4M.fd"
+  fi
 
   # Debian package-policy files are not used on Arch Linux.
   rm -rf "${pkgdir}/usr/share/doc" "${pkgdir}/usr/share/lintian"

--- a/pkgbuilds/claude-desktop/PKGBUILD
+++ b/pkgbuilds/claude-desktop/PKGBUILD
@@ -36,14 +36,14 @@ optdepends=(
   'gnome-keyring: store credentials in a system keyring'
   'bubblewrap: Claude Code sandboxing'
   'socat: Claude Code sandboxing'
-  'virtiofsd: file sharing with the Cowork virtual machine'
 )
+# Cowork is x86_64-only here: Arch Linux ARM ships no UEFI firmware package,
+# so on aarch64 the app's /usr/share/AAVMF probe has nothing to resolve to.
 optdepends_x86_64=(
   'qemu-system-x86: run Cowork tasks in a local virtual machine'
   'edk2-ovmf: UEFI firmware for the Cowork virtual machine'
+  'virtiofsd: file sharing with the Cowork virtual machine'
 )
-# No Cowork optdepends on aarch64: Arch Linux ARM ships no UEFI firmware
-# package, so the app's /usr/share/AAVMF probe has nothing to resolve to.
 
 makedepends=('libarchive')
 options=('!debug' '!strip')
@@ -85,9 +85,9 @@ package() {
 
   # Cowork probes Debian's paths for its VM stack; map them onto Arch's.
   # The links dangle harmlessly until the matching optdepends are installed.
-  install -d "${pkgdir}/usr/libexec"
-  ln -s ../lib/virtiofsd "${pkgdir}/usr/libexec/virtiofsd"
   if [[ "${CARCH}" == x86_64 ]]; then
+    install -d "${pkgdir}/usr/libexec"
+    ln -s ../lib/virtiofsd "${pkgdir}/usr/libexec/virtiofsd"
     # The app derives the VARS path from the CODE path, so both need a link.
     install -d "${pkgdir}/usr/share/edk2"
     ln -s x64/OVMF_CODE.4m.fd "${pkgdir}/usr/share/edk2/OVMF_CODE_4M.fd"

--- a/pkgbuilds/claude-desktop/claude-desktop-launcher.sh
+++ b/pkgbuilds/claude-desktop/claude-desktop-launcher.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+set -euo pipefail
+
+user_flags=()
+config_home="${XDG_CONFIG_HOME:-}"
+[[ -n "$config_home" || -z "${HOME:-}" ]] || config_home="$HOME/.config"
+flags_file="${config_home:+$config_home/claude-desktop-flags.conf}"
+
+if [[ -n "$flags_file" && -f "$flags_file" && -r "$flags_file" ]]; then
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    line="${line%%#*}"
+    [[ -n "${line//[[:space:]]/}" ]] || continue
+    read -r -a flags <<<"$line"
+    user_flags+=("${flags[@]}")
+  done <"$flags_file"
+fi
+
+# Chromium's own Ozone detection falls back to XWayland often enough to matter,
+# and the result is a blurry window on every scaled display. Ask for Wayland
+# directly, unless the user has already picked a platform themselves.
+platform_flags=()
+if [[ -n "${WAYLAND_DISPLAY:-}" || "${XDG_SESSION_TYPE:-}" == wayland ]]; then
+  platform_flags=(--ozone-platform=wayland)
+
+  for flag in "${user_flags[@]}" "$@"; do
+    case "$flag" in
+      --ozone-platform=* | --ozone-platform-hint=*) platform_flags=() ;;
+    esac
+  done
+fi
+
+exec /usr/lib/claude-desktop/claude-desktop "${platform_flags[@]}" "${user_flags[@]}" "$@"


### PR DESCRIPTION
Anthropic ships the Claude desktop app for Linux (beta since June) only through its own Debian repository at `downloads.claude.ai/claude-desktop/apt/stable`, for amd64 and arm64. This packages it the way `openai-codex-desktop` packages the ChatGPT desktop app: extract the deb's `data.tar.xz`, replace the bare `/usr/bin/claude-desktop` symlink with a launcher that asks Chromium for Wayland directly (same logic as `chatgpt-launcher.sh`, with its own `claude-desktop-flags.conf`), keep the vendor copyright as the license, and drop the Debian policy files. The app has no self-updater on Linux, so nothing needs disabling.

Updates come through the declarative `debian` upstream provider rather than a bespoke hook: Claude's versions (`1.46388.2`) are already valid Arch pkgvers, so the apt Packages index names the newest release and the two pool debs are hashed when one appears. `release_ring` is `fast`, like the other AI desktop apps.

Dependencies were mapped from the deb's control stanza and verified against `readelf -d` on the actual binary — every NEEDED soname is satisfied directly or transitively by the declared depends. Cowork (the VM-backed agent tab) needs QEMU, UEFI firmware and virtiofsd. The app probes Debian's paths for that stack — `/usr/libexec/virtiofsd`, and `/usr/share/OVMF/OVMF_CODE_4M.fd` with the VARS path derived from it — so `package()` ships symlinks mapping them onto Arch's `/usr/lib/virtiofsd` and `/usr/share/edk2/x64/*.4m.fd`, dangling harmlessly until the optdepends are installed. Every Cowork optdepend and shim is x86_64-only: Arch Linux ARM, which the aarch64 builds run against, ships no UEFI firmware package, so on that arch there is no VM to promise and the aarch64 package carries no Cowork pieces at all. The embedded Claude Code names bubblewrap and socat as its sandbox dependencies; both are optdepends, matching the standalone `claude-code` package.

Verified:
- `bin/sync-upstream claude-desktop` round-trip: pinned the PKGBUILD to 1.44121.2, the sync rewrote it to 1.46388.2 byte-identical to the checked-in file, and reports no update when current.
- `makepkg` smoke test of `package()` against the real amd64 deb: launcher, license, doc/lintian cleanup, the chrome-sandbox setuid bit, and the Cowork shims all come out right; installed alongside `edk2-ovmf` and `virtiofsd`, every path the app probes resolves to the real file and virtiofsd executes through its shim.
- The built package installs on stock Omarchy and launches to its welcome screen as a native Wayland window (`com.anthropic.Claude`) under Hyprland.
- The zstd numbers in the COMPRESSZST comment are measured on this payload (210 MB default vs 160 MB at `--ultra -22`, ~3 minutes extra).

One known gap, shared with `1password`: the `debian` provider reads a single index (binary-amd64) and substitutes that version into both arch URLs. If Anthropic ever lands amd64 before arm64, that sync run fails loudly on the arm64 404 and self-heals on the next run once both are published. `openai-codex-desktop`'s hook handles that race by comparing both indexes; if it shows up in practice here, the fix belongs in the generic provider rather than another bespoke hook.

