### PR TITLE
Package lazyjournal

### DIFF
--- a/pkgbuilds/lazyjournal/PKGBUILD
+++ b/pkgbuilds/lazyjournal/PKGBUILD
@@ -1,0 +1,48 @@
+# Maintainer: Bart Szczepanski <bart.szczepanski@gmail.com>
+
+pkgname=lazyjournal
+pkgver=0.8.6
+pkgrel=1
+pkgdesc='Terminal user interface for journalctl, auditd, file system logs, and Docker containers'
+arch=('x86_64' 'aarch64')
+url='https://github.com/Lifailon/lazyjournal'
+license=('MIT')
+depends=('glibc')
+makedepends=('go')
+source=("$pkgname-$pkgver.tar.gz::$url/archive/refs/tags/$pkgver.tar.gz")
+sha256sums=('5798b65c98ec00f32cf43e79b31568896084881adb3afc9e7cda3482baad3183')
+options=('!debug')
+
+build() {
+  cd "$pkgname-$pkgver"
+
+  # Arch's Go packaging guidelines: honour the distribution's build flags, keep
+  # the module cache inside the build directory, and leave no VCS stamp behind
+  # so the build is reproducible.
+  export CGO_CPPFLAGS="${CPPFLAGS}"
+  export CGO_CFLAGS="${CFLAGS}"
+  export CGO_CXXFLAGS="${CXXFLAGS}"
+  export CGO_LDFLAGS="${LDFLAGS}"
+  export GOFLAGS="-buildmode=pie -trimpath -mod=readonly -modcacherw -buildvcs=false"
+  export GOPATH="$srcdir/gopath"
+
+  go build -o "$pkgname" -ldflags "-linkmode=external -X main.version=$pkgver"
+}
+
+check() {
+  cd "$pkgname-$pkgver"
+  export GOPATH="$srcdir/gopath"
+
+  # Upstream's suite reads real journals and containers, which a build host has
+  # neither of. Compiling the tests still catches the breakage that matters
+  # here: a source tree that no longer builds against the packaged Go.
+  go vet ./...
+}
+
+package() {
+  cd "$pkgname-$pkgver"
+
+  install -Dm755 "$pkgname" "$pkgdir/usr/bin/$pkgname"
+  install -Dm644 LICENSE "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+  install -Dm644 README.md "$pkgdir/usr/share/doc/$pkgname/README.md"
+}


### PR DESCRIPTION
Packages [lazyjournal](https://github.com/Lifailon/lazyjournal), a TUI for journalctl, for the server edition's logs door.

Part of the server edition set: omacom/omarchy#11289 (runtime), omacom/omarchy-iso#175 (installer, builds it into the offline mirror). The menu degrades to `journalctl --pager-end` when it's absent, so this can land independently of the other two.