### PR TITLE
Add omarchy-studio

### DIFF
--- a/pkgbuilds/omarchy-studio/.omarchy/package.json
+++ b/pkgbuilds/omarchy-studio/.omarchy/package.json
@@ -1,0 +1,10 @@
+{
+  "source": "local",
+  "upstream": {
+    "git_tags": "https://github.com/the2dl/omarchy-studio.git",
+    "tag_pattern": "v{pkgver}",
+    "sources": {
+      "any": ["https://github.com/the2dl/omarchy-studio/archive/refs/tags/{tag}.tar.gz"]
+    }
+  }
+}

--- a/pkgbuilds/omarchy-studio/PKGBUILD
+++ b/pkgbuilds/omarchy-studio/PKGBUILD
@@ -1,0 +1,106 @@
+# Maintainer: Dan <dan@nano.rs>
+
+pkgname=omarchy-studio
+pkgver=0.1.0
+pkgrel=1
+pkgdesc="Non-destructive screen recorder and editor for Hyprland: automatic zoom, camera, backdrops, redaction"
+arch=('x86_64' 'aarch64')
+url="https://github.com/the2dl/omarchy-studio"
+license=('Apache-2.0')
+depends=(
+  'bash'
+  'ffmpeg'
+  'gpu-screen-recorder'
+  'hyprland'
+  'jq'
+  'libnotify'
+  'libpulse'
+  'mpv'
+  'omarchy'
+  'python'
+  'qt6-declarative'
+  'qt6-multimedia'
+  'slurp'
+  'v4l-utils'
+  'xdg-utils'
+)
+makedepends=('gcc' 'mesa' 'pkgconf' 'wayland' 'wayland-protocols')
+checkdepends=('python-pytest')
+optdepends=(
+  'python-faster-whisper: local speech-to-text for automatic captions'
+  'hyprland-studio-screenshare: hides the camera self-view from a portal capture instead of blacking it out (hyprpm)'
+)
+options=('!debug')
+
+source=("$pkgname-$pkgver.tar.gz::$url/archive/refs/tags/v$pkgver.tar.gz")
+sha256sums=('52eebf81bb343af034a6e71dc989d507e2b302d1a0c9bd4ce1449a66582bfb03')
+
+build() {
+  cd "$pkgname-$pkgver"
+
+  # Optional. Without it, "just this window" falls back to capturing the window's
+  # rectangle, which records whatever is stacked on top of it.
+  contrib/omarchy-capture-window/build.sh \
+    || warning "native window recorder did not build; window capture falls back to a rectangle"
+}
+
+check() {
+  cd "$pkgname-$pkgver"
+
+  # tests/test_parity.py is excluded, not skipped by accident. It renders frames through
+  # QML and compares them pixel-wise against the ffmpeg export, so it wants a live
+  # compositor -- a VideoOutput grabs empty under every headless Qt platform. On a build
+  # host it is either skipped for that reason or, worse, runs and is flaky. It belongs in
+  # a graphical session, where the project runs it. Everything else -- the filtergraph
+  # compilers, the timing model, the audio chain, the bundle format -- runs here.
+  OMARCHY_STUDIO_NO_REVEAL=1 python -m pytest -q --ignore=tests/test_parity.py
+}
+
+package() {
+  cd "$pkgname-$pkgver"
+  local root="$pkgdir/usr/lib/$pkgname"
+
+  # Installed whole rather than split across FHS: the entry points locate lib/,
+  # editor/, daemon/ and contrib/ relative to their own resolved path.
+  install -d "$root"
+  cp -a bin lib editor daemon "$root/"
+  if [[ -x contrib/omarchy-capture-window/omarchy-capture-window ]]; then
+    install -Dm755 contrib/omarchy-capture-window/omarchy-capture-window \
+      "$root/contrib/omarchy-capture-window/omarchy-capture-window"
+  fi
+  find "$root" -name '__pycache__' -type d -prune -exec rm -rf {} + 2>/dev/null || true
+
+  # Public commands as "PATH name:file in the tree". The recorder is deliberately not
+  # installed as omarchy-capture-screenrecording: omarchy already owns that path, and
+  # this is the studio's recorder rather than a replacement for it. Nothing internal is
+  # affected -- callers reach it by absolute path, never through PATH.
+  install -d "$pkgdir/usr/bin"
+  local pair name target
+  for pair in \
+    omarchy-studio:omarchy-studio \
+    omarchy-recordings:omarchy-recordings \
+    omarchy-studio-record:omarchy-capture-screenrecording \
+    omarchy-capture-screenrecording-edit:omarchy-capture-screenrecording-edit \
+    omarchy-studio-transcribe:omarchy-studio-transcribe \
+    omarchy-teleprompter:omarchy-teleprompter
+  do
+    name="${pair%%:*}"
+    target="${pair##*:}"
+    ln -s "/usr/lib/$pkgname/bin/$target" "$pkgdir/usr/bin/$name"
+  done
+
+  install -Dm644 packaging/omarchy-studio.desktop \
+    "$pkgdir/usr/share/applications/$pkgname.desktop"
+
+  local size
+  for size in 16 24 32 64 128 256 512; do
+    install -Dm644 "docs/media/logo/png/mark-$size.png" \
+      "$pkgdir/usr/share/icons/hicolor/${size}x${size}/apps/$pkgname.png"
+  done
+  install -Dm644 docs/media/logo/svg/mark-full-accent.svg \
+    "$pkgdir/usr/share/icons/hicolor/scalable/apps/$pkgname.svg"
+
+  install -Dm644 README.md docs/how-it-works.md docs/engines.md docs/using-the-editor.md \
+    -t "$pkgdir/usr/share/doc/$pkgname"
+  install -Dm644 LICENSE "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+}


### PR DESCRIPTION
## What it is

A **Screen Studio-style screen recorder and editor for Omarchy** — the polished-product
kind of screen recording that Linux has largely not had.

You record, and then you decide everything else afterwards. Recording captures pixels,
editing captures intent, and export is the only place the two meet:

- **Automatic zoom, derived from your clicks.** The clicks are recorded as *data*, not
  baked in, so the zoom they imply can be retuned, or an individual move deleted, long
  after the take is over.
- **The camera is a separate stream**, never composited into the frame — move it,
  resize it, reshape it, mirror it, shadow it, or cut it out of part of the take, after
  the fact.
- **Backdrops** with padding, rounded corners and a drop shadow, so a raw capture reads
  as a finished video.
- **Cuts, text, captions, and redaction** (blur/pixelate, applied at export at a
  strength calibrated so the preview shows exactly what ships).
- **Nothing is rendered until you export.** The editor plays a proxy; a recording is a
  bundle directory whose `edit.json` is the only thing an edit writes. Delete it and you
  have the raw capture back.

It is built for Hyprland specifically: three capture backends (KMS for 60fps and
sub-rectangle capture, xdg-desktop-portal where a window needs hiding so the camera
self-view stays out of the recording, and `hyprland_toplevel_export_v1` for true
single-window capture), a click/cursor daemon sampling the pointer over Hyprland's own
socket, and a HUD the compositor keeps out of the frame.

Docs: https://the2dl.github.io/omarchy-studio/ · Repo: https://github.com/the2dl/omarchy-studio

## The package

`{"source": "local"}` with an `upstream.git_tags` declaration, so `bin/sync-upstream`
follows new releases without another PR here.

- **Both architectures.** `arch=('x86_64' 'aarch64')`. Upstream CI builds and runs the
  full suite natively on both on every push, including a check that the compiled
  single-window recorder is actually inside the package.
- **Sources the release tarball with a pinned `sha256`**, not `git+…#tag=`.
- **Installs the tree whole** under `/usr/lib/omarchy-studio` rather than split across
  FHS: the entry points locate `lib/`, `editor/`, `daemon/` and `contrib/` relative to
  their own resolved path.
- **Does not take `/usr/bin/omarchy-capture-screenrecording`** — omarchy already owns
  that path. The recorder goes on `PATH` as `omarchy-studio-record`, which is the better
  name anyway: this is the studio's recorder, not a replacement for omarchy's. Nothing
  internal is affected; callers reach it by absolute path.
- **`check()` runs the suite** (921 tests) minus `tests/test_parity.py`, which renders
  frames through QML and compares them pixel-wise against the ffmpeg export. That one
  wants a live compositor — a `VideoOutput` grabs empty under every headless Qt
  platform — so it belongs in a graphical session rather than on a build host.

Runtime deps are all in Arch repos plus `omarchy` itself (for `omarchy-shell`, which
refreshes the bar indicator, and `omarchy-notification-send`). `faster-whisper` is
optional and only used for caption transcription.

## Testing

Built and installed on Omarchy (x86_64) from this exact PKGBUILD; the aarch64 package is
built and published by upstream CI on native arm64 runners.
