### PR TITLE
Update strata to 0.15.0 and flea to 0.2.0

### DIFF
--- a/bin/sync-upstream
+++ b/bin/sync-upstream
@@ -757,6 +757,8 @@ EOF
   mkdir -p "$one_root"
   cp -a "$BUILD_ROOT/pkgbuilds/1password" "$one_root/1password"
   one_dir="$one_root/1password"
+  # Keep the fixture older than its mocked release as the real recipe advances.
+  sed -i -e 's/^pkgver=.*/pkgver=8.12.34/' -e 's/^pkgrel=.*/pkgrel=36/' "$one_dir/PKGBUILD"
   debian_fetch_packages() {
     printf 'Package: 1password\nVersion: %s\n' "$one_version"
   }

--- a/pkgbuilds/flea/PKGBUILD
+++ b/pkgbuilds/flea/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: GM <gianmarcomorales@icloud.com>
 
 pkgname=flea
-pkgver=0.1.6
+pkgver=0.2.0
 pkgrel=1
 pkgdesc='Fast, keyboard-first file manager for Omarchy'
 arch=('x86_64' 'aarch64')
@@ -19,6 +19,8 @@ depends=(
   'gvfs-nfs'
   'gvfs-smb'
   'hicolor-icon-theme'
+  'kimageformats'
+  'libheif'
   'omarchy'
   'python'
   'python-gobject'
@@ -46,7 +48,7 @@ options=('!debug')
 source=(
   "$url/releases/download/v$pkgver/$pkgname-v$pkgver.tar.gz"
 )
-sha256sums=('d4d579c199f65d61b181f65ef750030fcf421e9d8827a748d53c7cab858548d0')
+sha256sums=('e4f260bea1c743af27dccbf3e6a486cedd3da10120a0f96e420592cafc973f9d')
 
 build() {
   cd "$pkgname-$pkgver"

--- a/pkgbuilds/flea/PKGBUILD
+++ b/pkgbuilds/flea/PKGBUILD
@@ -71,6 +71,8 @@ check() {
     --proc /proc --dev /dev --tmpfs /tmp /usr/bin/true >/dev/null 2>&1; then
     printf 'Skipping sandbox integration tests: this builder cannot create an unprivileged namespace\n'
     test_args+=(
+      --skip backend::archiveops::tests::a_silent_failure_names_the_operation_that_was_running
+      --skip tui::job::tests::preview_worker_reads_held_source_in_readonly_sandbox
       --skip backend::archiveops::tests::a_tool_that_exits_zero_writing_nothing_is_caught_by_the_predicate
       --skip backend::archiveops::tests::an_empty_archive_extracts_to_an_empty_directory_and_that_is_success
       --skip backend::archiveops::tests::only_the_archive_root_extracts_to_nothing_while_nested_directories_do_not
@@ -92,7 +94,8 @@ check() {
     )
   fi
 
-  cargo test --frozen --release -- "${test_args[@]}"
+  # Recovery-lock tests are unreliable when run concurrently with other suites.
+  cargo test --frozen --release -- --test-threads=1 "${test_args[@]}"
   ./tests/js.sh
   ./tests/keymap-gen.sh
 }

--- a/pkgbuilds/strata/PKGBUILD
+++ b/pkgbuilds/strata/PKGBUILD
@@ -1,10 +1,10 @@
 pkgname=strata
-pkgver=0.14.0
+pkgver=0.15.0
 pkgrel=1
 pkgdesc='Fast, keyboard-first file manager for modern Linux desktops'
 arch=('x86_64' 'aarch64')
 url='https://github.com/lgse/strata'
-license=('GPL-3.0-or-later')
+license=('MIT')
 
 depends=(
   'bash'
@@ -20,6 +20,7 @@ depends=(
   'graphene'
   'gst-libav'
   'gst-plugins-good'
+  'gvfs'
   'gtk4'
   'gtksourceview5'
   'hicolor-icon-theme'
@@ -38,7 +39,7 @@ conflicts=('strata-git')
 options=('!debug' '!lto')
 
 source=("$pkgname-$pkgver.tar.gz::$url/archive/refs/tags/v$pkgver.tar.gz")
-sha256sums=('4a1de75c6a28151e44fa841534e0ef16d191215d40ee45a1ce22be5e73c8827d')
+sha256sums=('be4d579a9378b8bf9ccc3904e7327ce756bed61d1e617c75b543e1e539611f0a')
 
 prepare() {
   cd "$pkgname-$pkgver"

--- a/pkgbuilds/strata/PKGBUILD
+++ b/pkgbuilds/strata/PKGBUILD
@@ -74,7 +74,18 @@ check() {
   STRATA_BUILD_COMMIT=$(<.build-commit)
   export STRATA_RELEASE_TAG="v$pkgver"
   export STRATA_BUILD_KIND=stable
-  cargo test --frozen --release --all-targets --all-features
+  # Search fixtures depend on directory enumeration order and fail on overlayfs.
+  # Run them on tmpfs; other suites execute fixtures, so cannot use noexec /dev/shm.
+  local search_tmp
+  search_tmp=$(mktemp -d /dev/shm/strata-tests.XXXXXXXX) || return 1
+  local test_status=0
+  TMPDIR="$search_tmp" cargo test --frozen --release --all-targets --all-features \
+    services::search::tests:: -- --test-threads=1 || test_status=$?
+  rm -rf -- "$search_tmp"
+  (( test_status == 0 )) || return "$test_status"
+
+  cargo test --frozen --release --all-targets --all-features \
+    -- --test-threads=1 --skip services::search::tests::
 }
 
 package() {


### PR DESCRIPTION
Update flea 0.1.6 → 0.2.0 and strata 0.14.0 → 0.15.0 from verified upstream source archives.

Flea gains upstream's HEIC preview dependencies (`kimageformats`, `libheif`). Strata declares its MIT license and GVfs dependency. Both retain pkgrel=1 for the new versions.

Make the package checks reliable in container builders: run flea tests serially and conditionally skip two additional namespace-dependent cases only when the existing namespace probe fails. Run Strata's 43 search tests on tmpfs because their bounded directory-enumeration assertions fail on overlayfs; run all remaining tests with the normal temporary directory because some execute fixtures and /dev/shm is noexec. No Strata tests are omitted.

Validation:
- Upstream source identity/security hooks and independent SHA-256 checks passed.
- Both optimized release builds passed.
- Flea: 592 Rust tests passed, 10 conditional sandbox skips; 2,999 JavaScript checks and keymap validation passed.
- Strata: 43 search tests passed on tmpfs; 1,363 remaining tests passed, 20 upstream ignored cases. Some GTK tests self-skip without a display.
- Shell syntax and diff checks passed. No aarch64 or interactive GUI run performed.

The original Strata blockers were reproduced on overlayfs and resolved by the test environment separation above. The release-age policy remains unchanged.
