### PR TITLE
Install the omarchy-wifi-recover user unit

### DIFF
--- a/pkgbuilds/omarchy-settings-dev/PKGBUILD
+++ b/pkgbuilds/omarchy-settings-dev/PKGBUILD
@@ -193,6 +193,12 @@ package() {
   install -Dm644 default/systemd/user/omarchy-tailscale-receive.service "$pkgdir/usr/lib/systemd/user/omarchy-tailscale-receive.service"
   install -Dm644 default/systemd/user/omarchy-fcitx5.service "$pkgdir/usr/lib/systemd/user/omarchy-fcitx5.service"
   install -Dm644 default/systemd/user/omarchy-crash-watch.service "$pkgdir/usr/lib/systemd/user/omarchy-crash-watch.service"
+  # Lands with omacom/omarchy#7831. Release pins and a quattro tip from before
+  # it have no unit to install; first-run stages it from the omarchy tree until
+  # this package ships it.
+  if [[ -f default/systemd/user/omarchy-wifi-recover.service ]]; then
+    install -Dm644 default/systemd/user/omarchy-wifi-recover.service "$pkgdir/usr/lib/systemd/user/omarchy-wifi-recover.service"
+  fi
   # Marks app.slice (and only app.slice) as a systemd-oomd kill candidate, so
   # memory pressure costs one app scope instead of the compositor session.
   # Thresholds live in etc/systemd/oomd.conf.d/10-omarchy.conf. Both this and

--- a/pkgbuilds/omarchy-settings/PKGBUILD
+++ b/pkgbuilds/omarchy-settings/PKGBUILD
@@ -188,6 +188,12 @@ package() {
   install -Dm644 default/systemd/user/omarchy-tailscale-receive.service "$pkgdir/usr/lib/systemd/user/omarchy-tailscale-receive.service"
   install -Dm644 default/systemd/user/omarchy-fcitx5.service "$pkgdir/usr/lib/systemd/user/omarchy-fcitx5.service"
   install -Dm644 default/systemd/user/omarchy-crash-watch.service "$pkgdir/usr/lib/systemd/user/omarchy-crash-watch.service"
+  # Lands with omacom/omarchy#7831. Release pins and a quattro tip from before
+  # it have no unit to install; first-run stages it from the omarchy tree until
+  # this package ships it.
+  if [[ -f default/systemd/user/omarchy-wifi-recover.service ]]; then
+    install -Dm644 default/systemd/user/omarchy-wifi-recover.service "$pkgdir/usr/lib/systemd/user/omarchy-wifi-recover.service"
+  fi
   # Marks app.slice (and only app.slice) as a systemd-oomd kill candidate, so
   # memory pressure costs one app scope instead of the compositor session.
   # Thresholds live in etc/systemd/oomd.conf.d/10-omarchy.conf. Both this and


### PR DESCRIPTION
Companion to omacom/omarchy#7831, which adds `omarchy-wifi-recover` and its user unit under `default/systemd/user`. `omarchy-settings` and `omarchy-settings-dev` install user units by explicit name, so without this the unit lands only in the `default/` template tree and never in `/usr/lib/systemd/user`, the same omission `omarchy-crash-watch.service` had in 2aa5c50.

The install is guarded on the file existing. `omarchy-settings` pins v4.0.3 and `omarchy-settings-dev` builds the quattro tip, and neither carries the unit until #7831 merges and the pin moves, so an unguarded line would fail the build in the meantime. First-run on the omarchy side stages the unit into `~/.config/systemd/user` until this package ships it and removes that staged copy once the packaged one exists, so the two sides can merge in either order.

The `etc/sudoers.d/omarchy-restart-wifi` grant from the same PR needs nothing here; `cp -a etc/.` already picks it up and the existing block sets the 0440 mode.

Checked by running the guarded block against both trees: the PR head installs the unit, current quattro skips it. No `pkgrel` bump, matching 2aa5c50; at the current pin the package output is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
