### PR TITLE
fix(sunshine): patch packager build flags

### DIFF
--- a/pkgbuilds/sunshine/.omarchy/patches/packager-build-flags.patch
+++ b/pkgbuilds/sunshine/.omarchy/patches/packager-build-flags.patch
@@ -1,0 +1,15 @@
+--- a/PKGBUILD
++++ b/PKGBUILD
+@@ -155,9 +155,9 @@ build() {
+       -D CMAKE_INSTALL_PREFIX=/usr
+       -D SUNSHINE_EXECUTABLE_PATH=/usr/bin/sunshine
+       -D SUNSHINE_ASSETS_DIR="share/sunshine"
+-      -D SUNSHINE_PUBLISHER_NAME='LizardByte'
+-      -D SUNSHINE_PUBLISHER_WEBSITE='https://app.lizardbyte.dev'
+-      -D SUNSHINE_PUBLISHER_ISSUE_URL='https://app.lizardbyte.dev/support'
++      -D SUNSHINE_PUBLISHER_NAME='Omarchy'
++      -D SUNSHINE_PUBLISHER_WEBSITE='https://omarchy.org'
++      -D SUNSHINE_PUBLISHER_ISSUE_URL='https://github.com/omacom/omarchy-pkgs/issues'
+     )
+ 
+     if [[ $CARCH == aarch64 ]]; then


### PR DESCRIPTION
This patch redirects users to Omarchy for support since upstream (me) does not control this package.

And for Arch I only officially support https://github.com/LizardByte/pacman-repo