### PR TITLE
Fix Sunshine AUR sync and ARM submodule checkout

### DIFF
--- a/pkgbuilds/sunshine/.omarchy/package.json
+++ b/pkgbuilds/sunshine/.omarchy/package.json
@@ -1,4 +1,4 @@
 {
   "source": "aur",
-  "upstream_commit": "3c38fe4064f8c8a49b9d2420468c29f812074d3f"
+  "upstream_commit": "42bc63ecad9478b35338d34ed923887bdbd81b29"
 }

--- a/pkgbuilds/sunshine/.omarchy/patches/arm-dependencies.patch
+++ b/pkgbuilds/sunshine/.omarchy/patches/arm-dependencies.patch
@@ -1,50 +1,49 @@
 --- a/PKGBUILD
 +++ b/PKGBUILD
-@@ -36,7 +36,6 @@ depends=(
+@@ -38,7 +38,6 @@
    'libcap'
    'libdrm'
    'libevdev'
 -  'libmfx'
-   'libnotify'
    'libpipewire'
    'libpulse'
-@@ -53,6 +52,10 @@ depends=(
+   'libva'
+@@ -58,6 +57,9 @@
    'which'
  )
  
-+depends_x86_64=(
-+  'libmfx'
-+)
++# Intel Media SDK is unavailable on ARM.
++depends_x86_64=('libmfx')
 +
  makedepends=(
    'appstream'
    'appstream-glib'
-@@ -69,6 +72,10 @@ makedepends=(
+@@ -72,6 +74,9 @@
    'shaderc'
  )
  
-+makedepends_aarch64=(
-+  'vulkan-headers'
-+)
++# Use distro Vulkan headers instead of the bundled SDK's recursive sources.
++makedepends_aarch64=('vulkan-headers')
 +
  checkdepends=(
    'gcovr'
- )
-@@ -111,7 +118,12 @@ if [ -n "${optdepends+x}" ]; then
+   'imagemagick'
+@@ -119,7 +124,13 @@
  
  prepare() {
      cd "$pkgname"
--    git submodule update --recursive --init
+-    git submodule update --recursive --init --depth 1
 +    if [[ $CARCH == aarch64 ]]; then
-+      git submodule update --init
-+      git -C third-party/moonlight-common-c submodule update --init enet
++      git submodule update --init --depth 1
++      # Fetch Moonlight's nested sources without pulling in the bundled SDK.
++      git -C third-party/moonlight-common-c submodule update --recursive --init --depth 1
 +    else
-+      git submodule update --recursive --init
++      git submodule update --recursive --init --depth 1
 +    fi
+ }
  
-     # Backport https://github.com/LizardByte/Sunshine/commit/060b6b07d376e9ef4c4ce4a5c6d648d08fe0eab9
-     patch -Np1 -i "${srcdir}/2026.516.143833-060b6b07-remove-setuptools-from-glad-dependencies.patch"
-@@ -145,6 +157,10 @@ build() {
+ build() {
+@@ -149,6 +160,10 @@
        -D SUNSHINE_PUBLISHER_ISSUE_URL='https://app.lizardbyte.dev/support'
      )
  

--- a/pkgbuilds/sunshine/PKGBUILD
+++ b/pkgbuilds/sunshine/PKGBUILD
@@ -6,11 +6,11 @@
 : "${_support_headless_testing:=false}"
 : "${_use_cuda:=detect}" # nvenc
 
-: "${_commit:=14ffa6fdaa53f7b51512be2b3d24f3939695403c}"
+: "${_commit:=cb72dffa3233c5815cd5ba88f09f049dd679ba75}"
 
 pkgname='sunshine'
-pkgver=2026.516.143833
-pkgrel=4.1
+pkgver=2026.906.222525
+pkgrel=1.1
 pkgdesc="Self-hosted game stream host for Moonlight"
 arch=('x86_64' 'aarch64')
 url=https://app.lizardbyte.dev/Sunshine
@@ -32,11 +32,12 @@ depends=(
   'avahi'
   'curl'
   'gcc-libs'
+  'gtk3'
+  'hicolor-icon-theme'
   'libayatana-appindicator'
   'libcap'
   'libdrm'
   'libevdev'
-  'libnotify'
   'libpipewire'
   'libpulse'
   'libva'
@@ -49,14 +50,15 @@ depends=(
   'numactl'
   'openssl'
   'opus'
+  'qt6-base'
+  'qt6-svg'
   'udev'
   'vulkan-icd-loader'
   'which'
 )
 
-depends_x86_64=(
-  'libmfx'
-)
+# Intel Media SDK is unavailable on ARM.
+depends_x86_64=('libmfx')
 
 makedepends=(
   'appstream'
@@ -72,12 +74,12 @@ makedepends=(
   'shaderc'
 )
 
-makedepends_aarch64=(
-  'vulkan-headers'
-)
+# Use distro Vulkan headers instead of the bundled SDK's recursive sources.
+makedepends_aarch64=('vulkan-headers')
 
 checkdepends=(
   'gcovr'
+  'imagemagick'
 )
 
 optdepends=(
@@ -87,16 +89,8 @@ optdepends=(
 provides=()
 conflicts=()
 
-source=(
-  "$pkgname::git+https://github.com/LizardByte/Sunshine.git#commit=${_commit}"
-  '2026.516.143833-060b6b07-remove-setuptools-from-glad-dependencies.patch'
-  '2026.516.143833-3377f7a7-link-shared-libstdcxx-with-gcc-15.patch'
-)
-sha256sums=(
-  'SKIP'
-  '06a78d624975887541e2b0013b3085e798195e334fdb05d35caf4bbad818ddde'
-  '63f86f6ffd6d9f3da35353109fa4a4df9a900a791f70b29cafc8e464b870337d'
-)
+source=("$pkgname::git+https://github.com/LizardByte/Sunshine.git#commit=${_commit}")
+sha256sums=('SKIP')
 
 # Options Handling
 if [[ "${_use_cuda::1}" == "d" ]] && pacman -Qi cuda &> /dev/null; then
@@ -131,22 +125,17 @@ fi
 prepare() {
     cd "$pkgname"
     if [[ $CARCH == aarch64 ]]; then
-      git submodule update --init
-      git -C third-party/moonlight-common-c submodule update --init enet
+      git submodule update --init --depth 1
+      # Fetch Moonlight's nested sources without pulling in the bundled SDK.
+      git -C third-party/moonlight-common-c submodule update --recursive --init --depth 1
     else
-      git submodule update --recursive --init
+      git submodule update --recursive --init --depth 1
     fi
-
-    # Backport https://github.com/LizardByte/Sunshine/commit/060b6b07d376e9ef4c4ce4a5c6d648d08fe0eab9
-    patch -Np1 -i "${srcdir}/2026.516.143833-060b6b07-remove-setuptools-from-glad-dependencies.patch"
-
-    # Backport the GCC 15+ linking fix from https://github.com/LizardByte/Sunshine/commit/3377f7a73f8768518430f4c771987153fcd77b77
-    patch -Np1 -i "${srcdir}/2026.516.143833-3377f7a7-link-shared-libstdcxx-with-gcc-15.patch"
 }
 
 build() {
     export BRANCH="master"
-    export BUILD_VERSION="2026.516.143833"
+    export BUILD_VERSION="2026.906.222525"
     export COMMIT="${_commit}"
 
     export CC="gcc${_gcc_env_suffix}"
@@ -198,7 +187,7 @@ build() {
     fi
 
     if [[ -z "${GITHUB_ACTIONS}" ]]; then
-      _appstreamcli_arguments=(--no-net)
+	    _appstreamcli_arguments=(--no-net)
     fi
 
     cmake "${_cmake_options[@]}"
@@ -217,7 +206,9 @@ check() {
       export CXX="g++${_gcc_env_suffix}"
 
       cd "${srcdir}/build/tests"
-      ./test_sunshine --gtest_color=yes --gtest_output=xml:test_results.xml
+      # Do not silently upload misleading coverage if the gcov runtime cannot
+      # write profile data, such as when its version differs from the compiler.
+      GCOV_EXIT_AT_ERROR=1 ./test_sunshine --gtest_color=yes --gtest_output=xml:test_results.xml
 
       # Generate coverage report
       # Run gcovr from the build directory (where all .gcda/.gcno files are)

--- a/pkgbuilds/sunshine/sunshine.install
+++ b/pkgbuilds/sunshine/sunshine.install
@@ -1,11 +1,15 @@
+# shellcheck shell=bash
+
 do_setcap() {
-  setcap cap_sys_admin,cap_sys_nice+p $(readlink -f usr/bin/sunshine)
+  setcap cap_sys_admin,cap_sys_nice+p "$(readlink -f usr/bin/sunshine)"
 }
 
 do_udev_reload() {
   udevadm control --reload-rules
   udevadm trigger --property-match=DEVNAME=/dev/uinput
   udevadm trigger --property-match=DEVNAME=/dev/uhid
+  udevadm trigger --subsystem-match=hidraw
+  udevadm trigger --subsystem-match=input
   modprobe uinput || true
   modprobe uhid || true
 }


### PR DESCRIPTION
Sunshine's September 7 AUR update broke the context in our ARM patch, causing the entire scheduled AUR sync to fail. Refresh the patch and sync Sunshine to `2026.906.222525-1.1` from AUR commit `42bc63e`.

Keep `libmfx` on x86_64 only and use system Vulkan headers on aarch64. ARM now fetches Moonlight's submodules recursively: this release needs `nanors` and its nested sources as well as `enet`. Recursion stays limited to Moonlight so ARM avoids downloading the bundled SDK's source tree. Sunshine remains AUR-managed.

Validation:

- Full AUR sync in an isolated checkout: 68 synced, zero failures.
- Repeated Sunshine sync produces identical files; patch applies without fuzz or offsets.
- [GitHub sync-aur workflow passed for Sunshine on this branch](https://github.com/omacom/omarchy-pkgs/actions/runs/34309043802).
- Complete x86_64 and aarch64 package builds passed through `bin/build`; aarch64 ran under QEMU.
- Installed each package in a fresh container: `sunshine --version` reports `2026.906.222525` at commit `cb72dffa3233c5815cd5ba88f09f049dd679ba75`, with no missing shared libraries.
- Verified both ELF architectures and package metadata: `libmfx` only on x86_64, `vulkan-headers` as a build dependency only on aarch64.
- Both PR CI checks, Bash syntax and `git diff --check` passed.

The container checks cover building and installation; hardware streaming was not exercised.

Failed job: https://github.com/omacom/omarchy-pkgs/actions/runs/34307722552/job/102327780895
