### PR TITLE
Initialize pacman keys in build containers

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -65,6 +65,10 @@ if [[ "$DRY_RUN" != true ]]; then
 
   mkdir -p "$BUILD_OUTPUT_DIR" "$FINAL_OUTPUT_DIR"
 
+  # The image drops pacman's private signing key. Keyring upgrades need a
+  # container-local key to sign newly trusted keys.
+  sudo pacman-key --init || exit 1
+
   # Bring the container up to date before any makedepends are installed. The
   # image is layer-cached, so its glibc drifts behind the mirror while makepkg
   # -s pulls makedepends from the freshly synced database -- a partial upgrade

--- a/tests/build-isolation.Dockerfile
+++ b/tests/build-isolation.Dockerfile
@@ -7,5 +7,7 @@ RUN pacman -Syu --noconfirm git jq sudo && \
     printf '#!/bin/bash\nexec /usr/bin/pacman --ask 4 "$@"\n' > /usr/local/bin/pacman-for-makepkg && \
     chmod +x /usr/local/bin/pacman-for-makepkg && \
     mkdir /src && chown builder:builder /src
+# Match the production image, which does not retain pacman's private key.
+RUN rm -rf /etc/pacman.d/gnupg/private-keys-v1.d
 USER builder
 WORKDIR /src

--- a/tests/build-isolation.sh
+++ b/tests/build-isolation.sh
@@ -62,6 +62,17 @@ run_build() {
   "$TEST_ROOT/bin/build" --arch "$TEST_ARCH" --package "$@"
 }
 
+# Exercise keyring population even if the image's keyring package is current.
+fixture keyring ''
+cat >> "$TEST_ROOT/pkgbuilds/keyring/PKGBUILD" <<'EOF'
+check() { sudo pacman-key --populate archlinux; }
+EOF
+run_build keyring > "$TEST_ROOT/keyring.log" 2>&1 || {
+  cat "$TEST_ROOT/keyring.log"
+  exit 1
+}
+printf 'PASS: keyring population works without a private key in the image\n'
+
 fixture omarchy-settings ''
 fixture omarchy "depends=('omarchy-settings=1')"
 fixture omarchy-settings-dev "provides=('omarchy-settings'); conflicts=('omarchy-settings')"


### PR DESCRIPTION
The builder image removes pacman's private signing key. When a later build upgrades `archlinux-keyring`, its install script cannot locally sign trusted keys and reports

```text
==> ERROR: There is no secret key available to sign with.
==> Use 'pacman-key --init' to generate a default secret key.
```

I reproduced this during native ARM testing of the isolated builder from #360. The package build can still succeed despite this keyring error.

Run `pacman-key --init` inside each build container before `pacman -Syu`, aborting if initialization fails. The key stays local to that container. The image still drops its private key, signature policy is unchanged, and dry-run planning does not initialize a keyring.

The existing isolation suite now uses a fixture image without the private key and checks `pacman-key --populate archlinux` during a source-free package build. This exercises the failure even when the installed keyring package is already current.

## Validation

- The new regression fails on unmodified `master` with the missing-secret-key error.
- All seven isolation scenarios pass on native ARM64 with the fix.
- All four repository self-test suites pass.
- Bash syntax, ShellCheck at the existing error severity and `git diff --check` pass.
- Native x86_64 validation is pending. The [existing CI run](https://github.com/omacom/omarchy-pkgs/actions/runs/34420227188) reports `action_required`, with no jobs started, and needs maintainer approval.

Based directly on `master`, with no ARM workflow or Snapdragon package dependencies.
