### PR TITLE
test: stabilize 1Password sync fixture

### DIFF
--- a/bin/sync-upstream
+++ b/bin/sync-upstream
@@ -757,6 +757,9 @@ EOF
   mkdir -p "$one_root"
   cp -a "$BUILD_ROOT/pkgbuilds/1password" "$one_root/1password"
   one_dir="$one_root/1password"
+  # Keep the real recipe shape, but make the fixture's starting version stable.
+  # Otherwise a routine package update can outrun the mocked release below.
+  sed -i -e 's/^pkgver=.*/pkgver=8.12.34/' -e 's/^pkgrel=.*/pkgrel=2/' "$one_dir/PKGBUILD"
   debian_fetch_packages() {
     printf 'Package: 1password\nVersion: %s\n' "$one_version"
   }


### PR DESCRIPTION
Fixes the self-test failure currently present on `master` after the checked-in 1Password recipe advanced to 8.12.36.

The end-to-end fixture now rewrites its copied recipe to a stable older starting version before mocking 8.12.35, preserving the intended update, `pkgrel`, URL, and checksum assertions while remaining independent of routine package bumps. Production package data is unchanged.

Validation:
- `bash -n bin/sync-upstream`
- `git diff --check`
- `self-tests` passed
- `build-isolation` passed

This also removes the inherited `master` failure currently affecting #346 and #395.