### PR TITLE
Add: ColliePWA, a phone web UI for herdr/tmux/zellij

### DIFF
--- a/pkgbuilds/collie-bin/.omarchy/package.json
+++ b/pkgbuilds/collie-bin/.omarchy/package.json
@@ -1,4 +1,5 @@
 {
+  "source": "local",
   "upstream": {
     "github": "AltanS/collie",
     "digests": true,

--- a/pkgbuilds/collie-bin/.omarchy/package.json
+++ b/pkgbuilds/collie-bin/.omarchy/package.json
@@ -1,0 +1,10 @@
+{
+  "upstream": {
+    "github": "AltanS/collie",
+    "digests": true,
+    "assets": {
+      "x86_64": "collie-{pkgver}-linux-x64.tar.gz",
+      "aarch64": "collie-{pkgver}-linux-arm64.tar.gz"
+    }
+  }
+}

--- a/pkgbuilds/collie-bin/PKGBUILD
+++ b/pkgbuilds/collie-bin/PKGBUILD
@@ -16,7 +16,7 @@
 
 pkgname=collie-bin
 _pkgname=collie
-pkgver=1.6.0
+pkgver=1.8.0
 pkgrel=1
 pkgdesc="Phone web UI for the AI agents running in your terminal, served over Tailscale (official binary release)"
 arch=('x86_64' 'aarch64')
@@ -69,8 +69,8 @@ source_aarch64=("$pkgname-$pkgver-aarch64.tar.gz::$_baseurl/collie-$pkgver-linux
 # three lines — `pkgver` above and the two arrays below — are the only ones
 # `scripts/refresh-packages.ts` rewrites, and it copies them from that manifest. Nothing here
 # hashes a file itself.
-sha256sums_x86_64=('ec4dfec7d14b22e6ad9393e841249e97299717239caef3b1b7c32fddc062e1a7')
-sha256sums_aarch64=('7b242bbcbb382aa080a345e81c83bda79fea204ac4806bd184ff33c35b2fd070')
+sha256sums_x86_64=('0b6ceeb73b2d13319587491be7d7c941fdcb875c484886d5622922eae2918164')
+sha256sums_aarch64=('e85ad44297800d1106e3b9c10e365155866b9736ab44e8be11e4689d51091cb4')
 
 # The tarball's own directory name, which carries the upstream platform spelling rather than $CARCH.
 _distdir() {

--- a/pkgbuilds/collie-bin/PKGBUILD
+++ b/pkgbuilds/collie-bin/PKGBUILD
@@ -1,0 +1,125 @@
+# Maintainer: Altan Sarisin <altan@sportsight.de>
+#
+# We author, publish and maintain this package ourselves, and nobody else is named here.
+# Prior art: Niko Lehtovirta's unpublished collie-bin PKGBUILD arrived at the same one-prefix
+# layout, and reading it confirmed the shape below. That is the whole of the relationship.
+#
+# ONE PKGBUILD serves two channels: the AUR, and Omarchy's own package repository
+# (omacom/omarchy-pkgs, which copies this file to pkgbuilds/collie-bin/PKGBUILD). The install root
+# is /opt/collie because that is the layout that repository expects of an application that ships a
+# whole tree — a thin /usr/bin symlink into /opt/<name> — and it is a layout the AUR is equally
+# happy with. See packaging/omarchy/README.md.
+
+# Collie ships a compiled Bun single-file executable in every GitHub release, so this package
+# downloads that tarball and installs it. Nothing is built here: no Bun, no git fetch, no
+# compilation. `pkgver` below is the only place the version is written.
+
+pkgname=collie-bin
+_pkgname=collie
+pkgver=1.6.0
+pkgrel=1
+pkgdesc="Phone web UI for the AI agents running in your terminal, served over Tailscale (official binary release)"
+arch=('x86_64' 'aarch64')
+url="https://github.com/AltanS/collie"
+license=('MIT')
+
+# glibc: the only shared-library set the executable links (libc, libm, libpthread, libdl and the
+#        dynamic loader all come from it) — everything else Bun statically links.
+# bash:  every action in the shipped herdr-plugin.toml is spelled `bash scripts/collie-ctl.sh …`
+#        and those command strings are frozen byte-for-byte (ADR 0006).
+#
+# `systemd` is NOT listed. `collie start` writes a `systemd --user` unit and drives it with
+# `systemctl --user`, and without one the CLI drops to its unsupervised tier — but systemd is the
+# init of every Arch and Omarchy host, so naming it buys nothing and Omarchy's repository does not
+# carry bare `systemd` in a depends array.
+depends=('glibc' 'bash')
+
+# A package is NOT a Herdr plugin, so `herdr` is not listed here. It follows the download path:
+# `herdr plugin link` would register an action set whose commands run `scripts/collie-ctl.sh` out of
+# a tree pacman owns, and the update action there is one Collie refuses (ADR 0035). Every `collie`
+# verb on PATH works regardless.
+optdepends=(
+  'tailscale: publish the one managed front door with `collie serve` (the supported way to reach Collie from a phone)'
+  'herdr: read Herdr sessions from the phone — the multiplexer Omarchy ships, and one of the three Collie drives'
+  'tmux: mirror tmux sessions instead — one of the three multiplexers Collie drives, and Omarchy ships it too'
+)
+
+# What pacman prints after installing and upgrading, before a removal and after it. Print-only: it enables no unit,
+# links no plugin and writes no config, because every one of those is the operator's decision and
+# `collie start` is where they are made. omarchy-pkgs carries `.install` files beside the PKGBUILD
+# and its sync keeps them, so one file serves both channels here too.
+install=collie-bin.install
+
+# Spelled as plain strings, not as "$_pkgname=$pkgver": the name a user asks pacman for is
+# `collie`, and this package answers it whichever version it carries.
+provides=('collie')
+conflicts=('collie')
+
+# !strip: the release binary is a Bun single-file executable — the bundle it runs from is embedded
+#         in the image, and stripping it produces a binary that no longer starts.
+# !debug: there is no source here to build a debug package from.
+options=('!strip' '!debug')
+
+_baseurl="$url/releases/download/v$pkgver"
+
+source_x86_64=("$pkgname-$pkgver-x86_64.tar.gz::$_baseurl/collie-$pkgver-linux-x64.tar.gz")
+source_aarch64=("$pkgname-$pkgver-aarch64.tar.gz::$_baseurl/collie-$pkgver-linux-arm64.tar.gz")
+
+# Taken from `collie-$pkgver.manifest.json`, the integrity manifest the release job writes. These
+# three lines — `pkgver` above and the two arrays below — are the only ones
+# `scripts/refresh-packages.ts` rewrites, and it copies them from that manifest. Nothing here
+# hashes a file itself.
+sha256sums_x86_64=('ec4dfec7d14b22e6ad9393e841249e97299717239caef3b1b7c32fddc062e1a7')
+sha256sums_aarch64=('7b242bbcbb382aa080a345e81c83bda79fea204ac4806bd184ff33c35b2fd070')
+
+# The tarball's own directory name, which carries the upstream platform spelling rather than $CARCH.
+_distdir() {
+  case "$CARCH" in
+    x86_64)  printf '%s' "$srcdir/collie-$pkgver-linux-x64" ;;
+    aarch64) printf '%s' "$srcdir/collie-$pkgver-linux-arm64" ;;
+    *) error "unsupported CARCH '$CARCH': no release tarball for this architecture"; return 1 ;;
+  esac
+}
+
+package() {
+  local _src _f
+  _src="$(_distdir)"
+
+  # The binary lives beside the tree it reads, not in /usr/bin. It resolves its own root as
+  # dirname(dirname(realpath(argv0))) and accepts that root only if herdr-plugin.toml sits in it
+  # (bridge/root.ts), so /usr/bin/collie is a SYMLINK: it resolves to /opt/collie/bin/collie and
+  # the root comes out as /opt/collie. Installing the file at /usr/bin/collie directly would make
+  # the root /usr, and the bridge would find neither web/dist nor the manifest.
+  install -Dm755 "$_src/bin/collie" "$pkgdir/opt/$_pkgname/bin/collie"
+  install -d "$pkgdir/usr/bin"
+  ln -s "/opt/$_pkgname/bin/collie" "$pkgdir/usr/bin/collie"
+
+  # Everything the RUN TIME reads keeps its path relative to that root: web/dist (the bridge serves
+  # it from disk at request time), herdr-plugin.toml (bridge/root.ts's marker and the canonical
+  # version), package.json (the bridge reads currentVersion from it at boot), .env.example, and
+  # scripts/collie-ctl.sh — which must stay beside the manifest, because the frozen action commands
+  # name it relatively (ADR 0006).
+  #
+  # README.md, CHANGELOG.md and docs/ are read by NOBODY at run time. Nothing under bridge/ or cli/
+  # opens them; every `docs/…` string there is prose printed for the operator to go and read on the
+  # website. So they leave the tree and land in /usr/share/doc, where a distribution package puts
+  # them, and the licence lands in /usr/share/licenses.
+  while IFS= read -r -d '' _f; do
+    _f="${_f#./}"
+    case "$_f" in
+      bin/*|LICENSE|README.md|CHANGELOG.md|docs/*) continue ;;
+      scripts/*) install -Dm755 "$_src/$_f" "$pkgdir/opt/$_pkgname/$_f" ;;
+      *)         install -Dm644 "$_src/$_f" "$pkgdir/opt/$_pkgname/$_f" ;;
+    esac
+  done < <(find "$_src" -type f -printf '%P\0')
+
+  install -Dm644 "$_src/LICENSE" "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+  install -Dm644 "$_src/README.md" "$pkgdir/usr/share/doc/$pkgname/README.md"
+  install -Dm644 "$_src/CHANGELOG.md" "$pkgdir/usr/share/doc/$pkgname/CHANGELOG.md"
+  while IFS= read -r -d '' _f; do
+    install -Dm644 "$_src/docs/$_f" "$pkgdir/usr/share/doc/$pkgname/docs/$_f"
+  done < <(find "$_src/docs" -type f -printf '%P\0')
+}
+
+# No systemd unit is shipped: Collie writes its own `--user` unit through `collie start`, into the
+# operator's own ~/.config/systemd/user.

--- a/pkgbuilds/collie-bin/collie-bin.install
+++ b/pkgbuilds/collie-bin/collie-bin.install
@@ -1,0 +1,39 @@
+# What pacman prints around installing, upgrading and removing collie-bin.
+#
+# It is print-only, on purpose. This package enables no unit, links no Herdr plugin and writes no
+# config: `collie start` writes the operator's own `systemd --user` unit, and a package is not a
+# Herdr plugin (ADR 0035). Every line below is therefore something the OPERATOR does, never
+# something that already happened.
+#
+# The removal message is split in two. `pre_remove` runs while the files are still there, so it is
+# the only place a warning can still be acted on; `post_remove` reports what is left.
+#
+# The `:: ` prefix is the house style of omarchy-pkgs, which carries this file beside the PKGBUILD;
+# its sync strips only .SRCINFO and .gitignore. See packaging/omarchy/README.md.
+
+post_install() {
+  echo ':: Start Collie with: collie start'
+  echo ':: Collie drives one multiplexer and will not guess when it sees two, for example tmux and Herdr.'
+  echo ':: Name one: COLLIE_MUX=herdr collie start'
+  echo ':: Optional: herdr plugin link /opt/collie adds Collie to the Herdr plugin menu.'
+  echo ':: Herdr does not scan /opt, so it never finds the package on its own.'
+  echo ':: Docs: /usr/share/doc/collie-bin/docs/install.md'
+}
+
+post_upgrade() {
+  echo ':: pacman replaced the files and restarted nothing, so the running service keeps the old'
+  echo ':: build. Take the new one with: collie restart'
+  echo ':: Until you do, collie doctor reports the service as restart-pending.'
+}
+
+pre_remove() {
+  echo ':: Removing collie-bin. The systemd --user unit and the tailscale serve mapping Collie'
+  echo ':: published stay unless you ran collie uninstall first. Stop here (Ctrl-C) to run it.'
+}
+
+post_remove() {
+  echo ':: pacman removed /opt/collie and /usr/bin/collie, and nothing else.'
+  echo ':: Left behind, delete by hand when you want them gone:'
+  echo '::   ~/.local/state/collie/'
+  echo '::   ~/.config/herdr/plugins/config/herdr.collie/'
+}


### PR DESCRIPTION
[ColliePWA](https://github.com/AltanS/collie) is a phone web UI for the AI coding agents running in your terminal, served over Tailscale. It drives tmux, zellij and Herdr, which Omarchy already ships. This package installs the official release tarball to /opt/collie with a /usr/bin symlink, follows GitHub releases through .omarchy/package.json with digests, and ships an .install that prints the start command. I maintain it.
