### PR TITLE
use herdr release binaries and track upstream updates

### DIFF
--- a/pkgbuilds/herdr/.omarchy/package.json
+++ b/pkgbuilds/herdr/.omarchy/package.json
@@ -1,3 +1,14 @@
 {
-  "source": "local"
+  "source": "local",
+  "upstream": {
+    "github": "herdrdev/herdr",
+    "digests": true,
+    "assets": {
+      "x86_64": "herdr-linux-x86_64",
+      "aarch64": "herdr-linux-aarch64"
+    },
+    "sources": {
+      "any": ["https://raw.githubusercontent.com/herdrdev/herdr/{tag}/LICENSE"]
+    }
+  }
 }

--- a/pkgbuilds/herdr/PKGBUILD
+++ b/pkgbuilds/herdr/PKGBUILD
@@ -2,43 +2,24 @@
 
 pkgname=herdr
 pkgver=0.9.0
-pkgrel=1
+pkgrel=2
 pkgdesc="Herdr terminal workspace manager for AI coding agents"
 arch=('x86_64' 'aarch64')
 url="https://github.com/herdrdev/herdr"
 license=('Apache-2.0')
 depends=('gcc-libs' 'glibc')
-makedepends=('cargo')
 replaces=('omarchy-herdr')
 conflicts=('omarchy-herdr')
-options=('!debug' '!lto')
+options=('!strip' '!debug')
 
-_zigver=0.15.2
-source=("herdr-$pkgver.tar.gz::$url/archive/refs/tags/v$pkgver.tar.gz")
-source_x86_64=("zig-x86_64-linux-$_zigver.tar.xz::https://ziglang.org/download/$_zigver/zig-x86_64-linux-$_zigver.tar.xz")
-source_aarch64=("zig-aarch64-linux-$_zigver.tar.xz::https://ziglang.org/download/$_zigver/zig-aarch64-linux-$_zigver.tar.xz")
-sha256sums=('1e83bff4b05834ed8281e16f1680e8f3e58375a94b2e3f2b3d021e28e293ef9a')
-sha256sums_x86_64=('02aa270f183da276e5b5920b1dac44a63f1a49e55050ebde3aecc9eb82f93239')
-sha256sums_aarch64=('958ed7d1e00d0ea76590d27666efbf7a932281b3d7ba0c6b01b0ff26498f667f')
-
-prepare() {
-  cd "herdr-$pkgver"
-
-  cargo fetch --locked --target "$CARCH-unknown-linux-gnu"
-}
-
-build() {
-  cd "herdr-$pkgver"
-
-  export CARGO_TARGET_DIR=target
-  export ZIG="$srcdir/zig-$CARCH-linux-$_zigver/zig"
-  export ZIG_GLOBAL_CACHE_DIR="$srcdir/zig-cache"
-  cargo build --frozen --release
-}
+source=("herdr-$pkgver-LICENSE::https://raw.githubusercontent.com/herdrdev/herdr/v$pkgver/LICENSE")
+source_x86_64=("herdr-$pkgver-linux-x86_64::$url/releases/download/v$pkgver/herdr-linux-x86_64")
+source_aarch64=("herdr-$pkgver-linux-aarch64::$url/releases/download/v$pkgver/herdr-linux-aarch64")
+sha256sums=('c71d239df91726fc519c6eb72d318ec65820627232b2f796219e87dcf35d0ab4')
+sha256sums_x86_64=('4fa1a01158dd8043da92d31b270780b0dcc10603038d9b61cac4d81ab63fb71f')
+sha256sums_aarch64=('9c8db20fb7e7427b138d5367113f1621ffd319f2f65d6f009e2594029115f0d2')
 
 package() {
-  cd "herdr-$pkgver"
-
-  install -Dm755 target/release/herdr "$pkgdir/usr/bin/herdr"
-  install -Dm644 LICENSE "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+  install -Dm755 "$srcdir/herdr-$pkgver-linux-$CARCH" "$pkgdir/usr/bin/herdr"
+  install -Dm644 "$srcdir/herdr-$pkgver-LICENSE" "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
 }


### PR DESCRIPTION
this switches the package to our official linux binaries and enables your existing upstream release tracker, following the mise-bin approach.

our next release requires zig 0.16.0 instead of 0.15.2. using the release binaries avoids maintaining rust and zig build requirements separately here.

the package name and release ring stay unchanged. stable releases produce automated update prs; previews are excluded.

tested packaging and running on x86_64 in an arch container, verified both architectures’ checksums, and passed the upstream tracker self-tests and live check. arm64 execution was not tested.