### PR TITLE
Publish what built instead of discarding the run over one package

### DIFF
--- a/bin/auto-release
+++ b/bin/auto-release
@@ -129,8 +129,19 @@ release_arch() {
   print_info "State file found: $state_file"
   print_info "Starting release workflow for $MIRROR ($arch)..."
 
-  if "$BUILD_ROOT/bin/repo" release --mirror "$MIRROR" --arch "$arch" --skip-prod-check; then
-    print_success "Release completed successfully for $MIRROR ($arch)"
+  # 2 is "published what built, reported what did not". That is progress, so it
+  # clears the queue and the backoff exactly like a clean run. Backing off for a
+  # package that is deterministically broken is what let one failure stall every
+  # other package: the release already reported it, and it retries on its own
+  # when a new commit or version changes the inputs that made it fail.
+  local release_status=0
+  "$BUILD_ROOT/bin/repo" release --mirror "$MIRROR" --arch "$arch" --skip-prod-check || release_status=$?
+  if ((release_status == 0 || release_status == 2)); then
+    if ((release_status == 2)); then
+      print_warning "Release for $MIRROR ($arch) published with package failures — see the log"
+    else
+      print_success "Release completed successfully for $MIRROR ($arch)"
+    fi
     local completed_state=("$state_file" "$fail_file")
     if [[ "$arch" == "x86_64" ]]; then
       completed_state+=("$(legacy_sync_queue_file "$MIRROR")" "$(legacy_sync_fail_file "$MIRROR")")

--- a/bin/build
+++ b/bin/build
@@ -330,7 +330,30 @@ if (( ${#FAILED_PACKAGES[@]} + ${#BLOCKED_PACKAGES[@]} )); then
     printf '  - %s\n' "${BLOCKED_PACKAGES[@]}"
   fi
   print_warning "Some packages failed (see details above)"
+
+  # Hand the names to the caller. Best effort on purpose: an unwritable state
+  # directory must not turn a partial build into a total one.
+  build_failures=$(build_failures_file "$MIRROR" "$ARCH")
+  if mkdir -p "$(dirname "$build_failures")" 2>/dev/null; then
+    {
+      if ((${#FAILED_PACKAGES[@]})); then printf '%s\n' "${FAILED_PACKAGES[@]}"; fi
+      if ((${#BLOCKED_PACKAGES[@]})); then printf '%s\n' "${BLOCKED_PACKAGES[@]}"; fi
+    } >"$build_failures" 2>/dev/null || true
+  fi
+
+  # One package that will not build must not strand every package that will.
+  # A run that produced nothing has nothing to publish and is still fatal; a
+  # run that produced something exits 2, and the caller publishes the rest and
+  # reports these at the end. Blocked packages are already excluded from the
+  # output, so nothing ships without the dependency it was built against.
+  if ((${#SUCCESSFUL_PACKAGES[@]})); then
+    print_warning "Continuing with the ${#SUCCESSFUL_PACKAGES[@]} package(s) that did build"
+    exit 2
+  fi
+  print_error "No packages built — nothing to publish"
   exit 1
 fi
 
+# Nothing failed, so no earlier run's list may outlive this one.
+rm -f "$(build_failures_file "$MIRROR" "$ARCH")" 2>/dev/null || true
 print_success "Build completed successfully!"

--- a/bin/release
+++ b/bin/release
@@ -138,11 +138,23 @@ if [[ "$DRY_RUN" == true ]]; then
 else
   print_info "Step 1/6: Building packages..."
 fi
-"$BUILD_ROOT/bin/build" "${BUILD_ARGS[@]}" || {
+# Exit 2 means some packages built and some did not. Publishing the survivors
+# is the whole point: a release that throws away twelve good packages because
+# of a thirteenth stops the channel for everyone. Any other non-zero produced
+# nothing to publish and still stops here.
+BUILD_EXIT=0
+"$BUILD_ROOT/bin/build" "${BUILD_ARGS[@]}" || BUILD_EXIT=$?
+if ((BUILD_EXIT != 0 && BUILD_EXIT != 2)); then
   print_error "Build failed"
   notify_error "Release failed: Build step failed" "$RELEASE_CONTEXT"
   exit 1
-}
+fi
+
+FAILED_TO_BUILD=""
+if ((BUILD_EXIT == 2)); then
+  FAILED_TO_BUILD=$(cat "$(build_failures_file "$MIRROR" "$ARCH")" 2>/dev/null || true)
+  print_warning "Some packages did not build — publishing the rest, reported at the end"
+fi
 
 if [[ "$DRY_RUN" == true ]]; then
   echo ""
@@ -225,6 +237,18 @@ else
     summary+="<br>Queued but not built: $(head -25 "$QUEUE_FILE" | tr '\n' ' ' | basecamp_html_escape)"
   fi
   notify_info "Release ran with nothing to publish: $MIRROR" "$summary"
+fi
+
+if [[ -n "$FAILED_TO_BUILD" ]]; then
+  echo ""
+  print_error "Published, but these packages did not build:"
+  printf '  - %s\n' $FAILED_TO_BUILD
+  failed_details="$RELEASE_CONTEXT<br><br><strong>Published without:</strong><br>"
+  failed_details+="$(tr '\n' ' ' <<<"$FAILED_TO_BUILD" | basecamp_html_escape)"
+  notify_error "Released with package failures: $MIRROR" "$failed_details"
+  echo ""
+  print_warning "Release workflow completed with package failures"
+  exit 2
 fi
 
 echo ""

--- a/helpers/paths.sh
+++ b/helpers/paths.sh
@@ -55,6 +55,13 @@ sync_fail_file() { # sync_fail_file <mirror> <arch>
   echo "$STATE_DIR/.build-failed-$1-$2"
 }
 
+# Packages the last build could not produce, one name per line. A release that
+# publishes the survivors reads this to name what it left behind: the build and
+# the release are separate processes, so the list has to outlive the builder.
+build_failures_file() { # build_failures_file <mirror> <arch>
+  echo "$STATE_DIR/.build-failures-$1-$2"
+}
+
 # The pre-architecture names, .sync-needed-<mirror> and .build-failed-<mirror>,
 # meant x86_64. A host upgraded mid-cycle may still hold one; readers treat
 # it as the x86_64 file until it is consumed.


### PR DESCRIPTION
## The failure this prevents

`flea` 0.2.1 failed its test suite and stopped **every channel for a day**. `bin/build` exited 1, `bin/release` treated that as fatal and returned before sign/promote/sync — so the **twelve packages that built successfully in the same run were discarded**, rebuilt on the next tick, and discarded again. Nothing reached edge, rc or stable from 09-11 until the package itself was fixed.

## What changes

| file | change |
|---|---|
| `bin/build` | `exit 2` when at least one package built but others failed/blocked. `exit 1` still means a run that produced nothing to publish. Writes the failed names to a state file. |
| `helpers/paths.sh` | new `build_failures_file <mirror> <arch>` — build and release are separate processes, so the list must outlive the builder |
| `bin/release` | accepts `2`, runs the rest of the pipeline on what did build, reports the missing packages through the existing notifier, exits `2` |
| `bin/auto-release` | treats `2` as progress: clears the queue and the backoff |

`bin/build` already distinguished `failed` from `blocked` and never builds a package whose dependency failed. What it couldn't express was "some built" vs "nothing built" — both exited 1, so the caller had to assume the worst.

## The debatable bit

**A partial release clears the backoff instead of counting as a failure.** Counting it would reinstate the original bug on a longer timescale: four consecutive partials back a channel off to six-hour intervals, and one permanently broken package again decides when every other package ships.

The cost: a *transient* failure is no longer retried on the next tick — it waits for the next commit or version bump, which is also when it has a reason to succeed. Happy to flip this if you'd rather keep retry-on-transient; it's a one-line change.

## Safety

Nothing publishes that couldn't before. Blocked packages are still excluded from the build output, so no package ships without the dependency it was built against.

## Testing

`bash -n` clean on all four. Diffs reviewed against copies before applying.

**Note:** CI's `self-tests` job covers `sync-upstream`, `sync-rebuilds`, `omarchy-pkgs` and `omarchy-release` — **none of these four files**. A green check here does not mean this path was exercised. The partial path has not yet run against a real failure, since flea now builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)