### PR TITLE
chore(mise): bump to 2026.9.4

### DIFF
--- a/pkgbuilds/mise-bin/PKGBUILD
+++ b/pkgbuilds/mise-bin/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Jeff Dickey <releases@mise.jdx.dev>
 pkgname=mise-bin
-pkgver=2026.9.1
+pkgver=2026.9.4
 pkgrel=1
 pkgdesc="dev tools, env vars, task runner"
 arch=('x86_64' 'aarch64')
@@ -14,8 +14,8 @@ provides=('mise')
 conflicts=('mise')
 source_x86_64=("https://github.com/jdx/mise/releases/download/v${pkgver}/mise-v${pkgver}-linux-x64.tar.xz")
 source_aarch64=("https://github.com/jdx/mise/releases/download/v${pkgver}/mise-v${pkgver}-linux-arm64.tar.xz")
-sha256sums_x86_64=('bbc21f8fe9b2aa09f74250be15f9bf32e87562e1039d858ad91d7944f057c8e2')
-sha256sums_aarch64=('7d0c28d44bd7e1c5444a7d867146afabe43592c728329bc0ed5ec59ca7106c48')
+sha256sums_x86_64=('77f312d9cb4696f5ba547af4296f50de86b2d280d73f98eb4d4ae71cda559607')
+sha256sums_aarch64=('ed4a996247a6f1fa088c8f6ae3c64c255a463347e2c6d074155e7147c454b0e3')
 
 package() {
     install -Dm755 "${srcdir}/mise/bin/mise" "${pkgdir}/usr/bin/mise"


### PR DESCRIPTION
Bump `mise-bin` from 2026.9.1 to [2026.9.4](https://github.com/jdx/mise/releases/tag/v2026.9.4), with the published x86_64 and aarch64 archive checksums. This includes the Muse and Basecamp registry entries required by [omacom/omarchy#9596](https://github.com/omacom/omarchy/pull/9596).

The release workflow completed successfully. Both archives were downloaded and their SHA-256 hashes verified against the published `SHASUMS256.txt` and GitHub asset digests. `bash -n` and `git diff --check` pass.

Validated in an Arch Linux x86_64 container:

- `makepkg --verifysource`, package build, and pacman installation passed. `pacman -Qkk mise-bin` reported zero altered files; `/usr/lib/mise/.disable-self-update` is installed.
- The installed binary reports 2026.9.4 and includes the Cursor Agent, Muse, and Basecamp registry shorthands.
- Against omacom/omarchy#9596 at `5f1cadcc`: offline generation of 22 lazy shims, actual cold installs/execution of Basecamp, Cursor Agent, Muse, and uv under `MISE_LOCKED=1`, and resolution of the remaining defaults via `mise install --include-lazy --dry-run` passed.
- Real mise/config operations for migration, user finalization, Remove/Restore Preinstalls, and later tool migrations passed. Desktop actions and unrelated package transactions were mocked.
- All six focused Omarchy shell suites and the CLI routing/metadata suite passed as an unprivileged user.

The aarch64 archive was checksum-verified but not executed. Full fresh-ISO and graphical Omarchy acceptance remain for validation on an Omarchy box.

*AI-assisted — Tool: Codex; model: unavailable; version: unavailable.*
