### PR TITLE
grok-bot: bump 0.29.0 → 0.47.0 (upstream renamed the Linux .deb)

### DIFF
--- a/pkgbuilds/grok-bot/PKGBUILD
+++ b/pkgbuilds/grok-bot/PKGBUILD
@@ -2,9 +2,9 @@
 # Contributor: Omarchy
 
 pkgname=grok-bot
-pkgver=0.29.0
+pkgver=0.47.0
 pkgrel=1
-_commit=f0e5bfcee649ea84c0c61369cf896cd146d72136
+_commit=c1e7d7a46549956d25f53e9c0b9f59666e03aa3a
 pkgdesc='Grok Bot desktop agent'
 arch=('x86_64')
 url='https://x.ai/bot'
@@ -26,11 +26,11 @@ provides=('sand')
 conflicts=('sand')
 options=('!strip' '!debug')
 source=(
-  "${pkgname}_${pkgver}.deb::https://downloads.cursor.com/grokbot/stable/${_commit}/linux/x64/Grok_Bot_${pkgver}.deb"
+  "${pkgname}_${pkgver}.deb::https://downloads.cursor.com/grokbot/stable/${_commit}/linux/x64/grok-bot_${pkgver}_amd64.deb"
   'grok-bot.sh'
   'grok-bot.desktop'
 )
-sha256sums=('d223b5830282aef11d5c46d8f4d1edd239bf992e336405cbd288d4476b9233d4'
+sha256sums=('11ca0f51a535b97af51a352adf9c0f9ecd2e1b0430a69ae9451b688a7a065808'
             '6dfa6c305941afa6cbaefbeaae06d05ab5a88f31630005d25a819a160c20c7a3'
             '856056c9ca63dda5d01158ce8fb6a9a7cbb3f67c13a92b573cd196d3e50f26e7')
 noextract=("${pkgname}_${pkgver}.deb")


### PR DESCRIPTION
## Summary

`pkgbuilds/grok-bot` is pinned to **0.29.0** while upstream stable is **0.47.0** (confirmed via Cursor's update feed today). Users installing Grok Bot from Omarchy's launcher get a 3-releases-old app with no upgrade path — `omarchy-pkg-add grok-bot` keeps serving 0.29.0 from `pkgs.omarchy.org`.

Precedent: omacom/omarchy#8070 (same failure class at 0.18.0, fixed by PR #201 in this repo).

## What changed upstream

Two things besides the version bump broke the PKGBUILD as-is:

1. **Filename**: the Linux artifact is now `grok-bot_0.47.0_amd64.deb` (was `Grok_Bot_<ver>.deb`).
2. **Commit path**: it now lives at `https://downloads.cursor.com/grokbot/stable/<40-char-commit>/linux/x64/...`. The current commit path is `c1e7d7a46549956d25f53e9c0b9f59666e03aa3a` (from the official download page at cursor.com/download/bot).

This PR bumps `pkgver`, `_commit`, the source filename, and the sha256.

## Also stale: `update-pkgver.sh`

The script extracts the commit hash from the update feed URL with a `[0-9a-f]{40}` regex — but the feed URL (`https://api2.cursor.sh/updates/api/update/darwin-arm64/sand/0.0.0/.../stable`) **no longer embeds a 40-char commit** (verified today; it resolves to `/grokbot/stable/darwin-arm64/0.47.0/...`). Running it now fails to resolve a commit, which is likely how the pin silently aged. The commit path now has to be scraped from the download page (or the feed format re-checked). I left the script untouched to keep this PR a clean bump — happy to follow up with a fix if you want it.

## Verification

- `makepkg` with this exact PKGBUILD builds `grok-bot-0.47.0-1-x86_64.pkg.tar.zst` (no dpkg needed; bsdtar path works)
- Package contains the 0.47.0 Electron binary, the Wayland wrapper at `usr/bin/grok-bot`, the `sand` symlink, the desktop entry, and the setuid `chrome-sandbox`
- The official `.deb` fetches (HTTP 200) from the pinned URL and its sha256 matches (`11ca0f51a535b97af51a352adf9c0f9ecd2e1b0430a69ae9451b688a7a065808`)
- I also installed 0.47.0 locally on Omarchy 4.0.3 (x86_64, Wayland/Hyprland) built from this same PKGBUILD and the app launches

Filed by an AI coding agent (Pi harness, model not self-reported) on behalf of patrickpassosb.