### PR TITLE
Update Hermes Desktop to 2026.9.7 and use normal release promotion

### DIFF
--- a/pkgbuilds/hermes-desktop/.omarchy/package.json
+++ b/pkgbuilds/hermes-desktop/.omarchy/package.json
@@ -1,4 +1,3 @@
 {
-  "source": "local",
-  "release_ring": "fast"
+  "source": "local"
 }

--- a/pkgbuilds/hermes-desktop/PKGBUILD
+++ b/pkgbuilds/hermes-desktop/PKGBUILD
@@ -4,8 +4,8 @@
 # so the upstream updater can rebuild and relaunch it in place.
 
 pkgname=hermes-desktop
-pkgver=2026.8.31
-pkgrel=3
+pkgver=2026.9.7
+pkgrel=1
 pkgdesc='Native desktop shell for Hermes Agent'
 arch=('x86_64')
 url='https://github.com/NousResearch/hermes-agent'
@@ -65,7 +65,7 @@ options=('!strip' '!debug')
 # before falling back to `git rev-parse`. That fallback is wrong here: makepkg
 # builds inside this repository, so git ascends out of srcdir and stamps the
 # app with an omarchy-pkgs commit that means nothing upstream.
-_commit=29112bef099274229cadff79cdff7bf7b99c4b77
+_commit=2237be355906fbe6065ce1815711eee52b2d646e
 
 _srcdir="hermes-agent-${pkgver}"
 source=("${pkgname}-${pkgver}.tar.gz::${url}/archive/refs/tags/v${pkgver}.tar.gz"
@@ -74,12 +74,12 @@ source=("${pkgname}-${pkgver}.tar.gz::${url}/archive/refs/tags/v${pkgver}.tar.gz
         'hermes-desktop.png'
         'runtime.patch'
         'runtime-test.py')
-sha256sums=('78fb3ff707ec1d17044b875ecac8bef28aa39d44242824f6871ca40afe7bf217'
+sha256sums=('907c2a72db1c5dd637ea8eeae97f4cb5b32cef615c17258f6b190924ec5bf688'
             '094d5f3191109a80eea9f23053b78a2e00dbecf90d62d1ca04c8e48866251469'
             '3ef685bfcf366776b025d26c37d32854d8d4aa2023b2bd07c8e08b001ef1e8c4'
             'd60d164e24fdcf6532133b8ea43c77a201e4b9e9dbc396187b58d51d8590ef52'
-            '03b67e26c234c797a6b1d4c9f34a57502dba37f462540e47ce6c88f6ea79302a'
-            '461e1120e7e6779f531c114d9926479e47fab79113d1b4646efea36bc771b3c5')
+            '9d5015d1be762a901f8f64319981ae862e9852fa5cb9a22a2ba1e691f90430a2'
+            '7337a12c71e8091ad5fc2e879e922c9cb1706c65f81b59d6dd70b12123dc7c00')
 
 build() {
   cd "${srcdir}/${_srcdir}"
@@ -109,9 +109,9 @@ package() {
 
   install -Dm644 "${srcdir}/${_srcdir}/scripts/install.sh" \
     "${pkgdir}/usr/share/${pkgname}/install.sh"
-  # Let the release's first updater relaunch with the user-namespace sandbox.
+  # Omarchy's installer still requires this patch. The release includes the
+  # fix, so the installer recognizes it through its reverse-apply check.
   install -Dm644 "${srcdir}/runtime.patch" "${pkgdir}/usr/share/${pkgname}/runtime.patch"
-
 
   install -Dm644 "${srcdir}/hermes-desktop.desktop" \
     "${pkgdir}/usr/share/applications/${pkgname}.desktop"

--- a/pkgbuilds/hermes-desktop/runtime-test.py
+++ b/pkgbuilds/hermes-desktop/runtime-test.py
@@ -14,7 +14,9 @@ with tempfile.TemporaryDirectory(prefix="hermes-runtime-check-") as temporary:
     destination = root / "scripts/desktop-update/posix.sh"
     destination.parent.mkdir(parents=True)
     shutil.copyfile(source / "scripts/desktop-update/posix.sh", destination)
-    subprocess.run(["git", "apply", str(patch_file.resolve())], cwd=root, check=True)
+    # Omarchy's installer requires the patch and accepts an upstreamed fix
+    # through its reverse check. Verify that path without changing the release.
+    subprocess.run(["git", "apply", "--reverse", "--check", str(patch_file.resolve())], cwd=root, check=True)
 
     home = root / "home with spaces"
     runtime = home / ".hermes/hermes-agent"
@@ -42,13 +44,14 @@ Path(os.environ["TEST_OUTPUT"]).write_text(json.dumps({
     module = runtime / "hermes_cli"
     module.mkdir()
     (module / "__init__.py").touch()
-    upstream = ast.parse((source / "hermes_cli/main.py").read_text())
+    upstream = ast.parse((source / "hermes_cli/main_desktop.py").read_text())
     option_parser = next(node for node in upstream.body
                         if isinstance(node, ast.FunctionDef) and node.name == "_desktop_launch_options")
-    stores = next(node for node in upstream.body if isinstance(node, ast.Assign)
-                  and any(isinstance(target, ast.Name) and target.id == "_LINUX_PASSWORD_STORES"
-                          for target in node.targets))
-    helper = "import os, shlex\n" + ast.unparse(stores) + "\n" + ast.unparse(option_parser) + "\n"
+    constants = [node for node in upstream.body if isinstance(node, ast.Assign)
+                 and any(isinstance(target, ast.Name)
+                         and target.id in ("_LINUX_PASSWORD_STORES", "_GPU_FLAG_WORDS")
+                         for target in node.targets)]
+    helper = "import os, shlex\n" + "\n".join(map(ast.unparse, constants)) + "\n" + ast.unparse(option_parser) + "\n"
     (module / "main.py").write_text(helper)
     (module / "config.py").write_text('''import json, os
 from pathlib import Path

--- a/pkgbuilds/hermes-desktop/runtime.patch
+++ b/pkgbuilds/hermes-desktop/runtime.patch
@@ -1,11 +1,13 @@
 --- a/scripts/desktop-update/posix.sh
 +++ b/scripts/desktop-update/posix.sh
-@@ -317,6 +317,8 @@
+@@ -327,6 +327,10 @@
+   sb="$unpacked/chrome-sandbox"
    if [ ! -e "$sb" ]; then GATE=relaunch; return; fi
    if [ -u "$sb" ] && [ "$(stat -c %u "$sb" 2>/dev/null)" = "0" ]; then GATE=relaunch; return; fi
- 
++  # Namespace sandbox usable => Electron never consults the setuid helper,
++  # so a non-root chrome-sandbox does not block relaunch (mirrors the
++  # _desktop_linux_userns_sandbox_available() probe in hermes_cli/main.py).
 +  if unshare --user --map-root-user true 2>/dev/null; then GATE=relaunch; return; fi
-+
+
    case "${ELECTRON_DISABLE_SANDBOX:-}" in 1|true|TRUE|True) GATE=relaunch; return ;; esac
    [ "$SANDBOX_FALLBACK" -eq 1 ] && { GATE=relaunch; return; }
-   for arg in ${RELAUNCH_ARGS[@]+"${RELAUNCH_ARGS[@]}"}; do


### PR DESCRIPTION
Update hermes-desktop from 2026.8.31-3 to 2026.9.7-1, pinning the [v2026.9.7](https://github.com/NousResearch/hermes-agent/releases/tag/v2026.9.7) release commit and the tarball checksum.

The release carries the namespace-sandbox change that `runtime.patch` used to add to `scripts/desktop-update/posix.sh`, and moves the desktop launch helpers out of `hermes_cli/main.py` into `hermes_cli/main_desktop.py`. `runtime.patch` is refreshed to upstream's text and still shipped, because Omarchy's installer refuses to run without the file and accepts an already-upstreamed patch through its reverse-apply check, so nothing is applied to a fresh 2026.9.7 runtime. `runtime-test.py` proves exactly that path by reverse-checking the patch against the release instead of applying it, and reads the launch option parser and its constants from `main_desktop.py`, which is where the launcher now finds them.

**Release policy.** Remove Hermes from the fast release ring. Package updates build on edge and reach rc and stable through the normal promotion pipeline, allowing the packaged release and Omarchy installer to be validated together. Users retain the existing in-app updater when they choose to move to newer upstream code.

**Rollout dependency.** [omacom/omarchy#10846](https://github.com/omacom/omarchy/pull/10846) fixes the installer's build-stamp import for the new module layout while retaining support for older releases. Ship that fix on edge before publishing this package there, then promote the compatible Omarchy installer and Hermes package together through rc and stable.

Release-policy validation: metadata validation passes; the build selector includes Hermes on edge and excludes it from automatic rc/stable builds; the promotion selector accepts both rc and stable.

Refs #262.

🤖 Reviewed by Fable 5.1 in Claude Code and Codex XHigh.
