### PR TITLE
omarchy-settings: add user tmpdir to skel

### DIFF
--- a/pkgbuilds/omarchy-settings/PKGBUILD
+++ b/pkgbuilds/omarchy-settings/PKGBUILD
@@ -142,6 +142,7 @@ package() {
   # Package-owned defaults that live elsewhere in the system belong under
   # default/** or etc/** instead.
   install -d "$pkgdir/etc/skel/.config"
+  install -d "$pkgdir/etc/skel/.local/tmp"
   cp -a config/. "$pkgdir/etc/skel/.config/"
 
   # Fastfetch reads /etc/fastfetch/config.jsonc when no user config exists.


### PR DESCRIPTION
add /etc/skel/.local/tmp so newly created users receive the private tmpdir by default.