### PR TITLE
Fix IPU7 camera rebuilds across jsoncpp ABI changes

### DIFF
--- a/pkgbuilds/intel-ipu7-camera/.omarchy/package.json
+++ b/pkgbuilds/intel-ipu7-camera/.omarchy/package.json
@@ -1,3 +1,12 @@
 {
-  "source": "local"
+  "source": "local",
+  "release_ring": "fast",
+  "rebuild_on": [
+    "jsoncpp"
+  ],
+  "rebuilt_against": {
+    "x86_64": {
+      "jsoncpp": "1.9.6-3"
+    }
+  }
 }

--- a/pkgbuilds/intel-ipu7-camera/PKGBUILD
+++ b/pkgbuilds/intel-ipu7-camera/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=intel-ipu7-camera
 pkgver=1.0.5
-pkgrel=1
+pkgrel=2
 pkgdesc="Intel IPU7 MIPI camera stack for Hurrican/Performance (OV08X40 + hardware ISP)"
 arch=('x86_64')
 url="https://github.com/TsaiGaggery/hurrican_omarchy_enabling"
@@ -16,7 +16,7 @@ depends=(
   'gst-plugins-base'
   'gst-plugins-good'
   'gst-plugins-bad'
-  'jsoncpp'
+  'libjsoncpp.so'
   'libdrm'
 )
 makedepends=(


### PR DESCRIPTION
## Problem

The RC channel upgraded `jsoncpp` from 1.9.6 (`libjsoncpp.so.26`) to 1.9.8 (`libjsoncpp.so.27`), while `intel-ipu7-camera 1.0.5-1` remained linked to `.26`. `ipu75xa.so` could no longer load, leaving the IPU7 V4L2 relay present but unable to produce frames.

## Fix

- Mark `intel-ipu7-camera` as a fast-ring package so it is built against each channel's own dependency set rather than carrying an artifact across incompatible channel ABIs.
- Track `jsoncpp` through `rebuild_on`, allowing the existing rebuild automation to bump the package when that dependency moves.
- Depend on the `libjsoncpp.so` soname provider rather than only the unversioned package name, exposing ABI compatibility to package metadata.
- Bump `pkgrel` to 2 so corrected artifacts are published now.

Fixes omacom/omarchy#10837.

## Verification

- `./bin/sync-rebuilds intel-ipu7-camera` generated the pkgrel bump and x86_64 dependency record.
- `./bin/sync-rebuilds --self-test`
- `./bin/omarchy-pkgs self-test`
- `bash -n pkgbuilds/intel-ipu7-camera/PKGBUILD`
- `makepkg --printsrcinfo` reports `depends = libjsoncpp.so`.
- `git diff --check`

A full IPU7 package build is intentionally left to the repository's native per-channel builders because the package includes kernel DKMS modules and proprietary camera components.