### PR TITLE
Rebuild Intel IPU7 camera against updated jsoncpp

### DIFF
--- a/pkgbuilds/intel-ipu7-camera/.omarchy/package.json
+++ b/pkgbuilds/intel-ipu7-camera/.omarchy/package.json
@@ -1,3 +1,11 @@
 {
-  "source": "local"
+  "source": "local",
+  "rebuild_on": [
+    "jsoncpp"
+  ],
+  "rebuilt_against": {
+    "x86_64": {
+      "jsoncpp": "1.9.8-1"
+    }
+  }
 }

--- a/pkgbuilds/intel-ipu7-camera/PKGBUILD
+++ b/pkgbuilds/intel-ipu7-camera/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=intel-ipu7-camera
 pkgver=1.0.5
-pkgrel=1
+pkgrel=2
 pkgdesc="Intel IPU7 MIPI camera stack for Hurrican/Performance (OV08X40 + hardware ISP)"
 arch=('x86_64')
 url="https://github.com/TsaiGaggery/hurrican_omarchy_enabling"


### PR DESCRIPTION
The installed Intel IPU7 camera HAL requires `libjsoncpp.so.26`, but jsoncpp 1.9.8-1 now provides `libjsoncpp.so.27`. The HAL consequently fails to load, leaving applications with no usable camera stream.

Bump `intel-ipu7-camera` from `1.0.5-1` to `1.0.5-2` so the release builder recompiles the HAL against the current library. Add `jsoncpp` to `rebuild_on` and use `bin/sync-rebuilds intel-ipu7-camera` to record the x86_64 dependency version, so future jsoncpp updates also trigger a package release.

Validation: `bin/sync-rebuilds --self-test`, a second targeted sync with no further changes, package metadata validation, `bash -n`, `makepkg --printsrcinfo`, and `git diff --check` all passed. A full package build and camera hardware test remain for the rebuilt package.
