### PR TITLE
Add ssf, Simple Software Factory, to the fast ring

### DIFF
--- a/pkgbuilds/ssf/.omarchy/package.json
+++ b/pkgbuilds/ssf/.omarchy/package.json
@@ -1,0 +1,11 @@
+{
+  "source": "local",
+  "release_ring": "fast",
+  "upstream": {
+    "git_tags": "https://github.com/mikekelly/simple-software-factory.git",
+    "tag_pattern": "v{pkgver}",
+    "sources": {
+      "any": ["https://github.com/mikekelly/simple-software-factory/archive/refs/tags/{tag}.tar.gz"]
+    }
+  }
+}

--- a/pkgbuilds/ssf/PKGBUILD
+++ b/pkgbuilds/ssf/PKGBUILD
@@ -18,7 +18,8 @@ pkgdesc="GitHub issues assigned to a bot become coding-agent sessions in herdr o
 arch=('x86_64' 'aarch64')
 url="https://github.com/mikekelly/simple-software-factory"
 license=('MIT')
-depends=('gcc-libs' 'glibc' 'jq' 'systemd' 'github-cli' 'herdr')
+# openssh: `ssf auth login` makes the bot's key with ssh-keygen and the bot pushes over ssh.
+depends=('gcc-libs' 'glibc' 'jq' 'systemd' 'github-cli' 'herdr' 'openssh')
 makedepends=('cargo')
 checkdepends=('git')
 optdepends=(
@@ -28,7 +29,6 @@ optdepends=(
   'fakeroot: builds the microVM image (ssf vm build)'
   'libarchive: bsdtar, unpacks the Arch bootstrap tarball for the microVM image'
   'e2fsprogs: mkfs.ext4, makes the microVM disks'
-  'openssh: reaches the microVM guest (ssf vm ssh, attach, status)'
   'curl: downloads Firecracker, gvproxy and the guest kernel'
 )
 install=ssf.install

--- a/pkgbuilds/ssf/PKGBUILD
+++ b/pkgbuilds/ssf/PKGBUILD
@@ -1,0 +1,85 @@
+# Maintainer: Mike Kelly <mikekelly321@gmail.com>
+#
+# Release PKGBUILD: builds a tagged release of ssf from the GitHub tag tarball.
+# This directory (PKGBUILD, ssf.install, .omarchy/package.json) is what goes
+# into Omarchy's package repository as pkgbuilds/ssf/. The development build
+# of the working tree is ../PKGBUILD, which sources this file for everything
+# but the source and version.
+#
+# New release: tag vX.Y.Z (Cargo.toml version first), then here
+#     pkgver=X.Y.Z, pkgrel=1, updpkgsums, makepkg -fd
+# Omarchy's sync-upstream does the same from .omarchy/package.json once the
+# package is in its repository.
+
+pkgname=ssf
+pkgver=0.1.0
+pkgrel=1
+pkgdesc="GitHub issues assigned to a bot become coding-agent sessions in herdr or Orca"
+arch=('x86_64' 'aarch64')
+url="https://github.com/mikekelly/simple-software-factory"
+license=('MIT')
+depends=('gcc-libs' 'glibc' 'jq' 'systemd' 'github-cli' 'herdr')
+makedepends=('cargo')
+checkdepends=('git')
+optdepends=(
+  'orca-ide-bin: Orca desktop app and CLI, the alternative driver (driver = "orca"; not in the Omarchy repo, install it by hand)'
+  'omarchy: bar widget, menu entries and floating-terminal flows'
+  'gum: nicer prompts in ssf-ui'
+  'fakeroot: builds the microVM image (ssf vm build)'
+  'libarchive: bsdtar, unpacks the Arch bootstrap tarball for the microVM image'
+  'e2fsprogs: mkfs.ext4, makes the microVM disks'
+  'openssh: reaches the microVM guest (ssf vm ssh, attach, status)'
+  'curl: downloads Firecracker, gvproxy and the guest kernel'
+)
+install=ssf.install
+# !debug: no ssf-debug split package. !lto: makepkg's -flto would reach
+# ring's C objects through the cc crate; cargo's release profile decides.
+options=('!debug' '!lto')
+source=("$pkgname-$pkgver.tar.gz::$url/archive/refs/tags/v$pkgver.tar.gz")
+sha256sums=('9a70c43cd9f1e349d11d90c8ddfb00b4b24a7df49fbe249432f77ed1af738ff6')
+
+# GitHub names the unpacked tree after the repository, not the package.
+_srcname="simple-software-factory-$pkgver"
+
+prepare() {
+  cd "$_srcname"
+  cargo fetch --locked --target "$(rustc -vV | sed -n 's/host: //p')"
+}
+
+build() {
+  cd "$_srcname"
+  export CARGO_TARGET_DIR=target
+  cargo build --frozen --release
+}
+
+check() {
+  cd "$_srcname"
+  export CARGO_TARGET_DIR=target
+  cargo test --frozen --release
+}
+
+package() {
+  cd "$_srcname"
+  install -Dm755 target/release/ssf "$pkgdir/usr/bin/ssf"
+  install -Dm755 bin/ssf-ui "$pkgdir/usr/bin/ssf-ui"
+  install -Dm644 packaging/ssf.service "$pkgdir/usr/lib/systemd/user/ssf.service"
+  # Enabled for every user out of the box; `ssf ui service disable` turns it off.
+  install -d "$pkgdir/usr/lib/systemd/user/graphical-session.target.wants"
+  ln -s ../ssf.service "$pkgdir/usr/lib/systemd/user/graphical-session.target.wants/ssf.service"
+  install -Dm644 omarchy-plugin/manifest.json "$pkgdir/usr/share/ssf/omarchy-plugin/manifest.json"
+  install -Dm644 omarchy-plugin/Panel.qml "$pkgdir/usr/share/ssf/omarchy-plugin/Panel.qml"
+  install -Dm644 config.example.toml "$pkgdir/usr/share/ssf/config.example.toml"
+  install -Dm755 vm/make-base.sh "$pkgdir/usr/share/ssf/vm/make-base.sh"
+  install -Dm755 vm/guest/provision-init.sh "$pkgdir/usr/share/ssf/vm/guest/provision-init.sh"
+  install -Dm755 vm/guest/provision.sh "$pkgdir/usr/share/ssf/vm/guest/provision.sh"
+  install -Dm755 vm/guest/net-up.sh "$pkgdir/usr/share/ssf/vm/guest/net-up.sh"
+  install -Dm755 vm/guest/seed.sh "$pkgdir/usr/share/ssf/vm/guest/seed.sh"
+  install -Dm644 vm/guest/sudoers "$pkgdir/usr/share/ssf/vm/guest/sudoers"
+  install -d "$pkgdir/usr/share/ssf/vm/guest/units"
+  install -m644 vm/guest/units/*.service "$pkgdir/usr/share/ssf/vm/guest/units/"
+  install -Dm644 SSF.example.md "$pkgdir/usr/share/ssf/SSF.example.md"
+  install -Dm644 README.md "$pkgdir/usr/share/doc/ssf/README.md"
+  install -d "$pkgdir/usr/share/doc/ssf/docs"
+  install -m644 docs/*.md "$pkgdir/usr/share/doc/ssf/docs/"
+  install -Dm644 LICENSE "$pkgdir/usr/share/licenses/ssf/LICENSE"
+}

--- a/pkgbuilds/ssf/ssf.install
+++ b/pkgbuilds/ssf/ssf.install
@@ -1,0 +1,52 @@
+# Start (or restart) ssf.service in every user manager that is running right
+# now. pacman runs as root outside any session, so the unit's
+# graphical-session.target.wants symlink only kicks in at the next login;
+# this covers the session that is installing the package.
+_start_for_logged_in_users() {
+  local action="$1" user started=0
+  for user in $(loginctl list-users --no-legend 2>/dev/null | awk '{print $2}'); do
+    if systemctl --machine="${user}@.host" --user is-system-running >/dev/null 2>&1 \
+      || systemctl --machine="${user}@.host" --user is-system-running 2>/dev/null | grep -qE 'running|degraded'; then
+      systemctl --machine="${user}@.host" --user daemon-reload >/dev/null 2>&1 || true
+      if systemctl --machine="${user}@.host" --user "$action" ssf.service >/dev/null 2>&1; then
+        echo "==> ssf.service ${action}ed for $user"
+        started=1
+      fi
+    fi
+  done
+  return $(( started == 0 ))
+}
+
+post_install() {
+  cat <<'MSG'
+==> Simple Software Factory (ssf) is installed.
+    It runs as a per-user service (ssf.service) and starts with the graphical session.
+    The agents run in herdr (installed with this package; by default inside a microVM
+    with `ssf vm`), or in Orca (orca-ide-bin, installed by hand; `ssf config set driver orca`).
+MSG
+  if ! _start_for_logged_in_users start; then
+    echo "    No running user session found; it starts at next login, or now with:"
+    echo "      systemctl --user daemon-reload && systemctl --user start ssf.service"
+  fi
+  cat <<'MSG'
+    Next: follow /usr/share/doc/ssf/docs/setup.md, yourself or with your coding agent:
+    the bot account (`ssf auth login --web`), the microVM (`ssf vm build && ssf config set
+    vm.enabled true`) or this machine, then a repository (`ssf repo add owner/name --harness claude`).
+MSG
+}
+
+post_upgrade() {
+  if ! _start_for_logged_in_users try-restart; then
+    echo "==> ssf upgraded; restart it with: systemctl --user restart ssf.service"
+  fi
+}
+
+post_remove() {
+  cat <<'MSG'
+==> ssf removed. Per-user files are left in place:
+    ~/.config/ssf (config, bot key), ~/.local/state/ssf (state),
+    ~/ssf/projects (clones and worktrees), ~/.local/share/ssf/vm (the microVM's disks),
+    ~/.config/omarchy/plugins/ssf.factory and the Factory menu entries
+    (remove with `ssf ui uninstall` before uninstalling, or by hand).
+MSG
+}

--- a/pkgbuilds/ssf/ssf.install
+++ b/pkgbuilds/ssf/ssf.install
@@ -45,8 +45,9 @@ post_remove() {
   cat <<'MSG'
 ==> ssf removed. Per-user files are left in place:
     ~/.config/ssf (config, bot key), ~/.local/state/ssf (state),
-    ~/ssf/projects (clones and worktrees), ~/.local/share/ssf/vm (the microVM's disks),
-    ~/.config/omarchy/plugins/ssf.factory and the Factory menu entries
-    (remove with `ssf ui uninstall` before uninstalling, or by hand).
+    ~/ssf/projects (clones and worktrees), ~/.local/share/ssf/vm (the microVM),
+    ~/.config/omarchy/plugins/ssf.factory and the Factory menu entries.
+    `ssf uninstall` before removing the package takes care of all but the
+    clones and the VM image (`--data` includes config and state); now it is by hand.
 MSG
 }


### PR DESCRIPTION
🤖mikekelly/simple-software-factory#125 says: <!-- ssf: origin=mikekelly/simple-software-factory#125 -->

Adds **ssf** (Simple Software Factory), a per-user daemon for Omarchy that turns GitHub issues assigned to a bot account into coding-agent sessions in herdr (or Orca), with a bar widget and a Factory menu. Source: https://github.com/mikekelly/simple-software-factory (MIT).

### How it is built

From source, from the `vX.Y.Z` tag tarball with its sha256 pinned: `cargo fetch --locked`, `cargo build --frozen --release`, `check()` runs the crate's tests. `options=('!debug')`, so no `-debug` split package. x86_64 and aarch64 in `arch=()`; only x86_64 was built and tested.

### How it tracks versions

Not in the AUR. `.omarchy/package.json` is `source: local` with a `git_tags` upstream (`v{pkgver}`, tarball under `archive/refs/tags/`), modelled on `tensaku`, so `bin/sync-upstream` picks up new tags. `release_ring: fast`, so it reaches stable without waiting for an Omarchy release; say the word if you would rather it went through edge.

### Dependencies

`github-cli` and `herdr` at runtime (`herdr` from this repository), plus `jq` and `systemd`; `makedepends=('cargo')`. The rest are `optdepends` (the microVM tooling and the Orca driver, which is not packaged anywhere and says so).

### Install script

`ssf.install` starts the user unit in every running user session at install time (`systemctl --machine=user@.host --user`), since pacman runs as root outside a session and the `graphical-session.target.wants` symlink only takes effect at the next login; upgrades `try-restart` it.

### Checks

- `makepkg -fd` in `pkgbuilds/ssf/` on Omarchy (the tarball's sha256 matches the pinned one), 241 tests in `check()`, one output file
- `pacman -Qip`/`-Qlp` as expected; installed into a scratch root with `pacman -r ... -Udd`, the binary runs
- `bin/repo list` shows the package with its metadata; `bin/sync-upstream ssf` reports no update at 0.1.0 and, with `pkgver` rolled back, resolves 0.1.0 from the tags