### PR TITLE
Ship the powerprofilesctl shebang hook in the omarchy package

### DIFF
--- a/pkgbuilds/omarchy-dev/PKGBUILD
+++ b/pkgbuilds/omarchy-dev/PKGBUILD
@@ -134,6 +134,9 @@ package() {
   install -Dm644 default/libalpm/hooks/00-omarchy-update-guard.hook "$pkgdir/usr/share/libalpm/hooks/00-omarchy-update-guard.hook"
   install -Dm644 default/libalpm/hooks/10-omarchy-hyprland-reload-pause.hook "$pkgdir/usr/share/libalpm/hooks/10-omarchy-hyprland-reload-pause.hook"
   install -Dm644 default/libalpm/hooks/90-omarchy-hyprland-reload-resume.hook "$pkgdir/usr/share/libalpm/hooks/90-omarchy-hyprland-reload-resume.hook"
+  # Re-apply the powerprofilesctl shebang fix after every power-profiles-daemon
+  # install or upgrade, since the daemon upgrades restore its packaged shebang.
+  install -Dm644 default/libalpm/hooks/70-omarchy-powerprofilesctl-shebang.hook "$pkgdir/usr/share/libalpm/hooks/70-omarchy-powerprofilesctl-shebang.hook"
 
   # Target-side setup scripts and package lists used by ISO finalization,
   # first login, future users, migrations, and reinstall/reset commands.

--- a/pkgbuilds/omarchy/PKGBUILD
+++ b/pkgbuilds/omarchy/PKGBUILD
@@ -134,6 +134,9 @@ package() {
   install -Dm644 default/libalpm/hooks/00-omarchy-update-guard.hook "$pkgdir/usr/share/libalpm/hooks/00-omarchy-update-guard.hook"
   install -Dm644 default/libalpm/hooks/10-omarchy-hyprland-reload-pause.hook "$pkgdir/usr/share/libalpm/hooks/10-omarchy-hyprland-reload-pause.hook"
   install -Dm644 default/libalpm/hooks/90-omarchy-hyprland-reload-resume.hook "$pkgdir/usr/share/libalpm/hooks/90-omarchy-hyprland-reload-resume.hook"
+  # Re-apply the powerprofilesctl shebang fix after every power-profiles-daemon
+  # install or upgrade, since the daemon upgrades restore its packaged shebang.
+  install -Dm644 default/libalpm/hooks/70-omarchy-powerprofilesctl-shebang.hook "$pkgdir/usr/share/libalpm/hooks/70-omarchy-powerprofilesctl-shebang.hook"
 
   # Target-side setup scripts and package lists used by ISO finalization,
   # first login, future users, migrations, and reinstall/reset commands.


### PR DESCRIPTION
Companion to omacom/omarchy#11097 (fix for omacom/omarchy#11031).

Installs the new `70-omarchy-powerprofilesctl-shebang.hook` from `default/libalpm/hooks/` into `/usr/share/libalpm/hooks/` in both the `omarchy` and `omarchy-dev` packages. The hook re-applies the `powerprofilesctl` system-python shebang fix after every `power-profiles-daemon` Install/Upgrade, keeping it from being reverted by daemon upgrades.

The omarchy repo's `config-test.sh` asserts this pairing whenever an `omarchy-pkgs` checkout is available, so the two PRs should land together.
