### PR TITLE
fix: run flea filesystem tests on tmpfs

### DIFF
--- a/pkgbuilds/flea/PKGBUILD
+++ b/pkgbuilds/flea/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=flea
 pkgver=0.2.1
-pkgrel=1
+pkgrel=2
 pkgdesc='Fast, keyboard-first file manager for Omarchy'
 arch=('x86_64' 'aarch64')
 url='https://github.com/thisisgm/flea'
@@ -95,6 +95,26 @@ check() {
   fi
 
   # Recovery-lock tests are unreliable when run concurrently with other suites.
+  # These fixtures require O_TMPFILE and fine-grained file timestamps, which
+  # the builder's /tmp filesystem may not provide. Keep executable fixtures
+  # in the remaining suites on the normal temp root (/dev/shm is noexec).
+  local -a filesystem_tests=(
+    backend::menu_actions::tests::
+    backend::menudelete::tests::
+    backend::redo::tests::
+    backend::trashbrowse::tests::
+    backend::trashdelete::
+    backend::trashmanifest::tests::
+  )
+  local test_tmp test_status=0 suite
+  test_tmp=$(mktemp -d /dev/shm/flea-tests.XXXXXXXX) || return 1
+  TMPDIR="$test_tmp" cargo test --frozen --release -- \
+    --test-threads=1 "${filesystem_tests[@]}" || test_status=$?
+  rm -rf -- "$test_tmp"
+  (( test_status == 0 )) || return "$test_status"
+  for suite in "${filesystem_tests[@]}"; do
+    test_args+=(--skip "$suite")
+  done
   cargo test --frozen --release -- --test-threads=1 "${test_args[@]}"
   ./tests/js.sh
   ./tests/keymap-gen.sh


### PR DESCRIPTION
The rc builder failed flea’s Trash tests because its `/tmp` filesystem rejects `O_TMPFILE` with EOPNOTSUPP. Run the six affected test suites with a private TMPDIR under `/dev/shm`, which supports anonymous files. Include the redo suite, whose failing change-detection fixture relies on file change timestamps advancing between writes.

Run the remaining suites on their usual temp root so executable fixtures continue to work when `/dev/shm` is mounted noexec. Clean up the private directory on success or test failure and preserve cargo’s failure status. Existing sandbox and optional-thumbnailer skips remain unchanged. Bump flea to 0.2.1-2.

Validation: the actual PKGBUILD check() passed in an Arch container: 64 Rust tests on tmpfs and 530 on the usual temp root, plus 3101 JavaScript checks and all keymap checks. No additional tests are skipped. Shell syntax and diff checks passed; vercmp confirms the version exceeds master and every published channel. Production validation remains pending; the build server is operated by the maintainer.
