### PR TITLE
Install the omarchy-camera-watch user unit

### DIFF
--- a/pkgbuilds/omarchy-settings-dev/PKGBUILD
+++ b/pkgbuilds/omarchy-settings-dev/PKGBUILD
@@ -193,6 +193,7 @@ package() {
   install -Dm644 default/systemd/user/omarchy-tailscale-receive.service "$pkgdir/usr/lib/systemd/user/omarchy-tailscale-receive.service"
   install -Dm644 default/systemd/user/omarchy-fcitx5.service "$pkgdir/usr/lib/systemd/user/omarchy-fcitx5.service"
   install -Dm644 default/systemd/user/omarchy-crash-watch.service "$pkgdir/usr/lib/systemd/user/omarchy-crash-watch.service"
+  install -Dm644 default/systemd/user/omarchy-camera-watch.service "$pkgdir/usr/lib/systemd/user/omarchy-camera-watch.service"
   # Marks app.slice (and only app.slice) as a systemd-oomd kill candidate, so
   # memory pressure costs one app scope instead of the compositor session.
   # Thresholds live in etc/systemd/oomd.conf.d/10-omarchy.conf. Both this and

--- a/pkgbuilds/omarchy-settings/PKGBUILD
+++ b/pkgbuilds/omarchy-settings/PKGBUILD
@@ -188,6 +188,7 @@ package() {
   install -Dm644 default/systemd/user/omarchy-tailscale-receive.service "$pkgdir/usr/lib/systemd/user/omarchy-tailscale-receive.service"
   install -Dm644 default/systemd/user/omarchy-fcitx5.service "$pkgdir/usr/lib/systemd/user/omarchy-fcitx5.service"
   install -Dm644 default/systemd/user/omarchy-crash-watch.service "$pkgdir/usr/lib/systemd/user/omarchy-crash-watch.service"
+  install -Dm644 default/systemd/user/omarchy-camera-watch.service "$pkgdir/usr/lib/systemd/user/omarchy-camera-watch.service"
   # Marks app.slice (and only app.slice) as a systemd-oomd kill candidate, so
   # memory pressure costs one app scope instead of the compositor session.
   # Thresholds live in etc/systemd/oomd.conf.d/10-omarchy.conf. Both this and


### PR DESCRIPTION
omacom/omarchy#11053 adds `omarchy-camera-watch`, a user service that names the app holding a camera over V4L2 when every other app reports no camera. Its unit is enabled from `install/user/first-run/enable-user-units.sh` in one `systemctl --user enable --now` call with the other shipped units, so it has to exist under `/usr/lib/systemd/user` where systemd looks, or the whole call fails and first-run never completes, the way it did for `omarchy-crash-watch` in #140.

This adds the install line to `omarchy-settings` and `omarchy-settings-dev`, next to the crash watcher's. Merge it right behind the omarchy side: `omarchy-settings-dev` builds the quattro tip, so `install -D` needs the unit there, while `omarchy-settings` pins a tag and picks the line up at the next release cut.

Validation: with this checkout as a sibling of the omarchy branch, `test/shell.d/config-test.sh` there goes from "PKGBUILD does not explicitly install default/systemd/user/omarchy-camera-watch.service" to passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
