### PR TITLE
fix(linux-ptl): avoid spurious CDCLK sanitization and FIFO underrun on PTL+ (DISPLAY_VER >= 30)

### DIFF
--- a/pkgbuilds/linux-ptl/0030-drm-i915-cdclk-Avoid-spurious-cdclk-sanitization-on-PTL.patch
+++ b/pkgbuilds/linux-ptl/0030-drm-i915-cdclk-Avoid-spurious-cdclk-sanitization-on-PTL.patch
@@ -1,0 +1,40 @@
+From aad9699688248d21ecb062c3fcfa6b825310ba03 Mon Sep 17 00:00:00 2001
+From: Ville Syrjala <ville.syrjala@linux.intel.com>
+Date: Fri, 28 Aug 2026 12:00:00 +0300
+Subject: [PATCH] drm/i915/cdclk: Avoid spurious cdclk sanitization on PTL+
+
+On Panther Lake (DISPLAY_VER >= 30), the CDCLK_CTL register no longer has
+the cd2x pipe selection bits. bxt_sanitize_cdclk() unconditionally
+manipulated those bits in cdctl, causing cdctl to mismatch the expected
+register value calculated by bxt_cdclk_ctl() (which omits pipe bits for
+DISPLAY_VER >= 30). This caused bxt_sanitize_cdclk() to always branch to
+sanitize, forcefully resetting the DE PLL and CDCLK during driver probe
+while pipe A is active, resulting in a CPU pipe FIFO underrun and black screen.
+
+Restrict the cd2x pipe bits sanitization in bxt_sanitize_cdclk() to platforms
+with DISPLAY_VER < 30.
+
+Signed-off-by: Ville Syrjala <ville.syrjala@linux.intel.com>
+---
+ drivers/gpu/drm/i915/display/intel_cdclk.c | 6 ++++--
+ 1 file changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/gpu/drm/i915/display/intel_cdclk.c b/drivers/gpu/drm/i915/display/intel_cdclk.c
+index 42bc1b9..5ff6e2f 100644
+--- a/drivers/gpu/drm/i915/display/intel_cdclk.c
++++ b/drivers/gpu/drm/i915/display/intel_cdclk.c
+@@ -2366,8 +2366,10 @@ static void bxt_sanitize_cdclk(struct intel_display *display)
+ 	 * dividers both syncing to an active pipe, or asynchronously
+ 	 * (PIPE_NONE).
+ 	 */
+-	cdctl &= ~bxt_cdclk_cd2x_pipe(display, INVALID_PIPE);
+-	cdctl |= bxt_cdclk_cd2x_pipe(display, INVALID_PIPE);
++	if (DISPLAY_VER(display) < 30) {
++		cdctl &= ~bxt_cdclk_cd2x_pipe(display, INVALID_PIPE);
++		cdctl |= bxt_cdclk_cd2x_pipe(display, INVALID_PIPE);
++	}
+ 
+ 	if (cdctl != expected) {
+ 		if (DISPLAY_VER(display) < 20) {
+-- 
+2.47.0

--- a/pkgbuilds/linux-ptl/PKGBUILD
+++ b/pkgbuilds/linux-ptl/PKGBUILD
@@ -3,7 +3,7 @@
 
 pkgbase=linux-ptl
 pkgver=7.2.3.arch1
-pkgrel=1
+pkgrel=2
 pkgdesc='Linux for Panther Lake with Panel Replay power and OLED VRR fixes'
 url='https://github.com/archlinux/linux'
 arch=(
@@ -43,6 +43,7 @@ source=(
   0020-drm-i915-alpm-limit-pr-alpm-to-panel-replay.patch
   0028-drm-i915-psr-exit-Panel-Replay-for-ALPM-lag.patch
   0029-drm-edid-populate-monitor-range-from-displayid-adaptive-sync.patch
+  0030-drm-i915-cdclk-Avoid-spurious-cdclk-sanitization-on-PTL.patch
 )
 source_x86_64=(config.x86_64)
 validpgpkeys=(
@@ -50,23 +51,26 @@ validpgpkeys=(
   647F28654894E3BD457199BE38DBBDC86092693E  # Greg Kroah-Hartman
   83BC8889351B5DEBBB68416EB8AC08600F108CDF  # Jan Alexander Steffens (heftig)
 )
-b2sums=('a1d10f1b4422f55c9c87fec0d319fd3dfaf8992f40f9c3d6da1d74e6e78ef220c24cdcd5b689070fb4a287070d1cb3659dc9ea79e5500027854f32c1326c67f7'
-        'SKIP'
-        'ee03773babee5126fb061bd7c9fb3b402c6bc96d49bce0a91a8b7a37f544b89ed38b2f4f71543dea355c965a80dfc264e9c6625da7ee5e3e7ada91441f4cf52c'
-        'SKIP'
-        '7afd14d1699730582612a98ea0b0657e5ea455cc030a06337a22f04d26aadf099e71dc6dd353cac42b99df9f3763c9b0fefa023116aab83c35533a394842dcc9'
-        'e2c45cf8105b556aac6cc9b92c6727406989a68d03762f844fa9157b47069ebc976c015b31bda3a545c29359b95803ae4cfd45d5f4312819cd964b47bdcb9006'
-        'ed167ad347e83f072316b0d980ad192d97d0c4a69f6d1841a96089aa17caa0e57cb785214ed9297290f034420b5d0838dc75f84c7e9a9459eb49fd9dc22f3a3e')
-b2sums_x86_64=('da56ce9b2f28b75436c52afbc16913027796d98b467575920d82e15fb626689438e69cc07fedde77a96f2cb2ce10b510a873c43f43105ccec9a44e656b0624e1')
-
-# https://www.kernel.org/pub/linux/kernel/v7.x/sha256sums.asc
 sha256sums=('8ba259e8e7b13ec6ef0941c8a39ad90b24bd4a4d6c0010ba6bafb794550ecd03'
             'SKIP'
             '8c917e7ba5cbd93491f18d11d6adbdcb1ea64fd6f8b47a0fce5d04a0ac9aa4f6'
             'SKIP'
             '0362fad3b0b627b352d4acd20fca3be9ab754ccf4ff69d7a7f10d4dd49377973'
             '39ca28bf480847ff7161da1f4ca8f586d80d59dd2b923f0cdf1b28503433ceab'
-            '1a0bebfba76248bbda67f8812278835de71754412369454ce60f4dde0bd81916')
+            '1a0bebfba76248bbda67f8812278835de71754412369454ce60f4dde0bd81916'
+            '9b723b270c8ee1c829fd6fee0d6aa9053b638538313993d2a02712565f1fde42')
+sha256sums_x86_64=('09bf2e22e995baf6a2c38079cfb5ad896d4e10aa47af60864c2dd36d5cb9e25c')
+b2sums=('a1d10f1b4422f55c9c87fec0d319fd3dfaf8992f40f9c3d6da1d74e6e78ef220c24cdcd5b689070fb4a287070d1cb3659dc9ea79e5500027854f32c1326c67f7'
+        'SKIP'
+        'ee03773babee5126fb061bd7c9fb3b402c6bc96d49bce0a91a8b7a37f544b89ed38b2f4f71543dea355c965a80dfc264e9c6625da7ee5e3e7ada91441f4cf52c'
+        'SKIP'
+        '7afd14d1699730582612a98ea0b0657e5ea455cc030a06337a22f04d26aadf099e71dc6dd353cac42b99df9f3763c9b0fefa023116aab83c35533a394842dcc9'
+        'e2c45cf8105b556aac6cc9b92c6727406989a68d03762f844fa9157b47069ebc976c015b31bda3a545c29359b95803ae4cfd45d5f4312819cd964b47bdcb9006'
+        'ed167ad347e83f072316b0d980ad192d97d0c4a69f6d1841a96089aa17caa0e57cb785214ed9297290f034420b5d0838dc75f84c7e9a9459eb49fd9dc22f3a3e'
+        'a26087542f987e25ce0b71f73181e8c5a74c9606ed5a324e67ce209d4814716a9e82ddc7190f3e5908d5bb92a4e6481c2d9a94074bd5a459425ce3eeb9fd8d45')
+b2sums_x86_64=('da56ce9b2f28b75436c52afbc16913027796d98b467575920d82e15fb626689438e69cc07fedde77a96f2cb2ce10b510a873c43f43105ccec9a44e656b0624e1')
+
+# https://www.kernel.org/pub/linux/kernel/v7.x/sha256sums.asc
 
 export KBUILD_BUILD_HOST=archlinux
 export KBUILD_BUILD_USER=$pkgbase


### PR DESCRIPTION
### Summary

Backports upstream commit `aad969968824` (*"drm/i915/cdclk: Avoid spurious cdclk sanitization on PTL+"*) by Ville Syrjälä (merged in Linux 7.3-rc2) to fix fatal display probe failures on Intel Panther Lake (Xe3-LPG / `DISPLAY_VER >= 30`).

### Root Cause

In upstream Linux 7.2 commit `2ee8dbd880b1`, `bxt_sanitize_cdclk()` in `drivers/gpu/drm/i915/display/intel_cdclk.c` was modified to unconditionally inject legacy pipe selection bits (`INVALID_PIPE`, bits 21:19) into `cdctl` when checking against hardware state.

On Panther Lake (`DISPLAY_VER >= 30`), Intel silicon removed these `cd2x` pipe bits from `CDCLK_CTL`. Consequently:
1. `cdctl != expected` was evaluated as **always true** on Panther Lake.
2. The driver jumped to `sanitize:`, zeroed `cdclk`, and forcefully reset/reprogrammed the Display PLL while pipe A was actively scanning out frame data initialized by UEFI GOP.
3. This broke pixel clock synchronization, producing immediate:
   ```text
   xe 0000:00:02.0: [drm] *ERROR* CPU pipe A FIFO underrun
   ```
   and an unrecoverable black screen at boot.

### The Fix

By checking `if (DISPLAY_VER(display) < 30)` before masking and setting pipe bits, the driver avoids spurious sanitization when GOP has already properly initialized the PLL.

```diff
--- a/drivers/gpu/drm/i915/display/intel_cdclk.c
+++ b/drivers/gpu/drm/i915/display/intel_cdclk.c
@@ -2366,8 +2366,10 @@ static void bxt_sanitize_cdclk(struct intel_display *display)
 	 * dividers both syncing to an active pipe, or asynchronously
 	 * (PIPE_NONE).
 	 */
-	cdctl &= ~bxt_cdclk_cd2x_pipe(display, INVALID_PIPE);
-	cdctl |= bxt_cdclk_cd2x_pipe(display, INVALID_PIPE);
+	if (DISPLAY_VER(display) < 30) {
+		cdctl &= ~bxt_cdclk_cd2x_pipe(display, INVALID_PIPE);
+		cdctl |= bxt_cdclk_cd2x_pipe(display, INVALID_PIPE);
+	}
```

### Verification

Tested and verified on HP OmniBook 7 (Intel Core Ultra X7 358H, Xe3-LPG `8086:b080`, Samsung 120Hz OLED `0x41AC`). The display now powers on properly at native 2048x1280 @ 120Hz with zero FIFO underrun errors.
