### PR TITLE
flea: depend on kimageformats and libheif

### DIFF
--- a/pkgbuilds/flea/PKGBUILD
+++ b/pkgbuilds/flea/PKGBUILD
@@ -19,6 +19,8 @@ depends=(
   'gvfs-nfs'
   'gvfs-smb'
   'hicolor-icon-theme'
+  'kimageformats'
+  'libheif'
   'omarchy'
   'python'
   'python-gobject'


### PR DESCRIPTION
Flea's own PKGBUILD has depended on both since v0.1.6 (`0d70a9d`): kimageformats ships `kimg_heif.so` over libheif, so without them the preview of a HEIC photo is a sentence rather than a picture.