### PR TITLE
Build changed packages on pull requests with the release builder's container

### DIFF
--- a/.github/workflows/build-changed.yml
+++ b/.github/workflows/build-changed.yml
@@ -1,0 +1,73 @@
+name: Build changed packages
+
+on:
+  pull_request:
+  push:
+    branches: [master]
+  workflow_dispatch:
+    inputs:
+      packages:
+        description: Space-separated package names to build
+        required: true
+
+jobs:
+  plan:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.plan.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      # One matrix entry per mirror a changed package ships to, decided by the
+      # same helper the release builder uses. Names are validated here and
+      # handed to the build job through env, never spliced into a script.
+      - name: Plan builds
+        id: plan
+        env:
+          BASE: ${{ github.event.pull_request.base.sha || github.event.before }}
+          REQUESTED: ${{ inputs.packages }}
+        run: |
+          set -euo pipefail
+          source helpers/package-metadata.sh
+          if [[ -n "$REQUESTED" ]]; then
+            names=$REQUESTED
+          else
+            names=$(git diff --name-only "$(git merge-base "$BASE" HEAD)" HEAD -- pkgbuilds | awk -F/ 'NF > 2 { print $2 }' | sort -u)
+          fi
+          matrix='[]'
+          for mirror in edge rc stable; do
+            packages=""
+            for name in $names; do
+              [[ "$name" =~ ^[a-z0-9@._+-]+$ ]] || { echo "refusing package name: $name" >&2; exit 1; }
+              pkgdir=$(package_dir_for_name "$name") || continue
+              package_builds_for_mirror "$pkgdir" "$mirror" && packages="$packages $name"
+            done
+            [[ -n "$packages" ]] && matrix=$(jq -c --arg mirror "$mirror" --arg packages "${packages# }" '. + [{mirror: $mirror, packages: $packages}]' <<<"$matrix")
+          done
+          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+          echo "plan: $matrix"
+
+  build:
+    needs: plan
+    if: needs.plan.outputs.matrix != '[]'
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJSON(needs.plan.outputs.matrix) }}
+    name: ${{ matrix.mirror }} ${{ matrix.packages }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Build with the release builder's container
+        env:
+          CONTAINER_ENGINE: docker
+          PACKAGES: ${{ matrix.packages }}
+          MIRROR: ${{ matrix.mirror }}
+        run: bin/build --package $PACKAGES --mirror "$MIRROR" --arch x86_64


### PR DESCRIPTION
A package can reach master with only the self-tests having run, so the first time its dependencies are resolved inside the channel's container is the release build. claude-desktop (#348) was reviewed on bare `makepkg` on a machine that already had every dependency installed, which proves `package()` and the artifact and nothing about resolution, and then failed its first `rc` release build on "Could not resolve all dependencies" while the same commit shipped to edge and stable. Whether that failure was the package or the builder could only be answered by running the real thing, and nothing had.

This adds a workflow with two jobs. `plan` diffs `pkgbuilds/` against the base and asks `package_builds_for_mirror` — the same helper the release builder uses — which mirrors each changed package ships to, so ring and channel policy stays in one place: edge always, rc and stable for `release_ring: fast`, pinned packages to edge only. `build` then runs `bin/build --package … --mirror … --arch x86_64` per mirror as a matrix, the same command and container the release builder runs. A pull request chooses its own directory names, so names are validated against `^[a-z0-9@._+-]+$` and handed to the build step through `env`, never interpolated into a script. With nothing changed under `pkgbuilds/`, the plan is empty and the build job is skipped in seconds, so the check is always present. `workflow_dispatch` takes an explicit package list for rebuilding on demand.

x86_64 only: an emulated aarch64 build of a half-gigabyte Electron tree is not a check anyone would wait for, and #171 covers native ARM runners. The proof is a run of this workflow on a fork against a touched claude-desktop, where edge, rc and stable each built in six to seven minutes on `ubuntu-latest`: https://github.com/spencerbull/omarchy-pkgs/actions/runs/34531142335

🤖 Generated by Fable 5 in Claude Code.
