### PR TITLE
Add cuda, gcc15 and ollama for aarch64 NVIDIA systems

### DIFF
--- a/pkgbuilds/cuda/.omarchy/package.json
+++ b/pkgbuilds/cuda/.omarchy/package.json
@@ -1,0 +1,3 @@
+{
+  "source": "local"
+}

--- a/pkgbuilds/cuda/PKGBUILD
+++ b/pkgbuilds/cuda/PKGBUILD
@@ -1,0 +1,284 @@
+# NVIDIA's SBSA (generic ARM64 server) CUDA 13 toolkit, repackaged from the
+# vendor .deb payloads. Arch Linux ARM ships no cuda package. Layout follows
+# the vendor's /usr/local/cuda-13.0 tree rather than Arch x86_64's /opt/cuda,
+# because the payloads' own launchers and configs reference that path.
+pkgname=cuda
+pkgver=13.0.3
+pkgrel=2
+pkgdesc='NVIDIA CUDA 13 toolkit for aarch64 (SBSA)'
+arch=('aarch64')
+url='https://developer.nvidia.com/cuda-toolkit'
+license=('LicenseRef-NVIDIA-CUDA')
+depends=('glibc>=2.42' 'gcc-libs' 'zlib' 'numactl' 'libxml2' 'libxcrypt-compat')
+optdepends=('gcc15: CUDA-compatible host compiler at /opt/gcc15/bin/g++'
+            'nvidia-utils: NVIDIA driver userspace'
+            'nsight-compute: CUDA profiling GUI'
+            'nsight-systems: system profiling GUI')
+options=('!strip' '!debug')
+backup=('usr/local/cuda-13.0/gds/cufile.json')
+source=(
+  https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/sbsa/./libcurand-13-0_10.4.0.35-1_arm64.deb
+  https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/sbsa/./libcurand-dev-13-0_10.4.0.35-1_arm64.deb
+  https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/sbsa/./cuda-cccl-13-0_13.0.85-1_arm64.deb
+  https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/sbsa/./cuda-crt-13-0_13.0.88-1_arm64.deb
+  https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/sbsa/./cuda-culibos-dev-13-0_13.0.85-1_arm64.deb
+  https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/sbsa/./cuda-cuobjdump-13-0_13.0.85-1_arm64.deb
+  https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/sbsa/./cuda-cupti-13-0_13.0.85-1_arm64.deb
+  https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/sbsa/./cuda-cupti-dev-13-0_13.0.85-1_arm64.deb
+  https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/sbsa/./cuda-cuxxfilt-13-0_13.0.85-1_arm64.deb
+  https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/sbsa/./cuda-documentation-13-0_13.0.85-1_arm64.deb
+  https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/sbsa/./cuda-gdb-13-0_13.0.85-1_arm64.deb
+  https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/sbsa/./cuda-nvcc-13-0_13.0.88-1_arm64.deb
+  https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/sbsa/./cuda-nvdisasm-13-0_13.0.85-1_arm64.deb
+  https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/sbsa/./cuda-nvml-dev-13-0_13.0.87-1_arm64.deb
+  https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/sbsa/./cuda-nvprune-13-0_13.0.85-1_arm64.deb
+  https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/sbsa/./cuda-nvrtc-13-0_13.0.88-1_arm64.deb
+  https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/sbsa/./cuda-nvrtc-dev-13-0_13.0.88-1_arm64.deb
+  https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/sbsa/./cuda-nvtx-13-0_13.0.85-1_arm64.deb
+  https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/sbsa/./cuda-profiler-api-13-0_13.0.85-1_arm64.deb
+  https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/sbsa/./cuda-sanitizer-13-0_13.0.85-1_arm64.deb
+  https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/sbsa/./libcufft-13-0_12.0.0.61-1_arm64.deb
+  https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/sbsa/./libcufft-dev-13-0_12.0.0.61-1_arm64.deb
+  https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/sbsa/./libcufile-13-0_1.15.1.6-1_arm64.deb
+  https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/sbsa/./libcufile-dev-13-0_1.15.1.6-1_arm64.deb
+  https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/sbsa/./libcusolver-13-0_12.0.4.66-1_arm64.deb
+  https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/sbsa/./libcusolver-dev-13-0_12.0.4.66-1_arm64.deb
+  https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/sbsa/./libcusparse-13-0_12.6.3.3-1_arm64.deb
+  https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/sbsa/./libcusparse-dev-13-0_12.6.3.3-1_arm64.deb
+  https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/sbsa/./libnpp-13-0_13.0.1.2-1_arm64.deb
+  https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/sbsa/./libnpp-dev-13-0_13.0.1.2-1_arm64.deb
+  https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/sbsa/./libnvfatbin-13-0_13.0.85-1_arm64.deb
+  https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/sbsa/./libnvfatbin-dev-13-0_13.0.85-1_arm64.deb
+  https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/sbsa/./libnvjitlink-13-0_13.0.88-1_arm64.deb
+  https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/sbsa/./libnvjitlink-dev-13-0_13.0.88-1_arm64.deb
+  https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/sbsa/./cuda-cudart-13-0_13.0.96-1_arm64.deb
+  https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/sbsa/./cuda-cudart-dev-13-0_13.0.96-1_arm64.deb
+  https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/sbsa/./cuda-driver-dev-13-0_13.0.96-1_arm64.deb
+  https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/sbsa/./cuda-toolkit-13-0-config-common_13.0.96-1_all.deb
+  https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/sbsa/./cuda-command-line-tools-13-0_13.0.3-1_arm64.deb
+  https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/sbsa/./cuda-compiler-13-0_13.0.3-1_arm64.deb
+  https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/sbsa/./cuda-libraries-13-0_13.0.3-1_arm64.deb
+  https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/sbsa/./cuda-libraries-dev-13-0_13.0.3-1_arm64.deb
+  https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/sbsa/./cuda-nsight-compute-13-0_13.0.3-1_arm64.deb
+  https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/sbsa/./cuda-nsight-systems-13-0_13.0.3-1_arm64.deb
+  https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/sbsa/./cuda-toolkit-13-0_13.0.3-1_arm64.deb
+  https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/sbsa/./cuda-tools-13-0_13.0.3-1_arm64.deb
+  https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/sbsa/./cuda-visual-tools-13-0_13.0.3-1_arm64.deb
+  https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/sbsa/./libcublas-13-0_13.1.1.3-1_arm64.deb
+  https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/sbsa/./libcublas-dev-13-0_13.1.1.3-1_arm64.deb
+  https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/sbsa/./cuda-toolkit-13-config-common_13.2.75-1_all.deb
+  https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/sbsa/./cuda-toolkit-config-common_13.2.75-1_all.deb
+)
+sha256sums=(
+  SKIP
+  SKIP
+  SKIP
+  SKIP
+  SKIP
+  SKIP
+  SKIP
+  SKIP
+  SKIP
+  SKIP
+  SKIP
+  SKIP
+  SKIP
+  SKIP
+  SKIP
+  SKIP
+  SKIP
+  SKIP
+  SKIP
+  SKIP
+  SKIP
+  SKIP
+  SKIP
+  SKIP
+  SKIP
+  SKIP
+  SKIP
+  SKIP
+  SKIP
+  SKIP
+  SKIP
+  SKIP
+  SKIP
+  SKIP
+  SKIP
+  SKIP
+  SKIP
+  SKIP
+  SKIP
+  SKIP
+  SKIP
+  SKIP
+  SKIP
+  SKIP
+  SKIP
+  SKIP
+  SKIP
+  SKIP
+  SKIP
+  SKIP
+  SKIP
+)
+sha512sums=(
+  69188b99e27e7e63ffd9dd392bb7df8857f5a45463e83bcd43989df0707e6ee1732a1c97dc5aeaf86c6e92fb727bb26dce1011d1eb9447ec53b3e8ba8e1f7c2f
+  fc15659370d79b31dd513713769b9c37e393215fa49a481ce55cd2877c6d0ce181ce736787f1cf9b31d65678547632fa2975db519eec3edccb82263f30932d6b
+  4a34d70a7f1b1f1410be128625c908f67f66d35c81926f3167514d909622347e0c6b339317215076a9a592b6f6e7cdf4d14d5a64a645bc89f9ff87ba1fdf767f
+  d8e7f190b804b7cf0ed3fa1b94efdca26e5bf4026e51dac83151928d7ad1bd3898e2a3390b50cdc9e9824d31488b888b32aefa331774339c515e1d293bd074cb
+  e9cd8160524983e21b983216970da2027088c8336284586926bcf839176a9d667fb7d13b2ca6bdecdb7b130cdbb30d2dabeb79073cddee9c791c13895dd9cdb9
+  d88949424c03e0c1668f98c865f5df1af5a1557af8aa84a2e863c7d824e000f45817235c4d9e4c3ba22d6fc3b1a49a1ec00e9b0b8b30b1926f0b1901a4f94b7f
+  a01e2987b5331f18b830961a22671596bc5d34c41c047b25b04079d2d8c5137d047f65ae51c4fd01ceadbbf4227dbd2cb8a537490fd63a9c1fc4f46e3a3e29a1
+  8a6405cdac2189584fc1d6e6dc5abff32480b682c8822c3feb0d9b0e68ad73068200444732299fb427868fcd6cba248de452a2e42b97b5b801cf937d42c011e5
+  bd90f6ec95328902fca8806c1720347c05f21f416a4b2e1318689550206a8d9e21d31141bf6714ea55498c8b268cab789490dde4245c11b08cae47f241563128
+  b84ccc6ef7ce8f9657722ce0d78d569cbbeb9514d8c5270a72a9b80aa756a981bb2c80670cb42af781595dcb41129be14c7609fe5509ba300adbf6bf432d10d4
+  48162b4a9133860aa76beb42fb68f11f709523fa57d3ba793bedd9c875daff797c9d764e454a205cda9d585d1f210f8191d2affc92b982d6f7b1a62a5d11312a
+  6415ade2d7a5f9febfe3449a6ba4ce8bce4b9dcec727c070bca8f63c944abb8ed947f34f653fc51de1e70cdfd060db7cd84109c57ee30fd5cf521d8fd8951138
+  589809df0eee72cf9a8805a249452fc618a789eda122057029ebfb25f9d24f9147d99e103efb2a79d16b34aea08f4bbd32c9068d0356211a3861e7aa69c31711
+  5a42450542eb18558d5519199b024f342abf125e9520a11ddf67e9355d287138a27f8d00d48fb23359603e6feae62ccde31876303dd916abacb46e3bfb1d6f6c
+  604b47d7018b4b3436d3e494a8e6197429b011c537bb8a2817a475aebfbe61407a4da1a628f4b16d03f219f9630a10684fb6d562f1ac9ac6c33cfdcbc3bce04c
+  47e719dbdff3c11bfd26b9d3f6d21d1f4411eb3fd8ef1ad97b7682b759f32942cd2db604764313ef5705c1aa4e066fbab1009af2705986badc556b2f3b6cfd24
+  cb31cb67c095e574bb10106ae82924ef19d9837297ca0986c618893f9b5361f700a3744b078c249db03cf36b912b88131754623d1fe604090b681ebde4186922
+  a8fae1e7b1f76a307df0927543b8a0a68ab66027a60407b87d0064e20d1d6809dcc5caa8329dcfd75b93ca6dbd54d7cc3e79c418026b39af778b59e013a52cda
+  6999f6ddad435d530b63b9fd0b0a3a4a93820bbad9b1407227d0256de27bbe4721512df47fde13ea86e21c76e227d92a9289080e10e3d1a678765d0553bcfe0c
+  21106776e3e03e5c0184bb6b02db60263fda6a8006bebea41764d99baee192a1528271ca0891dab4c1f21cedda33cc15f4acb2a23ca4d7221418258077a584e0
+  3fcd9b5deebb2368cb2a6f2a4008b6701122416b202e83d890b7e303914044ad7e13ad0de109c7af14fa94b7931290368bfe8b594952863c9517b5c8d470da0c
+  ddaa17954c83644e1f6a0f288d1275c1ca6c875da10199c5bd6bf86ab4c68d27ed3f458c5ea749169454a1fdf6c3d94e6f8fb8d553c105b665e56efdeab1b11e
+  11ab8fa4371f82d99fdbdd0d3b85ab04d5b013bdfbd6884a4c680baf6992bae121e8eae82379e2fef2310a1bf8c31517d444d1e1698aa36629830c27db39715f
+  449b885b94fb13c146bd2df4041c4a6c0d0de36ab2be059d4e50143899385512632ee0e6dc1f4e47927c4605ce18ca90e10d62be8aa449a5ba0d32a0c5f04396
+  e988bead76ed2b3de477ae69efa23eac7f6da3c72d65c2e520003adeb8d6921ac2236cc29d515044335a3ece047508c33892c5937ec05dd21f3abd28b1376dbb
+  25c3bda9af1c92e37e7ae5ccc2e731f84f4e8ce29055a604cd93962017f99625cbd6ad993d276a66e0c08d5ec236bb1a6ac108e6ee9cd7c964607291a24b3774
+  fbc4d5e931f9ffd786439c4fe3c0b4e16129ea5db5bea5d87ba220f1d76b6dbe58590d622cad6f2f19512a441de22945bed7078edb44011af6b7d347a472ace7
+  2de4bc9c2bc511aa144f9c782fdfde37248e759a16b00e73bac7d5af25765c6135492fd5e8fe7cd04ac0241fee1098c88ce11baeeece3eddf14923eb1b0d2408
+  05613aede825dd37b76cb90ae9012b38d60d251e6dcd92bf59fd9c8dab3df391e66dc84a71acc3489856badc999c70e8a6af94e4093de51a0fe50dd79a5581af
+  940aa5256ea24eefb24094dfdb856d23b3fb8ea528f92d8ef69c1eed6f8fa259c57b100dfe4c3cefd022a635495089a8dcf6acf724022f9d005810519c9d0558
+  a3909615a1d19c8813422ba99f3ace0921cbf0633c14e5ffab22c3dec731b8696343fddf76c084a349c03c3e5a65ad6333d8fab94ca96cad92bdd1fa5ceff39e
+  cc67c766e35cf64ed0e235412c127eab0e0f51aed1037c401f2408baf6ea2490a58c6aff5b39e974f663e457de4bd84b7ddaf9cdf64892062893a670337acf3d
+  3ade61de30c3ecc57238cda9c5f1d55a998b896e2075fc047f08d6f2b1fc2854598408bc1e63693d942ef2821e6941d3103b9324a7a500face89f37d75d193e3
+  84ad9be3c673eda1d04ea11bc6f6c52bf8166c0cd8010ac23ba992186f67505d8dc82614dac08a3a20b61962913f5db5e3ae6f6b3b35584bb1e6b7eea1b12b3d
+  4531814640a7488525b48ace659a551ca8b2f0113fa9d2d66bd8e09318a4efec7f30905ad7c6a41e60496646729fab0c300d4955ca6922bbb8db1c85a35081a2
+  173dce5e97870c038bfa5540e4ad9f680c53c66c0fa8eae9137888ef83a82f05a06f77146abe78b63a3413170582d4585c670f8b5a31451d42d8f3305a687593
+  4e6db9682aa64dfb66bb198e5bddc649e2289ba4e25ad929b4a2140a553be7d65edeff18b64f2c96ef5cc7df65b66b3378d6e04b285a7a8afe8c8212bf610b6c
+  69c5db4ea4a94ea2e79d0edc49ef8ca50a170836456981edb78370ce20607265509252b4c9339d339a443e47a23b7e247369bb19407065dd45434ea33256ada6
+  e6f037b64dd29c46ce2e0a84501344955835d444ac6c56ac6b82153edb4c9887343c4031869d828f8add69af110e3054a79475a23ffb3525a94fd5f35b82ea88
+  d74b3885b1c5ad4c08573be0a4d8d7b461ecb107efdb244ea746ec1e8ebf995739881fd969c0659af10e2ade82b8b72c356492357a883bdc57a0a94c2f8840c2
+  4d1eb154d46a6458ae256e89a9232fbceb6b62be958dd6a83770fcabe50414d109a14508ddb481691444df291cc95400038683a55e3a7dbcb91516a032b8f662
+  cabe3281c9d26fa0361fc0892218c795b88809b524023eeca7b992f19e2325b98a15ae56d4d7ffc76204c2fbb137a5dbcaae5ca5829c8e1bef62e4548ca8fcea
+  ccde6dae471cd42988dbc000d577f65a43aeee795559aaf5830fe6e440768e71773112b62048dcd258351af595fef63184326434efcbaa3e8860f5e61fdf3ca8
+  b10c6482e7e19342d13e12df6d0881d4ac3cdf190e25406f125ec9bf95d0e6bbde79ed077145b5fa0ba0db96d6bf40a59bae61dcdcc46c5e22aaf6006b357958
+  0933bb7db867b0cbd4e8de7d0b048c9b22d45bbd52ddef8b84a18a57fc73946373b609b238d0f4b715c3b22aa1078bcdf23c75125fde21ce1f3f8ac9b38c00b0
+  70af3471a0b7d7cad3d1898d86844ee1c0c5dd8ed96faf1af5d58166c5a02925ea0d30e08d582b0572f59092f0c500668d3d98ac61e65ec646a1515e033b1872
+  3cd55f5a55eebd2b6da09886259de0a54a7e45761e2dbffdebffe0a8a5b884afd926af77c8126ef56443a083317f039f20cc11fad3dcd1cee7da2f70cc87d9ef
+  ff400df3955818520eb813b7a9d84fb107ac13a81a73bb4cd8f0d90dd6e03daae86118ea7e4137e7c86fa1af0261a90a08fd2495b90e3fe40fd32a450a639766
+  2fd13d62622be1c50612c092065dd9201cb0cb8f4a0d4cacb9a80de37bb689f28a83983f07770b2dce93f38ddc1e9a5411c0ab5d8c5ba5732887fdf53b1475ba
+  01a0131a6d5be8797e52a6246305223423f1d722344e50b1282d1ea9d2c791b99b904b27251324ae194b501690da41a85377bbe69232be27730b0e7bf69e4c76
+  ea597e97c9704b67e1768466fc671dd520e142a8d2a46a6d43fb6bd7d61d0c900f6b2f9d022c0c86cfc6383c06036dd1d3ab9646074d3aac068d4cd4e4623b3c
+)
+noextract=(
+  libcurand-13-0_10.4.0.35-1_arm64.deb
+  libcurand-dev-13-0_10.4.0.35-1_arm64.deb
+  cuda-cccl-13-0_13.0.85-1_arm64.deb
+  cuda-crt-13-0_13.0.88-1_arm64.deb
+  cuda-culibos-dev-13-0_13.0.85-1_arm64.deb
+  cuda-cuobjdump-13-0_13.0.85-1_arm64.deb
+  cuda-cupti-13-0_13.0.85-1_arm64.deb
+  cuda-cupti-dev-13-0_13.0.85-1_arm64.deb
+  cuda-cuxxfilt-13-0_13.0.85-1_arm64.deb
+  cuda-documentation-13-0_13.0.85-1_arm64.deb
+  cuda-gdb-13-0_13.0.85-1_arm64.deb
+  cuda-nvcc-13-0_13.0.88-1_arm64.deb
+  cuda-nvdisasm-13-0_13.0.85-1_arm64.deb
+  cuda-nvml-dev-13-0_13.0.87-1_arm64.deb
+  cuda-nvprune-13-0_13.0.85-1_arm64.deb
+  cuda-nvrtc-13-0_13.0.88-1_arm64.deb
+  cuda-nvrtc-dev-13-0_13.0.88-1_arm64.deb
+  cuda-nvtx-13-0_13.0.85-1_arm64.deb
+  cuda-profiler-api-13-0_13.0.85-1_arm64.deb
+  cuda-sanitizer-13-0_13.0.85-1_arm64.deb
+  libcufft-13-0_12.0.0.61-1_arm64.deb
+  libcufft-dev-13-0_12.0.0.61-1_arm64.deb
+  libcufile-13-0_1.15.1.6-1_arm64.deb
+  libcufile-dev-13-0_1.15.1.6-1_arm64.deb
+  libcusolver-13-0_12.0.4.66-1_arm64.deb
+  libcusolver-dev-13-0_12.0.4.66-1_arm64.deb
+  libcusparse-13-0_12.6.3.3-1_arm64.deb
+  libcusparse-dev-13-0_12.6.3.3-1_arm64.deb
+  libnpp-13-0_13.0.1.2-1_arm64.deb
+  libnpp-dev-13-0_13.0.1.2-1_arm64.deb
+  libnvfatbin-13-0_13.0.85-1_arm64.deb
+  libnvfatbin-dev-13-0_13.0.85-1_arm64.deb
+  libnvjitlink-13-0_13.0.88-1_arm64.deb
+  libnvjitlink-dev-13-0_13.0.88-1_arm64.deb
+  cuda-cudart-13-0_13.0.96-1_arm64.deb
+  cuda-cudart-dev-13-0_13.0.96-1_arm64.deb
+  cuda-driver-dev-13-0_13.0.96-1_arm64.deb
+  cuda-toolkit-13-0-config-common_13.0.96-1_all.deb
+  cuda-command-line-tools-13-0_13.0.3-1_arm64.deb
+  cuda-compiler-13-0_13.0.3-1_arm64.deb
+  cuda-libraries-13-0_13.0.3-1_arm64.deb
+  cuda-libraries-dev-13-0_13.0.3-1_arm64.deb
+  cuda-nsight-compute-13-0_13.0.3-1_arm64.deb
+  cuda-nsight-systems-13-0_13.0.3-1_arm64.deb
+  cuda-toolkit-13-0_13.0.3-1_arm64.deb
+  cuda-tools-13-0_13.0.3-1_arm64.deb
+  cuda-visual-tools-13-0_13.0.3-1_arm64.deb
+  libcublas-13-0_13.1.1.3-1_arm64.deb
+  libcublas-dev-13-0_13.1.1.3-1_arm64.deb
+  cuda-toolkit-13-config-common_13.2.75-1_all.deb
+  cuda-toolkit-config-common_13.2.75-1_all.deb
+)
+
+source+=('fix-glibc242.patch')
+sha256sums+=('2df0fc7d18c21d5cdee1380994a4c1aa77ba2f251401c0fdff5af89466fa9d9b')
+sha512sums+=('SKIP')
+
+source+=(https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/sbsa/./gds-tools-13-0_1.15.1.6-1_arm64.deb)
+noextract+=(gds-tools-13-0_1.15.1.6-1_arm64.deb)
+sha256sums+=(SKIP)
+sha512sums+=(d8e8505b67bd24c4a6e862850f31bf05625577f6920b7301a11568074cf75a0071b2be905103dcc5afdef279ed92ea74cb4299e8140fa30dc8b5e7b4c7f3ca53)
+source+=(https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/sbsa/./libnvjpeg-13-0_13.0.1.86-1_arm64.deb)
+noextract+=(libnvjpeg-13-0_13.0.1.86-1_arm64.deb)
+sha256sums+=(SKIP)
+sha512sums+=(b0852be3d8632be4e12205c734720fffd8684b03c5d6ae1aa390501d5bf603615f1f3b31d7807033a4299f86c7d6dad84de439b8ad147e2ba36fd1a021a9d049)
+source+=(https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/sbsa/./libnvjpeg-dev-13-0_13.0.1.86-1_arm64.deb)
+noextract+=(libnvjpeg-dev-13-0_13.0.1.86-1_arm64.deb)
+sha256sums+=(SKIP)
+sha512sums+=(1df354fefc1e973c53daf05c48c3295d613936bc3415c5a26da3ef5843f2332cecb4202cd1478e26bd79e68d48e2ca6a7646ca3f270f4ad8d0d5f29a8d102ac9)
+source+=(https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/sbsa/./libnvptxcompiler-13-0_13.0.88-1_arm64.deb)
+noextract+=(libnvptxcompiler-13-0_13.0.88-1_arm64.deb)
+sha256sums+=(SKIP)
+sha512sums+=(e0e1cff89dfc6e03e90be14eb1ad38b729c2ad5a2eb2c94d8b8cb108e8279a5dd4a1e256eb10bd3584fe1d518872dfe536d61798a5d451e3f2ff8c4f5920b2ca)
+source+=(https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/sbsa/./libnvvm-13-0_13.0.88-1_arm64.deb)
+noextract+=(libnvvm-13-0_13.0.88-1_arm64.deb)
+sha256sums+=(SKIP)
+sha512sums+=(59ee5dc117a16c03c3a3db97144997160eafaf18ce85f227ab3b272e5e379f541b4343201a7ef1825de42ba9b8d9690fb500b6a8d771ae459e085b76aefac46e)
+
+package() {
+  set -o pipefail
+  local archive member
+  for archive in "${noextract[@]}"; do
+    member=$(bsdtar -tf "${srcdir}/${archive}" | grep -E '^data\.tar\.(xz|gz|zst)$')
+    [[ -n "$member" && "$member" != *$'\n'* ]] || return 1
+    bsdtar -xOf "${srcdir}/${archive}" "$member" | bsdtar -xf - -C "${pkgdir}"
+  done
+  # Match glibc 2.42 rsqrt declarations. fix-glibc242.patch adapts the fix from
+  # Arch Linux's cuda packaging (Sven-Hendrik Haase, Jakub Klinkovský; commit
+  # c36d77ac) to the SBSA include path.
+  patch -d "${pkgdir}" -Np1 -i "${srcdir}/fix-glibc242.patch"
+  # Replace Debian alternatives with package-owned links. Preserve vendor paths
+  # for binaries, Nsight launchers, and vendor documentation.
+  ln -s cuda-13.0 "${pkgdir}/usr/local/cuda"
+  ln -s cuda-13.0 "${pkgdir}/usr/local/cuda-13"
+  install -dm755 "${pkgdir}/etc/profile.d" "${pkgdir}/etc/ld.so.conf.d"
+  ln -s /usr/local/cuda-13.0/gds/cufile.json "${pkgdir}/etc/cufile.json"
+  printf '%s\n' 'export CUDA_HOME=/usr/local/cuda' \
+    'export PATH="${CUDA_HOME}/bin:${PATH}"' > "${pkgdir}/etc/profile.d/cuda.sh"
+  # The vendor config packages supply ld.so paths; pacman's normal ldconfig
+  # hook replaces the Debian postinst calls. Never add driver stub libraries.
+  printf '%s\n' '/usr/local/cuda-13.0/targets/sbsa-linux/lib' \
+    > "${pkgdir}/etc/ld.so.conf.d/cuda.conf"
+  install -dm755 "${pkgdir}/usr/share/licenses/${pkgname}"
+  cp "${pkgdir}/usr/share/doc/cuda-nvcc-13-0/copyright" \
+    "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"
+}

--- a/pkgbuilds/cuda/README.md
+++ b/pkgbuilds/cuda/README.md
@@ -1,0 +1,24 @@
+# cuda (aarch64)
+
+The recipe pins all 56 CUDA 13.0 toolkit payloads from NVIDIA's SBSA repository,
+including NVVM/PTX compilation, nvJPEG and GDS tools. Hashes come from NVIDIA's
+APT metadata for that repository. Source hashes are checked by makepkg;
+DEBs are extracted without executing their maintainer scripts.
+
+CUDA 13.0 requires a supported host compiler. Use the side-by-side gcc15 package:
+
+```sh
+nvcc -ccbin /opt/gcc15/bin/g++ -arch=sm_121 example.cu -o example
+```
+
+Release 2 adapts Arch's glibc 2.42 compatibility patch to the SBSA include path:
+https://gitlab.archlinux.org/archlinux/packaging/packages/cuda/-/commit/c36d77ac1d8e60fcd97490f8e432a8d034ddcc10
+
+This changes the rsqrt/rsqrtf exception declarations to match glibc. The compiler
+version check is not bypassed. Both compile and GPU execution must be tested;
+packaging alone does not establish compatibility. GDS additionally requires
+kernel/storage support and is not established by the unified-memory smoke test.
+
+The package keeps NVIDIA's license text under /usr/share/licenses. The payloads
+are NVIDIA's own SBSA (generic ARM64 server) toolkit, so nothing here is
+DGX-specific except the tested GPU; Arch Linux ARM ships no cuda package.

--- a/pkgbuilds/cuda/fix-glibc242.patch
+++ b/pkgbuilds/cuda/fix-glibc242.patch
@@ -1,0 +1,22 @@
+diff --git a/usr/local/cuda-13.0/targets/sbsa-linux/include/crt/math_functions.h b/usr/local/cuda-13.0/targets/sbsa-linux/include/crt/math_functions.h
+index a083253..b811f97 100644
+--- a/usr/local/cuda-13.0/targets/sbsa-linux/include/crt/math_functions.h
++++ b/usr/local/cuda-13.0/targets/sbsa-linux/include/crt/math_functions.h
+@@ -594,7 +594,7 @@ extern __DEVICE_FUNCTIONS_DECL__ __device_builtin__ double         __cdecl sqrt(
+  *
+  * \note_accuracy_double
+  */
+-extern __DEVICE_FUNCTIONS_DECL__ __device_builtin__ double                 rsqrt(double x);
++extern __DEVICE_FUNCTIONS_DECL__ __device_builtin__ double                 rsqrt(double x) noexcept(true);
+
+ /**
+  * \ingroup CUDA_MATH_SINGLE
+@@ -618,7 +618,7 @@ extern __DEVICE_FUNCTIONS_DECL__ __device_builtin__ double                 rsqrt
+  *
+  * \note_accuracy_single
+  */
+-extern __DEVICE_FUNCTIONS_DECL__ __device_builtin__ float                  rsqrtf(float x);
++extern __DEVICE_FUNCTIONS_DECL__ __device_builtin__ float                  rsqrtf(float x) noexcept(true);
+
+ #if defined(__QNX__) && !defined(_LIBCPP_VERSION)
+ namespace std {

--- a/pkgbuilds/gcc15/.omarchy/package.json
+++ b/pkgbuilds/gcc15/.omarchy/package.json
@@ -1,0 +1,3 @@
+{
+  "source": "local"
+}

--- a/pkgbuilds/gcc15/PKGBUILD
+++ b/pkgbuilds/gcc15/PKGBUILD
@@ -1,0 +1,43 @@
+pkgname=gcc15
+pkgver=15.3.0
+pkgrel=2
+pkgdesc='Side-by-side GCC 15 C/C++ compiler under /opt/gcc15, the newest host compiler CUDA 13 accepts'
+arch=('aarch64')
+url='https://gcc.gnu.org/'
+license=('GPL-3.0-with-GCC-exception' 'GFDL-1.3-or-later')
+depends=('binutils' 'glibc' 'gcc-libs' 'gmp' 'mpfr' 'libmpc' 'libisl' 'zlib' 'zstd')
+makedepends=('python')
+options=('!lto' '!debug')
+source=("https://gcc.gnu.org/pub/gcc/releases/gcc-${pkgver}/gcc-${pkgver}.tar.xz")
+sha512sums=('0de9e296153b52c021b1c7e63c9c62151d7a0ac03f23ce6e9f772c1b0eb783f6acdd81cc4567bfe4128a6f64968c2cfc8eff40b36229cba7425349f7d637c654')
+
+build() {
+  # Match Arch's GCC packaging: GCC diagnostics use nonliteral translated
+  # strings, so the distro-wide format-security Werror flag breaks this build.
+  CFLAGS=${CFLAGS/-Werror=format-security/}
+  CXXFLAGS=${CXXFLAGS/-Werror=format-security/}
+  mkdir -p "${srcdir}/gcc-build"
+  cd "${srcdir}/gcc-build"
+  "${srcdir}/gcc-${pkgver}/configure" \
+    --prefix=/opt/gcc15 \
+    --enable-languages=c,c++ \
+    --disable-bootstrap \
+    --disable-werror \
+    --disable-multilib \
+    --disable-nls \
+    --disable-libsanitizer \
+    --disable-libquadmath \
+    --disable-libstdcxx-pch \
+    --enable-checking=release \
+    --enable-default-pie \
+    --enable-default-ssp \
+    --with-system-zlib
+  make
+}
+
+package() {
+  cd "${srcdir}/gcc-build"
+  make DESTDIR="${pkgdir}" install
+  install -Dm644 "${srcdir}/gcc-${pkgver}/COPYING.RUNTIME" \
+    "${pkgdir}/usr/share/licenses/${pkgname}/RUNTIME.LIBRARY.EXCEPTION"
+}

--- a/pkgbuilds/gcc15/README.md
+++ b/pkgbuilds/gcc15/README.md
@@ -1,0 +1,14 @@
+# CUDA-compatible host compiler
+
+CUDA 13.0's nvcc explicitly rejects GCC versions newer than 15;
+the initial native Arch compilation test failed with Arch ARM's GCC 16.
+
+This package builds GNU GCC 15.3.0 for aarch64 under `/opt/gcc15`, so it can coexist
+with Arch's system compiler. Select it explicitly using
+`nvcc -ccbin /opt/gcc15/bin/g++`. No unsupported-compiler bypass is configured.
+
+The source checksum is from GNU's published release `sha512.sum`. This first
+build uses a single-stage C/C++ compiler configuration; bootstrap comparison and
+the full GCC testsuite are not performed. Optional sanitizer/quadmath runtimes
+are excluded. C/C++ and native CUDA compilation/execution tests are required
+before treating this package as validated.

--- a/pkgbuilds/ollama/.omarchy/package.json
+++ b/pkgbuilds/ollama/.omarchy/package.json
@@ -1,0 +1,3 @@
+{
+  "source": "local"
+}

--- a/pkgbuilds/ollama/PKGBUILD
+++ b/pkgbuilds/ollama/PKGBUILD
@@ -1,0 +1,103 @@
+# Maintainer: Alexander F. Rødseth <xyproto@archlinux.org>
+# Maintainer: Sven-Hendrik Haase <svenstaro@archlinux.org>
+# Contributor: Steven Allen <steven@stebalien.com>
+# Contributor: Matt Harrison <matt@harrison.us.com>
+# Contributor: Kainoa Kanter <kainoa@t1c.dev>
+#
+# Arch Linux's ollama recipe (0BSD) reduced to what aarch64 can build: the CPU
+# package and a CUDA backend. Arch builds only x86_64 because its cuda package
+# is x86_64-only; Arch Linux ARM has neither ollama nor cuda. This uses
+# Omarchy's aarch64 cuda package under /usr/local/cuda with gcc15 as the CUDA
+# host compiler, since CUDA 13 rejects Arch Linux ARM's GCC 16. ROCm, Vulkan
+# and docs are dropped.
+pkgbase=ollama
+pkgname=(ollama ollama-cuda)
+pkgver=0.33.3
+pkgrel=1
+pkgdesc='Create, run and share large language models (LLMs)'
+arch=(aarch64)
+url='https://github.com/ollama/ollama'
+license=(MIT)
+options=('!lto')
+depends=(libgcc libstdc++ glibc)
+makedepends=(cmake git go cuda gcc15)
+source=(git+https://github.com/ollama/ollama#tag=v$pkgver
+        ollama-ld.conf
+        ollama.service
+        sysusers.conf
+        tmpfiles.conf)
+b2sums=('31bfd082723082bb0105dc8512772333d79deb8e60a52823e2f71fe3b0a17cf8ac6fac63f72b01332d10b716de5484c90e3115af470893644f1f73855622e425'
+        '121a7854b5a7ffb60226aaf22eed1f56311ab7d0a5630579525211d5c096040edbcfd2608169a4b6d83e8b4e4855dbb22f8ebf3d52de78a34ea3d4631b7eff36'
+        '031e0809a7f564de87017401c83956d43ac29bd0e988b250585af728b952a27d139b3cad0ab1e43750e2cd3b617287d3b81efc4a70ddd61709127f68bd15eabd'
+        '68622ac2e20c1d4f9741c57d2567695ec7b5204ab43356d164483cd3bc9da79fad72489bb33c8a17c2e5cb3b142353ed5f466ce857b0f46965426d16fb388632'
+        'e8f2b19e2474f30a4f984b45787950012668bf0acb5ad1ebb25cd9776925ab4a6aa927f8131ed53e35b1c71b32c504c700fe5b5145ecd25c7a8284373bb951ed')
+
+build() {
+  export CGO_CPPFLAGS="${CPPFLAGS}"
+  export CGO_CFLAGS="${CFLAGS}"
+  export CGO_CXXFLAGS="${CXXFLAGS}"
+  export CGO_LDFLAGS="${LDFLAGS}"
+  export GOPATH="${srcdir}"
+  export GOFLAGS="-buildmode=pie -mod=readonly -modcacherw '-ldflags=-linkmode=external -compressdwarf=false -X=github.com/ollama/ollama/version.Version=$pkgver -X=github.com/ollama/ollama/server.mode=release'"
+
+  export CUDAToolkit_ROOT=/usr/local/cuda
+  export PATH="/usr/local/cuda/bin:$PATH"
+  # The CUDA backend is an external CMake project that does not inherit
+  # CMAKE_CUDA_HOST_COMPILER; nvcc must be told the host compiler through the
+  # environment, or it picks the system GCC 16 that CUDA 13 rejects.
+  export NVCC_CCBIN=/opt/gcc15/bin/g++
+  export CUDAHOSTCXX=/opt/gcc15/bin/g++
+
+  cd ollama
+
+  # Remove the runtime dependencies from installation so CMake doesn't install
+  # lots of system dependencies into the target path.
+  sed -i 's/PRE_INCLUDE_REGEXES.*/PRE_INCLUDE_REGEXES = ""/' CMakeLists.txt
+
+  local cmake_options=(
+    -B build
+    -W no-dev
+    -D CMAKE_BUILD_TYPE=Release
+    -D CMAKE_INSTALL_PREFIX=/usr
+    -D OLLAMA_LLAMA_BACKENDS="cuda_v13"
+    -D CMAKE_CUDA_COMPILER=/usr/local/cuda/bin/nvcc
+    -D CMAKE_CUDA_HOST_COMPILER=/opt/gcc15/bin/g++
+    # Native code for the GB10 (DGX Spark), the only ARM GPU this has been
+    # tested on, plus PTX so newer compute capabilities can JIT.
+    -D CMAKE_CUDA_ARCHITECTURES="121;121-virtual"
+  )
+
+  cmake "${cmake_options[@]}"
+  cmake --build build
+  go build .
+
+  DESTDIR=staging-install cmake --install build
+}
+
+check() {
+  ollama/ollama --version > /dev/null
+}
+
+package_ollama() {
+  cp -r ollama/staging-install/* "$pkgdir"
+  rm -r "$pkgdir/usr/lib/ollama/cuda"*
+
+  install -Dm755 ollama/ollama "$pkgdir/usr/bin/ollama"
+  install -dm755 "$pkgdir/var/lib/ollama"
+  install -Dm644 ollama.service "$pkgdir/usr/lib/systemd/system/ollama.service"
+  install -Dm644 sysusers.conf "$pkgdir/usr/lib/sysusers.d/ollama.conf"
+  install -Dm644 tmpfiles.conf "$pkgdir/usr/lib/tmpfiles.d/ollama.conf"
+  install -Dm644 ollama-ld.conf "$pkgdir/etc/ld.so.conf.d/ollama.conf"
+  install -Dm644 ollama/LICENSE "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+
+  ln -s /var/lib/ollama "$pkgdir/usr/share/ollama"
+}
+
+package_ollama-cuda() {
+  pkgdesc='Create, run and share large language models (LLMs) with CUDA (built for GB10, sm_121)'
+  depends+=(ollama cuda)
+
+  mkdir -p "$pkgdir/usr/lib/ollama"
+  cp -r ollama/staging-install/usr/lib/ollama/cuda* "$pkgdir/usr/lib/ollama"
+  install -Dm644 ollama/LICENSE "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+}

--- a/pkgbuilds/ollama/README.md
+++ b/pkgbuilds/ollama/README.md
@@ -1,0 +1,11 @@
+# ollama and ollama-cuda (aarch64)
+
+Omarchy's Install → AI → Ollama installs `ollama-cuda` when `nvidia-smi` is
+present. Arch's recipe is x86_64-only because Arch's CUDA is; Arch Linux ARM has
+neither. This is Arch's split recipe reduced to the CPU package `ollama` and an
+`ollama-cuda` backend built against Omarchy's aarch64 `cuda` package with
+`gcc15` as the CUDA host compiler. ROCm, Vulkan and docs are dropped.
+
+The CUDA backend carries native code for compute capability 12.1 (GB10, the
+DGX Spark) plus PTX for that capability; it has not been tested on any other
+ARM GPU. The service, sysusers, tmpfiles and ld.so.conf files are Arch's.

--- a/pkgbuilds/ollama/ollama-ld.conf
+++ b/pkgbuilds/ollama/ollama-ld.conf
@@ -1,0 +1,1 @@
+/usr/lib/ollama

--- a/pkgbuilds/ollama/ollama.service
+++ b/pkgbuilds/ollama/ollama.service
@@ -1,0 +1,22 @@
+[Unit]
+Description=Ollama Service
+Wants=network-online.target
+After=network.target network-online.target
+
+[Service]
+ExecStart=/usr/bin/ollama serve
+WorkingDirectory=/var/lib/ollama
+Environment="HOME=/var/lib/ollama"
+Environment="OLLAMA_MODELS=/var/lib/ollama"
+User=ollama
+Group=ollama
+Restart=on-failure
+RestartSec=3
+RestartPreventExitStatus=1
+Type=simple
+PrivateTmp=yes
+ProtectSystem=full
+ProtectHome=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/pkgbuilds/ollama/sysusers.conf
+++ b/pkgbuilds/ollama/sysusers.conf
@@ -1,0 +1,2 @@
+g ollama - -
+u! ollama - "ollama user" /var/lib/ollama

--- a/pkgbuilds/ollama/tmpfiles.conf
+++ b/pkgbuilds/ollama/tmpfiles.conf
@@ -1,0 +1,1 @@
+Q /var/lib/ollama 0755 ollama ollama


### PR DESCRIPTION
Arch Linux ARM ships no cuda package and no ollama, so Omarchy's Install → AI →
Ollama has no path on aarch64. This adds the three recipes that path needs,
all aarch64-only:

- `cuda`: NVIDIA's SBSA CUDA 13.0.3 toolkit repackaged from the vendor .deb
  payloads with recorded sha512 hashes, plus Arch's glibc 2.42 header fix. It
  keeps the vendor /usr/local/cuda-13.0 layout rather than x86_64 Arch's
  /opt/cuda because the payloads' own launchers reference it. About 2.9 GB.
- `gcc15`: GCC 15.3 under /opt/gcc15, the newest host compiler CUDA 13
  accepts; Arch Linux ARM's system GCC is 16.
- `ollama` / `ollama-cuda`: Arch's 0.33.3 recipe reduced to the CPU package
  and a CUDA backend built against the two above. Native code for sm_121
  (GB10) plus PTX; ROCm, Vulkan and docs dropped. Arch's recipe (0BSD) is
  credited in the PKGBUILD.

Testing: built with `bin/build --arch aarch64` in the repo's container on a
DGX Spark running a fresh aarch64 Omarchy edge install, installed with
pacman -U, then: nvcc with the gcc15 host compiler compiled and ran a kernel
on the GB10; ollama discovered the GPU (`library=CUDA compute=12.1`), placed
qwen2.5:0.5b 100% on GPU and generated at ~240 tokens/s.

Limits: only the GB10 has been tested; GDS, Nsight, nvJPEG and cuFile
components are packaged but unexercised; the ollama system service was not
enabled. The cuda package is large, so whether the repository host should
carry it is a question for the maintainers.
