### PR TITLE
fix: package renamed 1Password desktop file

### DIFF
--- a/pkgbuilds/1password/PKGBUILD
+++ b/pkgbuilds/1password/PKGBUILD
@@ -1,6 +1,6 @@
 pkgname=1password
 pkgver=8.12.36
-pkgrel=1
+pkgrel=2
 conflicts=('1password-beta' '1password-beta-bin')
 pkgdesc="Password manager and secure wallet"
 arch=('x86_64' 'aarch64')
@@ -51,7 +51,8 @@ package() {
             "${pkgdir}/usr/share/icons/hicolor/${resolution}/apps/1password.png"
     done
     # Install desktop file
-    install -Dm0644 resources/1password.desktop -t "${pkgdir}"/usr/share/applications/
+    install -Dm0644 resources/com.onepassword.OnePassword.desktop \
+        "${pkgdir}/usr/share/applications/1password.desktop"
 
     # 1Password reads the display scale itself, the way Electron apps do, and
     # comes up oversized next to every other window on a scaled monitor. Pin it
@@ -80,7 +81,7 @@ EOF" > ./com.1password.1Password.policy
     # Cleanup un-needed files
     rm "${pkgdir}"/opt/1Password/com.1password.1Password.policy "${pkgdir}"/opt/1Password/com.1password.1Password.policy.tpl "${pkgdir}"/opt/1Password/install_biometrics_policy.sh
     rm -r "${pkgdir}"/opt/1Password/resources/icons/
-    rm "${pkgdir}"/opt/1Password/resources/1password.desktop "${pkgdir}"/opt/1Password/resources/custom_allowed_browsers
+    rm "${pkgdir}"/opt/1Password/resources/com.onepassword.OnePassword.desktop "${pkgdir}"/opt/1Password/resources/custom_allowed_browsers
 
     # Symlink /usr/bin executable to opt
     install -dm0755 "${pkgdir}"/usr/bin


### PR DESCRIPTION
1Password 8.12.36 renamed its desktop source to `resources/com.onepassword.OnePassword.desktop`, causing `package()` to fail with “cannot stat resources/1password.desktop”. Update installation and cleanup to use the new source name, while preserving `/usr/share/applications/1password.desktop` and the display-scale override. Bump pkgrel to 2 for the packaging change.

Validation: reproduced the original failure and built `1password 8.12.36-2` with makepkg in an Arch container (dependency checks skipped). Source checksums and the official PGP signature passed; inspected the packaged launcher and metadata. Confirmed the same source filename in the aarch64 archive. `vercmp` confirms the new version exceeds master and all published channel versions.
