### PR TITLE
Add Kujo package

### DIFF
--- a/pkgbuilds/kujo/.omarchy/package.json
+++ b/pkgbuilds/kujo/.omarchy/package.json
@@ -1,0 +1,14 @@
+{
+  "source": "local",
+  "upstream": {
+    "github": "kujolang/kujo",
+    "checksums": "checksums.txt",
+    "assets": {
+      "x86_64": "kujo-{tag}-linux-x64.tar.gz",
+      "aarch64": "kujo-{tag}-linux-arm64.tar.gz"
+    },
+    "sources": {
+      "any": ["https://raw.githubusercontent.com/kujolang/kujo/{tag}/LICENSE"]
+    }
+  }
+}

--- a/pkgbuilds/kujo/PKGBUILD
+++ b/pkgbuilds/kujo/PKGBUILD
@@ -1,0 +1,20 @@
+pkgname=kujo
+pkgver=1.3.1
+pkgrel=1
+pkgdesc="Programming language and runtime for AI-native software"
+arch=('x86_64' 'aarch64')
+url="https://kujolang.ai"
+license=('MIT')
+depends=('gcc-libs' 'glibc' 'zlib')
+options=('!strip' '!debug')
+source=("LICENSE-$pkgver::https://raw.githubusercontent.com/kujolang/kujo/v$pkgver/LICENSE")
+source_x86_64=("https://github.com/kujolang/kujo/releases/download/v$pkgver/kujo-v$pkgver-linux-x64.tar.gz")
+source_aarch64=("https://github.com/kujolang/kujo/releases/download/v$pkgver/kujo-v$pkgver-linux-arm64.tar.gz")
+sha256sums=('4b6449939f8dce26dc5fb87756740a5977da9085517af127d9e634e6a6492506')
+sha256sums_x86_64=('0d2162aad32b989bf8a766c8a6996b88cd299964c82ca9b9882b033ed6d33e50')
+sha256sums_aarch64=('ebc164696de874177bede389e1dcb635de6318b98ccf969d3758f38f308ce7bb')
+
+package() {
+  install -Dm755 "$srcdir/kujo" "$pkgdir/usr/bin/kujo"
+  install -Dm644 "$srcdir/LICENSE-$pkgver" "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+}


### PR DESCRIPTION
Kujo is a programming language and runtime for AI-native software and local automation. This adds a `kujo` package using the official v1.3.1 Linux binaries for x86_64 and aarch64.

The package installs `/usr/bin/kujo` and its MIT license. It uses pinned SHA-256 hashes from upstream's `checksums.txt` and declares its runtime dependencies: glibc, gcc-libs and zlib. Kujo already refuses to replace a package-managed binary through its own upgrade command.

The existing upstream sync workflow tracks new GitHub releases and updates the version, both archive hashes and the license hash. The package follows the normal edge → rc → stable release path.

### Validation

- Verified both official archives and their checksums. Built and installed the x86_64 package with makepkg and pacman in disposable Arch Linux. Offline program execution, package ownership, self-update refusal and removal passed.
- All four package-repository self-test suites passed. A live upstream sync on a disposable copy restored the exact v1.3.1 version and checksum arrays.
- ARM64 program execution passed under emulation on Ubuntu 24.04. A native Arch Linux ARM package build remains unverified; this does not enable ARM64 publication.

Namcap reported advisory warnings for the dynamic loader, libgcc supplied through gcc-libs, and the missing Maintainer header. The Arch container also printed keyring-hook and fakeroot warnings; the build completed, and the installed package passed ownership and integrity checks.

The companion Omarchy change, https://github.com/omacom/omarchy/pull/10823, adds Kujo to fresh installations. This package must reach the target channel before that change ships.
