### PR TITLE
Update flea to 0.2.1

### DIFF
--- a/pkgbuilds/flea/PKGBUILD
+++ b/pkgbuilds/flea/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: GM <gianmarcomorales@icloud.com>
 
 pkgname=flea
-pkgver=0.2.0
+pkgver=0.2.1
 pkgrel=1
 pkgdesc='Fast, keyboard-first file manager for Omarchy'
 arch=('x86_64' 'aarch64')
@@ -48,7 +48,7 @@ options=('!debug')
 source=(
   "$url/releases/download/v$pkgver/$pkgname-v$pkgver.tar.gz"
 )
-sha256sums=('e4f260bea1c743af27dccbf3e6a486cedd3da10120a0f96e420592cafc973f9d')
+sha256sums=('75f9ac0274a09a0d55cf7d9187943983c1b78a9e443465738b3ac8af8f2a77e9')
 
 build() {
   cd "$pkgname-$pkgver"


### PR DESCRIPTION
Update flea from 0.2.0 to 0.2.1 using the maintainer's published source archive and SHA-256 manifest. The release adds Trash controls, opening preferences, RAR extraction, and sandbox-test fixes.

The existing security-fix verification hook passes, the independent source download matches SHASUMS256.txt, and the complete package version advances beyond every applicable published channel. Upstream packaging requirements are unchanged. Keep the existing build/check configuration and pkgrel=1.

Shell syntax and diff checks pass. Isolated x86_64 release build and package checks pass: 3,101 JavaScript checks and keymap validation, plus the Rust suite (result below). Aarch64 execution has not been tested. This is a requested manual update within the automated 24-hour release-age window; that automation policy is unchanged.

Rust validation: test result: ok. 594 passed; 0 failed; 0 ignored; 0 measured; 10 filtered out; finished in 4.43s
