### PR TITLE
Add tb-ar-shim-dkms: Alpine Ridge suspend fix for the MacBookPro14,1

### DIFF
--- a/pkgbuilds/tb-ar-shim-dkms/.omarchy/package.json
+++ b/pkgbuilds/tb-ar-shim-dkms/.omarchy/package.json
@@ -1,0 +1,10 @@
+{
+  "source": "local",
+  "upstream": {
+    "git_tags": "https://github.com/orospakr/linux-apple-alpine-ridge-suspend.git",
+    "tag_pattern": "v{pkgver}",
+    "sources": {
+      "any": ["https://github.com/orospakr/linux-apple-alpine-ridge-suspend/archive/refs/tags/{tag}.tar.gz"]
+    }
+  }
+}

--- a/pkgbuilds/tb-ar-shim-dkms/PKGBUILD
+++ b/pkgbuilds/tb-ar-shim-dkms/PKGBUILD
@@ -1,0 +1,20 @@
+# Maintainer: Andrew Clunis <andrew@orospakr.ca>
+_pkgbase=tb-ar-shim
+_repo=linux-apple-alpine-ridge-suspend
+pkgname=tb-ar-shim-dkms
+pkgver=1.0.0
+pkgrel=1
+pkgdesc="Suspend/resume fix for the Alpine Ridge Thunderbolt controller on Apple MacBookPro14,x (DKMS)"
+arch=('x86_64')
+url="https://github.com/orospakr/$_repo"
+license=('GPL-2.0-only')
+depends=('dkms')
+source=("$pkgname-$pkgver.tar.gz::$url/archive/refs/tags/v$pkgver.tar.gz")
+sha256sums=('30ceacceabe854904ef4d555e225e9901c17fd7b524f075c4a17de8e7b2a8b9c')
+
+package() {
+  cd "$_repo-$pkgver"
+  install -Dm644 -t "$pkgdir/usr/src/$_pkgbase-$pkgver" \
+    module/tb_ar_shim.c module/Makefile module/dkms.conf
+  install -Dm644 -t "$pkgdir/usr/share/doc/$pkgname" README.md
+}


### PR DESCRIPTION
Adds `tb-ar-shim-dkms`, a temporary (`[FOR-UPSTREAM]`) DKMS package fixing suspend/resume of the Alpine Ridge Thunderbolt 3 controller on the Apple MacBookPro14,1, per the investigation in omacom/omarchy#10593.

**Shape:** the same as `qmk-hid` / `tzupdate` — a `"source": "local"` PKGBUILD that fetches a tag tarball from the module's own public repo, https://github.com/orospakr/linux-apple-alpine-ridge-suspend, with a `git_tags` upstream provider in `package.json` so `sync-upstream` opens the version bumps. What omarchy-pkgs carries is the PKGBUILD and the metadata (~35 lines); the module source, its README, the in-tree `drivers/pci/quirks.c` patch headed to linux-pci, and the CI that builds the module against Arch `linux`/`linux-lts` headers and re-checks the upstream patch against pci-next weekly all live in that repo. (An earlier revision of this PR vendored the C source here; this is the slimmed-down replacement.)

**What it fixes:** two kernel bugs on this machine, both of which leave Thunderbolt and the USB-C ports dead after every suspend:

1. **deep/S3:** the PCI core saves the controller's bridge config space *after* the thunderbolt driver has already put the chip to sleep, so it saves all-ones and restores garbage on wake — 75–107 s resumes, dead NHI, hot-removed xHCI.
2. **s2idle:** the core skips config restore entirely (`skip_bus_pm` + `pm_suspend_no_platform()`), but this controller genuinely loses its config space during sleep — dead NHI (`-ESHUTDOWN`) until module reload.

The module grafts a `dev_pm_domain` onto the controller's upstream bridge: saves the subtree's config space in `suspend_late` (while the chip is still readable) and restores it parents-first in `resume_noirq`. It autoloads by PCI modalias and verifies the on-board controller via Apple's ACPI signature (same trick as the mainline Cactus Ridge quirk), so it exits `-ENODEV` everywhere else.

**Validation:** 28/28 suspend cycles on a MacBookPro14,1 across both sleep modes, 1.3–1.4 s resumes; the previous revision of this exact module was installed via pacman, dkms-built, and verified through a cold boot (modalias autoload + suspend). `makepkg` of this revision verified locally against the v1.0.0 tag tarball; the module source is byte-identical apart from one comment line pointing at the new repo.

**Sunset:** documented in the upstream repo README — once the quirks land in mainline and every bootable kernel has them, the package is removed with `pacman -Rns`. The companion install-script/migration PR omacom/omarchy#10758 (gating on the exact DMI model and defaulting the machine to s2idle) depends on this package being published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014SjBV8RAyo6et6LMmurU9W
