### PR TITLE
Symlink omarchy-settings support binaries into the CLI bin dir

### DIFF
--- a/pkgbuilds/omarchy-settings-dev/PKGBUILD
+++ b/pkgbuilds/omarchy-settings-dev/PKGBUILD
@@ -400,4 +400,13 @@ EOF
   install -Dm755 bin/omarchy-upload-log "$pkgdir/usr/bin/omarchy-upload-log"
   install -Dm755 bin/omarchy-debug      "$pkgdir/usr/bin/omarchy-debug"
   install -Dm755 bin/omarchy-debug-idle "$pkgdir/usr/bin/omarchy-debug-idle"
+
+  # The omarchy CLI dispatcher discovers subcommands by scanning
+  # /usr/share/omarchy/bin, so these three need the same symlink omarchy's
+  # PKGBUILD creates for every command it ships. Without them `omarchy debug`,
+  # `omarchy debug idle` and `omarchy upload log` are Unknown Omarchy command.
+  install -d "$pkgdir/usr/share/omarchy/bin"
+  ln -s /usr/bin/omarchy-upload-log "$pkgdir/usr/share/omarchy/bin/omarchy-upload-log"
+  ln -s /usr/bin/omarchy-debug      "$pkgdir/usr/share/omarchy/bin/omarchy-debug"
+  ln -s /usr/bin/omarchy-debug-idle "$pkgdir/usr/share/omarchy/bin/omarchy-debug-idle"
 }

--- a/pkgbuilds/omarchy-settings/PKGBUILD
+++ b/pkgbuilds/omarchy-settings/PKGBUILD
@@ -398,4 +398,13 @@ EOF
   install -Dm755 bin/omarchy-upload-log "$pkgdir/usr/bin/omarchy-upload-log"
   install -Dm755 bin/omarchy-debug      "$pkgdir/usr/bin/omarchy-debug"
   install -Dm755 bin/omarchy-debug-idle "$pkgdir/usr/bin/omarchy-debug-idle"
+
+  # The omarchy CLI dispatcher discovers subcommands by scanning
+  # /usr/share/omarchy/bin, so these three need the same symlink omarchy's
+  # PKGBUILD creates for every command it ships. Without them `omarchy debug`,
+  # `omarchy debug idle` and `omarchy upload log` are Unknown Omarchy command.
+  install -d "$pkgdir/usr/share/omarchy/bin"
+  ln -s /usr/bin/omarchy-upload-log "$pkgdir/usr/share/omarchy/bin/omarchy-upload-log"
+  ln -s /usr/bin/omarchy-debug      "$pkgdir/usr/share/omarchy/bin/omarchy-debug"
+  ln -s /usr/bin/omarchy-debug-idle "$pkgdir/usr/share/omarchy/bin/omarchy-debug-idle"
 }


### PR DESCRIPTION
## Problem

The `omarchy` CLI dispatcher discovers subcommands by scanning `/usr/share/omarchy/bin`
(`OMARCHY_BIN_DIR` in `bin/omarchy`). The `omarchy` package creates a symlink there for
every binary it ships, and deliberately skips three:

```bash
# omarchy/PKGBUILD — "ship everything in bin/ except the debug helpers
# that ship from omarchy-settings (needed before omarchy is installed,
# e.g. on the ISO live env)."
case "$base" in
  omarchy-debug|omarchy-debug-idle|omarchy-upload-log)
    continue
    ;;
esac
install -Dm755 "$bin" "$pkgdir/usr/bin/$base"
ln -s "/usr/bin/$base" "$pkgdir/usr/share/omarchy/bin/$base"
```

That rationale is sound, but `omarchy-settings` then installs the three to `/usr/bin`
without the matching symlink, so the dispatcher never sees them and all three are
unreachable through the CLI:

```
$ omarchy debug --no-sudo --print
Unknown Omarchy command: omarchy debug --no-sudo --print
$ omarchy debug idle
Unknown Omarchy command: omarchy debug idle
$ omarchy upload log
Unknown Omarchy command: omarchy upload log
```

They work when called by binary name (`omarchy-debug`), and their own metadata expects
the dispatched form — `bin/omarchy-debug` declares
`# omarchy:examples=omarchy debug --print --no-sudo`, and `bin/omarchy` carries
`GROUP_DESCRIPTIONS[debug]="Diagnostics and support logs"`. So this reads as an
oversight rather than intent.

It also has a self-defeating consequence: `omarchy debug --no-sudo --print` is precisely
what the bundled `diagnose-crash` skill instructs users to run to gather diagnostics
*for an Omarchy bug report*, and what `omarchy/contributing.md` documents under "Filing
a Good Bug Report". Anyone following either lands on `Unknown Omarchy command` and
reasonably concludes the docs are stale.

## Fix

Create the same three symlinks `omarchy`'s PKGBUILD makes for everything else, in both
`omarchy-settings` and `omarchy-settings-dev`. The binaries stay owned by
`omarchy-settings`, and `omarchy` still skips them, so the two packages do not contend
for any path — only the directory is shared, which pacman already allows.

## Verification

On an installed Omarchy 4.0.2-1 (`omarchy-settings 4.0.2-1`), staging just the symlink
into a copy of the bin dir is enough to fix dispatch:

```
$ ls /usr/share/omarchy/bin/omarchy-debug
ls: cannot access '...': No such file or directory
$ ls /usr/bin/omarchy-debug
-rwxr-xr-x 1 root root 2269 Aug 31 08:41 /usr/bin/omarchy-debug

# copy the bin dir, add the one missing symlink, dispatch through it:
$ "$tmp/omarchy" debug --help
Usage:
  omarchy debug [--no-sudo] [--print]
```

`bash -n` passes on both PKGBUILDs, and all four CI self-tests pass locally on Arch:

```
./bin/sync-upstream self-test     ✓
./bin/sync-rebuilds --self-test   ✓
./bin/omarchy-pkgs self-test      ✓
./bin/omarchy-release self-test   ✓
```

## Note on versioning

I deliberately did not touch `pkgver`/`pkgrel`. This is a packaging-only change against
the same source, so per the README it wants a `pkgrel` bump to ship — but
`omarchy-settings` is `"pinned": true` with its version set per release on the standing
`rc` branch, and the header says not to hand-edit the versioning convention. Happy to
add the bump if you'd rather it ride along, or leave it to the release train.
